### PR TITLE
[cstor#120] Pick replication options from config file Issue

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -20,6 +20,8 @@ do
 		path)			path=${VALUE} ;;
 		size)			size=${VALUE} ;;
 		externalIP)		externalIP=${VALUE} ;;
+		replication_factor)	replication_factor=${VALUE} ;;
+		consistency_factor)	consistency_factor=${VALUE} ;;
 		*)
 	esac
 done
@@ -57,6 +59,8 @@ then
 fi
 
 sed -i "s|TargetName.*|TargetName $volname|g" $CONF_FILE
+sed -i "s|ReplicationFactor.*|ReplicationFactor $replication_factor|g" $CONF_FILE
+sed -i "s|ConsistencyFactor.*|ConsistencyFactor $consistency_factor|g" $CONF_FILE
 sed -i "s|TargetAlias.*|TargetAlias nicknamefor-$volname|g" $CONF_FILE
 sed -i "s|Portal UC1.*|Portal UC1 $portal:3261|g" $CONF_FILE
 sed -i "s|Portal DA1.*|Portal DA1 $portal:3260|g" $CONF_FILE

--- a/src/istgt.conf
+++ b/src/istgt.conf
@@ -48,6 +48,8 @@
   AuthGroup None
   UseDigest Auto
   ReadOnly No
+  ReplicationFactor 3
+  ConsistencyFactor 2
   UnitType Disk
   UnitOnline Yes
   BlockLength 512

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -1404,6 +1404,7 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 		ISTGT_ERRLOG("LU%d: TargetName not found\n", lu->num);
 		goto error_return;
 	}
+	lu->volname = xstrdup(val);
 	if (strncasecmp(val, "iqn.", 4) != 0
 		&& strncasecmp(val, "eui.", 4) != 0
 		&& strncasecmp(val, "naa.", 4) != 0) {
@@ -2170,6 +2171,7 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 
  error_return:
 	xfree(lu->name);
+	xfree(lu->volname);
 	xfree(lu->alias);
 	xfree(lu->inq_vendor);
 	xfree(lu->inq_product);
@@ -2801,6 +2803,7 @@ istgt_lu_del_unit(ISTGT_Ptr istgt, ISTGT_LU_Ptr lu)
 	//MTX_UNLOCK(&istgt->mutex);
 
 	xfree(lu->name);
+	xfree(lu->volname);
 	xfree(lu->alias);
 	xfree(lu->inq_vendor);
 	xfree(lu->inq_product);

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -1612,7 +1612,35 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 	
 	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "ReadOnly %s\n",
 	    lu->readonly ? "Yes" : "No");
+#ifdef REPLICATION
+	val = istgt_get_val(sp, "ReplicationFactor");
+	if (val == NULL) {
+		ISTGT_ERRLOG("ReplicationFactor not found in conf file\n");
+		goto error_return;
+	} else {
+		lu->replication_factor = (int) strtol(val, NULL, 10);
+	}
 
