### PR TITLE
[cstor#130] Setting up travis for istgt repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: c
+sudo: required
+dist: trusty
+before_install:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -qq
+    - sudo apt-get install --yes -qq gcc-6 g++-6
+    - sudo apt-get install libssl-dev open-iscsi docker.io
+    # use gcc-6 by default
+    - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+    - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
+install:
+    - git clone https://github.com/openebs/istgt
+    - cd istgt
+    - git checkout replication
+    - ./configure --with-replication
+    - sudo make
+script:
+    # run ztest and test supported zio backends
+    - travis_wait 60 sudo bash ./test_istgt.sh || travis_terminate 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ before_install:
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
 install:
-    - git clone https://github.com/openebs/istgt
-    - cd istgt
-    - git checkout replication
     - ./configure --with-replication
     - sudo make
 script:

--- a/src/setup_istgt.sh
+++ b/src/setup_istgt.sh
@@ -7,4 +7,4 @@ sudo cp istgt.conf istgtcontrol.conf /tmp/cstor/
 sudo cp istgt.conf istgtcontrol.conf /usr/local/etc/istgt/
 sudo cp istgt istgtcontrol /usr/local/bin/
 ps -aux | grep "\./istgt" | grep -v grep | sudo kill -9 `awk '{print $2}'`
-sudo ./init.sh volname=vol1 portal=192.168.1.16 path=/tmp/cstor size=10g externalIP=192.168.1.16 replication_factor=3 consistency_factor=2
+sudo ./init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=3 consistency_factor=2

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1,0 +1,14 @@
+sudo sh ./src/setup_istgt.sh &
+
+sleep 5
+
+sudo truncate -s 20G test_vol
+
+sudo ./src/replication_test 127.0.0.1 6060 127.0.0.1 6161 &
+
+sleep 5
+
+sudo iscsiadm -m discovery -t st -p 127.0.0.1:3260
+
+sudo iscsiadm -m node -l
+

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1,14 +1,54 @@
-sudo sh ./src/setup_istgt.sh &
+
+# Wait for iSCSI device node (scsi device) to be created
+get_scsi_disk() {
+	device_name=$(sudo iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
+	i=0
+	while [ -z $device_name ]; do
+		sleep 5
+		device_name=$(sudo iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
+		i=`expr $i + 1`
+		if [ $i -eq 10 ]; then
+			echo "scsi disk not found";
+			exit;
+		else
+			continue;
+		fi
+	done
+}
+
+cd src
+sudo sh ./setup_istgt.sh &
 
 sleep 5
 
+cd ..
 sudo truncate -s 20G test_vol
 
 sudo ./src/replication_test 127.0.0.1 6060 127.0.0.1 6161 &
 
-sleep 5
+sleep 15
 
 sudo iscsiadm -m discovery -t st -p 127.0.0.1:3260
 
 sudo iscsiadm -m node -l
+
+sudo iscsiadm -m session -P 3
+
+get_scsi_disk
+
+echo $device_name
+
+if [ "$device_name" != "" ]; then
+	sudo mkdir -p /mnt/store
+	sudo mount /dev/$device_name /mnt/store
+
+	sudo dd if=/dev/urandom of=/mnt/store/file1 bs=4k count=10000
+	sudo dd if=/mnt/store/file1 of=/dev/zero bs=4k count=10000
+
+	sudo umount /mnt/store
+fi
+
+sudo iscsiadm -m node -u
+
+sudo iscsiadm -m node -o delete
 


### PR DESCRIPTION
This PR takes care of setting up travis
- to compile code
- to start istgt/replication_test binaries in background
- doing iscsiadm commands to discover iscsi disks
- mounting iscsi disks and running read/write IOs
Currently, due to issue in istgt, mounting is failing. Once that gets fixed, mounting also should work fine.
Till then, this PR serves the purpose of compilation, bringing up binaries and discovering iscsi disks.