+	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "ReplicationFactor %d\n",
+	    lu->replication_factor);
+
+	val = istgt_get_val(sp, "ConsistencyFactor");
+	if (val == NULL) {
+		ISTGT_ERRLOG("ConsistencyFactor not found in conf file\n");
+		goto error_return;
+	} else {
+		lu->consistency_factor = (int) strtol(val, NULL, 10);
+	}
+
+	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "ConsistencyFactor %d\n",
+	    lu->consistency_factor);
+
+	if(lu->replication_factor <= 0 || lu->consistency_factor <= 0 ||
+		lu->replication_factor < lu->consistency_factor) {
+		ISTGT_ERRLOG("Invalid ReplicationFactor/ConsistencyFactor or their ratio\n");
+		goto error_return;
+	}
+#endif
 	val = istgt_get_val(sp, "UnitType");
 	if (val == NULL) {
 		ISTGT_ERRLOG("LU%d: unknown unit type\n", lu->num);

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -266,6 +266,7 @@ typedef struct istgt_lu_disk_nexus {
 typedef struct istgt_lu_t {
 	int num;
 	char *name;
+	char *volname;
 	char *alias;
 
 	char *inq_vendor;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -323,7 +323,10 @@ typedef struct istgt_lu_t {
 	int maxmap;
 	ISTGT_LU_MAP map[MAX_LU_MAP];
 	int conns;
-
+#ifdef REPLICATION
+	int replication_factor;
+	int consistency_factor;
+#endif
 } ISTGT_LU;
 typedef ISTGT_LU *ISTGT_LU_Ptr;
 
@@ -816,6 +819,8 @@ typedef struct istgt_lu_disk_t {
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
 	int replica_count;
 	int consistency_count;
+	int replication_factor;
+	int consistency_factor;
 	bool ready;
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/

--- a/src/replication.c
+++ b/src/replication.c
@@ -771,18 +771,18 @@ create_replica_entry(spec_t *spec, int iofd, char *replicaip, int replica_port) 
 	if (rc != 0) {
 		ISTGT_ERRLOG("pthread_create(replicator_thread) failed\n");
 		return NULL;
-	}	
+	}
 	zvol_io_hdr_t *rio;
 	rio = (zvol_io_hdr_t *)malloc(sizeof(zvol_io_hdr_t));
 	rio->opcode = ZVOL_OPCODE_HANDSHAKE;
 	rio->io_seq = 0;
 	rio->offset = 0;
-	char *data = malloc(strlen("vol1")+1);
-	rio->len    = strlen("vol1");
-	strncpy(data, "vol1", strlen("vol1"));
-	
+	char *data = malloc(strlen(spec->lu->volname)+1);
+	rio->len    = strlen(spec->lu->volname);
+	strncpy(data, spec->lu->volname, strlen(spec->lu->volname));
+
 	write(replica->iofd, rio, sizeof(zvol_io_hdr_t));
-	write(replica->iofd, data, strlen("vol1"));
+	write(replica->iofd, data, strlen(spec->lu->volname));
 	free(rio);
 	rio = NULL;
 	spec->ready = true;
@@ -796,7 +796,7 @@ zvol_handshake(char *volname, char *replicaip, int replica_port) {
 	REPLICA_LOG("VOLNAME = %s\n", volname);
 	MTX_LOCK(&specq_mtx);
 	TAILQ_FOREACH(spec, &spec_q, spec_next) {
-		if(strcmp(volname, volname) == 0)  {
+		if(strcmp(volname, spec->lu->volname) == 0)  {
 			if((iofd = cstor_ops.conn_connect(replicaip, replica_port)) < 0) {
 				REPLICA_ERRLOG("conn_connect() failed errno:%d\n", errno);
 				exit(EXIT_FAILURE);
@@ -864,7 +864,7 @@ accept_mgmt_conns(int epfd, int sfd) {
 		}
 		MTX_LOCK(&specq_mtx);
 		TAILQ_FOREACH(spec, &spec_q, spec_next) {
-			data_len += snprintf(buf, BUFSIZE, "%s", "vol1") + 1;
+			data_len += snprintf(buf, BUFSIZE, "%s", spec->lu->volname) + 1;
 		}
 		MTX_UNLOCK(&specq_mtx);
 		mgmt_opcode = ZVOL_OPCODE_HANDSHAKE;

--- a/src/restart.sh
+++ b/src/restart.sh
@@ -7,4 +7,4 @@ sudo cp istgt.conf istgtcontrol.conf /tmp/cstor/
 sudo cp istgt.conf istgtcontrol.conf /usr/local/etc/istgt/
 sudo cp istgt istgtcontrol /usr/local/bin/
 ps -aux | grep "\./istgt" | grep -v grep | sudo kill -9 `awk '{print $2}'`
-sudo ./init.sh volname=vol1 portal=192.168.1.16 path=/tmp/cstor size=10g externalIP=192.168.1.16
+sudo ./init.sh volname=vol1 portal=192.168.1.16 path=/tmp/cstor size=10g externalIP=192.168.1.16 replication_factor=3 consistency_factor=2


### PR DESCRIPTION
istgt code was using hard coded volume name as 'vol1'. This needs to be picked from configuration file.
Replication and consistency factor also need to be picked from istgt.conf file.

Signed-off-by: Payes <payes.anand@cloudbyte.com>