### PR TITLE
[cstor#121] Halt IOs till required number of replicas are connected to target

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -106,6 +106,7 @@ build_image:
 	sh ./package.sh
 
 all: stamp-depend config.h $(SUBPROGRAM) istgtcontrol istgt replication_test build_image
+dev: stamp-depend config.h $(SUBPROGRAM) istgtcontrol istgt replication_test
 
 install: install-dirs
 	$(INSTALL) -m 0755 istgt $(DESTDIR)$(bindir)

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -71,4 +71,6 @@ int update_replica_list(int, spec_t *, int);
 int remove_replica_from_list(spec_t *, int);
 void unblock_blocked_cmds(replica_t *);
 replica_t *create_replica_entry(spec_t *, int, char *, int);
+void update_volstate(spec_t *);
+void clear_replica_cmd(spec_t *, replica_t *, rcmd_t *);
 #endif

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -818,9 +818,10 @@ typedef struct istgt_lu_disk_t {
 	TAILQ_HEAD(, rcommon_cmd_s) rcommon_pendingq; //Contains IOs waiting for acks from remaining replicas
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
 	int replica_count;
-	int consistency_count;
 	int replication_factor;
 	int consistency_factor;
+	int healthy_rcount;
+	int degraded_rcount;
 	bool ready;
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -88,7 +88,7 @@ extern clockid_t clockid;
 		rcomm_cmd->total_len = 0;\
 		rcomm_cmd->offset = offset;\
 		rcomm_cmd->data_len    = nbytes;\
-		rcomm_cmd->completed = 0;\
+		rcomm_cmd->state = CMD_CREATED;\
 		rcomm_cmd->luworker_id = cmd->luworkerindx;\
 		rcomm_cmd->acks_recvd = 0;\
 		rcomm_cmd->status = 0;\
@@ -5570,10 +5570,10 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 	status = rcomm_cmd->status;
 	if(status == -1 )  {
 		ISTGT_LOG("STATUS = -1\n");
-		if(rcomm_cmd->completed == 1) {
+		if(rcomm_cmd->state == CMD_EXECUTION_COMPLETED) {
 			free(rcomm_cmd);
 		} else {
-			rcomm_cmd->completed = 1;
+			rcomm_cmd->state = CMD_EXECUTION_COMPLETED;
 		}
 		cmd->data = NULL;
 		rc = -1;
@@ -5582,12 +5582,12 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 	}
 	rc = cmd->data_len = rcomm_cmd->data_len;
 	cmd->data = rcomm_cmd->data;
-	if(rcomm_cmd->completed == 1) {
+	if(rcomm_cmd->state == CMD_EXECUTION_COMPLETED) {
 		MTX_UNLOCK(&spec->rcommonq_mtx);
 		free(rcomm_cmd);
 	} else {
 		MTX_UNLOCK(&spec->rcommonq_mtx);
-		rcomm_cmd->completed = 1;
+		rcomm_cmd->state = CMD_EXECUTION_COMPLETED;
 	}
 	return rc;
 }

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -9087,7 +9087,7 @@ istgt_lu_disk_execute(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 	}
 
 	MTX_LOCK(&spec->state_mutex);
-	if (spec->state == ISTGT_LUN_BUSY && (!istgt_lu_disk_busy_excused(cdb[0]))) {
+	if ((spec->state == ISTGT_LUN_BUSY && (!istgt_lu_disk_busy_excused(cdb[0]))) || !spec->ready) {
 		lu_cmd->data_len  = 0;
 		lu_cmd->status = ISTGT_SCSI_STATUS_BUSY;
 		MTX_UNLOCK(&spec->state_mutex);

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -5575,7 +5575,7 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 		if(rcomm_cmd->completed) {
 			free(rcomm_cmd);
 		} else {
-			rcomm_cmd->completed = 1;
+			rcomm_cmd->completed = true;
 		}
 		cmd->data = NULL;
 		rc = -1;
@@ -5589,7 +5589,7 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 		free(rcomm_cmd);
 	} else {
 		MTX_UNLOCK(&spec->rcommonq_mtx);
-		rcomm_cmd->completed = 1;
+		rcomm_cmd->completed = true;
 	}
 	return rc;
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -623,6 +623,7 @@ handle_read_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp, void *
 		for (i=1; i < rcommq_ptr->iovcnt + 1; i++) { \
 			xfree(rcommq_ptr->iov[i].iov_base); \
 		} \
+		rcommq_ptr->state = CMD_EXECUTION_DONE; \
 		rcommq_ptr->completed = true; \
 	} \
 	MTX_UNLOCK(&spec->rcommonq_mtx); \

--- a/src/replication.c
+++ b/src/replication.c
@@ -90,6 +90,12 @@ cstor_conn_ops_t cstor_ops = {
 	}\
 }
 
+#define signal_luworker() { \
+	MTX_LOCK(&spec->luworker_rmutex[luworker_id]); \
+	pthread_cond_signal(&spec->luworker_rcond[luworker_id]); \
+	MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]); \
+}
+
 int
 send_mgmtio(int fd, zvol_op_code_t mgmt_opcode, void *buf, size_t data_len) {
 	zvol_io_hdr_t *rmgmtio = NULL;
@@ -155,6 +161,7 @@ dequeue_common_sendq:
 		cmd->acks_recvd = 0;
 		cmd->bitset = 0;
 		TAILQ_REMOVE(&spec->rcommon_sendq, cmd, send_cmd_next);
+		cmd->state = CMD_ENQUEUED_TO_WAITQ; \
 		TAILQ_INSERT_TAIL(&spec->rcommon_waitq, cmd, wait_cmd_next);
 		//Check for blockage in rcommon_pendingq and set corresponding blocked replica bits
 		bitset = 0;
@@ -180,6 +187,7 @@ dequeue_common_sendq:
 				continue;
 			}
 			cmd->bitset |= (1 << replica->id);
+			cmd->copies_sent++;
 			if(bitset & (1 << replica->id)) {
 				TAILQ_INSERT_TAIL(&replica->blockedq, rcmd, rblocked_cmd_next);
 			} else {
@@ -192,9 +200,6 @@ dequeue_common_sendq:
 			MTX_UNLOCK(&replica->r_mtx);
 			if((rcmd->opcode == ZVOL_OPCODE_READ) && read_cmd_sent) {
 				break;
-			} else if(rcmd->opcode == ZVOL_OPCODE_WRITE) {
-				//TODO This needs to be added in the starting
-				cmd->copies_sent++;
 			}
 		}
 	}
@@ -268,7 +273,7 @@ replica_sender(void *arg) {
 	rcommon_cmd_t *cmd = NULL;
 	rcmd_t *rcmd = NULL;
 	struct epoll_event event;
-	rcommon_cmd_t *rcommq_ptr;//REMOVE	
+	rcommon_cmd_t *rcommq_ptr;//REMOVE
 	epfd = epoll_create1(0);
 
 	event.data.fd = replica->iofd;
@@ -344,12 +349,58 @@ update_replica_list(int epfd, spec_t *spec, int replica_count) {
 	return replica_count;
 }
 
+void update_volstate(spec_t *spec) {
+	if(((spec->healthy_rcount + spec->degraded_rcount >= spec->consistency_factor) &&
+		(spec->healthy_rcount >= 1))||
+		(spec->healthy_rcount  + spec->degraded_rcount 
+			>= MAX(spec->replication_factor - spec->consistency_factor + 1, spec->consistency_factor))) {
+		spec->ready = true;
+		pthread_cond_broadcast(&spec->rq_cond);
+	} else {
+		spec->ready = false;
+	}
+}
+
+void clear_replica_cmd(spec_t *spec, replica_t *replica, rcmd_t *rep_cmd) {
+	int i;
+	rcommon_cmd_t *rcommq_ptr = rep_cmd->rcommq_ptr;
+	int luworker_id = rcommq_ptr->luworker_id;
+	rcommq_ptr->bitset &= ~(1 << replica->id);
+	//TODO Add check for acks_received in read also, same as write
+	if(rep_cmd->opcode == ZVOL_OPCODE_READ) {
+		rcommq_ptr->status = -1;
+		rcommq_ptr->state = CMD_EXECUTION_COMPLETED;
+		signal_luworker();
+	} else if(rep_cmd->opcode == ZVOL_OPCODE_WRITE) {
+		if(rcommq_ptr->acks_recvd + rcommq_ptr->ios_aborted
+				== rcommq_ptr->copies_sent - 1) {
+			if (rcommq_ptr->acks_recvd < spec->consistency_factor) {
+				rcommq_ptr->status = -1;
+				rcommq_ptr->state = CMD_EXECUTION_COMPLETED;
+				signal_luworker();
+			} else {
+				for (i=1; i < rcommq_ptr->iovcnt + 1; i++) {
+					xfree(rcommq_ptr->iov[i].iov_base);
+				}
+				if(rcommq_ptr->state == CMD_ENQUEUED_TO_PENDINGQ) {
+					TAILQ_REMOVE(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next);
+				} else if(rcommq_ptr->state == CMD_ENQUEUED_TO_WAITQ) {
+					TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next);
+				}
+				rcommq_ptr->state = CMD_EXECUTION_COMPLETED;
+				free(rcommq_ptr);
+			}
+		} else {
+			rcommq_ptr->ios_aborted++;
+		}
+	}
+}
+
+
 int
 remove_replica_from_list(spec_t *spec, int iofd) {
 	replica_t *replica;
-	int luworker_id;
 	rcmd_t *rep_cmd = NULL;
-	rcommon_cmd_t *rcommq_ptr;
 	MTX_LOCK(&spec->rq_mtx);
 	TAILQ_FOREACH(replica, &spec->rq, r_next) {
 		if(iofd == replica->iofd) {
@@ -357,51 +408,21 @@ remove_replica_from_list(spec_t *spec, int iofd) {
 			MTX_LOCK(&replica->r_mtx);
 			//Empty waitq of replica
 			while((rep_cmd = TAILQ_FIRST(&replica->waitq))) {
-				rcommq_ptr = rep_cmd->rcommq_ptr;
-				luworker_id = rcommq_ptr->luworker_id;
-				if(rep_cmd->opcode == ZVOL_OPCODE_READ) {
-					rcommq_ptr->status = -1;
-					MTX_LOCK(&spec->luworker_rmutex[luworker_id]);
-					pthread_cond_signal(&spec->luworker_rcond[luworker_id]); 
-					MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]);
-				}else if(rcommq_ptr->acks_recvd == rcommq_ptr->copies_sent - 1) {
-					rcommq_ptr->status = -1;
-					MTX_LOCK(&spec->luworker_rmutex[luworker_id]);
-					pthread_cond_signal(&spec->luworker_rcond[luworker_id]); 
-					MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]);
-				} else {
-					rcommq_ptr->acks_recvd++;
-				}
+				clear_replica_cmd(spec, replica, rep_cmd);
 				TAILQ_REMOVE(&replica->waitq, rep_cmd, rwait_cmd_next);
 			}
 			//Empty blockedq of replica
 			while((rep_cmd = TAILQ_FIRST(&replica->blockedq))) {
-				rcommq_ptr = rep_cmd->rcommq_ptr;
-				luworker_id = rcommq_ptr->luworker_id;
-				if(rep_cmd->opcode == ZVOL_OPCODE_READ) {
-					rcommq_ptr->status = -1;
-					MTX_LOCK(&spec->luworker_rmutex[luworker_id]);
-					pthread_cond_signal(&spec->luworker_rcond[luworker_id]); 
-					MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]);
-				}else if(rcommq_ptr->acks_recvd == rcommq_ptr->copies_sent - 1) {
-					rcommq_ptr->status = -1;
-					MTX_LOCK(&spec->luworker_rmutex[luworker_id]);
-					pthread_cond_signal(&spec->luworker_rcond[luworker_id]); 
-					MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]);
-				} else {
-					rcommq_ptr->acks_recvd++;
-				}
+				clear_replica_cmd(spec, replica, rep_cmd);
 				TAILQ_REMOVE(&replica->blockedq, rep_cmd, rblocked_cmd_next);
 			}
 			replica->removed = true;
 			pthread_cond_signal(&replica->r_cond);
 			MTX_UNLOCK(&replica->r_mtx);
 			spec->replica_count--;
-			if((spec->healthy_rcount < spec->consistency_factor) &&
-				(MAX(spec->replication_factor - spec->consistency_factor + 1, spec->consistency_factor) <
-					 spec->healthy_rcount  + spec->degraded_rcount)) {
-				spec->ready = false;
-			}
+			//TODO Update spec->degraded_rcount || spec->healthy_rcount over here
+			//based on state of  replica when it gets disconnected
+			update_volstate(spec);
 			TAILQ_REMOVE(&spec->rq, replica, r_next);
 			close(replica->iofd);
 		}
@@ -432,11 +453,13 @@ read_data(int fd, uint8_t *data, uint64_t len) {
 
 #define read_io_resp() {\
 	if(replica->read_rem_data) {\
-		count = read_data(events[i].data.fd, (uint8_t *)replica->io_rsp_data + replica->recv_len, replica->total_len - replica->recv_len);\
+		count = read_data(events[i].data.fd, (uint8_t *)replica->io_rsp_data \
+			+ replica->recv_len, replica->total_len - replica->recv_len);\
 		if(count < 0 && errno == EAGAIN) {\
 			MTX_UNLOCK(&replica->r_mtx);\
 			break;\
-		} else if(((uint64_t)count < (int64_t)replica->total_len - replica->recv_len) && errno == EAGAIN) {\
+		} else if(((uint64_t)count < (int64_t)replica->total_len - replica->recv_len) \
+				&& errno == EAGAIN) {\
 			replica->recv_len += count;\
 			MTX_UNLOCK(&replica->r_mtx);\
 			break;\
@@ -448,11 +471,13 @@ read_data(int fd, uint8_t *data, uint64_t len) {
 			goto execute_io;\
 		}\
 	} else if(replica->read_rem_hdr) {\
-		count = read_data(events[i].data.fd, (uint8_t *)replica->io_rsp + replica->recv_len, replica->total_len - replica->recv_len);\
+		count = read_data(events[i].data.fd, (uint8_t *)replica->io_rsp \
+			+ replica->recv_len, replica->total_len - replica->recv_len);\
 		if(count < 0 && errno == EAGAIN) {\
 			MTX_UNLOCK(&replica->r_mtx);\
 			break;\
-		} else if(((uint64_t)count < replica->total_len - replica->recv_len) && errno == EAGAIN) {\
+		} else if(((uint64_t)count < replica->total_len - replica->recv_len) \
+			&& errno == EAGAIN) {\
 			replica->recv_len += count;\
 			MTX_UNLOCK(&replica->r_mtx);\
 			break;\
@@ -534,9 +559,10 @@ void unblock_blocked_cmds(replica_t *replica)
 		}
 	}
 }
+
 int
 handle_read_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp, void *data)
-{ 
+{
 	int luworker_id;
 	bool io_found = false;
 	rcmd_t *rep_cmd = NULL;
@@ -556,17 +582,15 @@ handle_read_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp, void *
 			luworker_id = rcommq_ptr->luworker_id;
 			free(rep_cmd);
 
-			MTX_LOCK(&spec->luworker_rmutex[luworker_id]);
-			pthread_cond_signal(&spec->luworker_rcond[luworker_id]);
-			MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]);
+			signal_luworker();
 
 			MTX_LOCK(&spec->rcommonq_mtx);
 			TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next);
-			if(rcommq_ptr->completed == 1) {
+			if(rcommq_ptr->state == CMD_EXECUTION_COMPLETED) {
 				MTX_UNLOCK(&spec->rcommonq_mtx);
 				free(rcommq_ptr);
 			} else {
-				rcommq_ptr->completed = 1;
+				rcommq_ptr->state = CMD_EXECUTION_COMPLETED;
 				MTX_UNLOCK(&spec->rcommonq_mtx);
 			}
 			return 0;
@@ -578,6 +602,52 @@ handle_read_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp, void *
 		return -1;
 	}
 	return 0;
+}
+
+#define handle_consistency_met() {\
+	rcommq_ptr->status = 1; \
+	MTX_LOCK(&spec->rcommonq_mtx); \
+	TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next); \
+	if (rcommq_ptr->acks_recvd != rcommq_ptr->copies_sent) { \
+		rcommq_ptr->state = CMD_ENQUEUED_TO_PENDINGQ; \
+		TAILQ_INSERT_TAIL(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next); \
+	} else { \
+		for (i=1; i < rcommq_ptr->iovcnt + 1; i++) { \
+			xfree(rcommq_ptr->iov[i].iov_base); \
+		} \
+		rcommq_ptr->state = CMD_EXECUTION_COMPLETED; \
+	} \
+	MTX_UNLOCK(&spec->rcommonq_mtx); \
+	signal_luworker(); \
+}
+
+#define handle_all_resp_recvd() { \
+	MTX_LOCK(&spec->rcommonq_mtx); \
+	TAILQ_REMOVE(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next); \
+	for (i=1; i < rcommq_ptr->iovcnt + 1; i++) { \
+		xfree(rcommq_ptr->iov[i].iov_base); \
+	} \
+	if(rcommq_ptr->state == CMD_EXECUTION_COMPLETED) { \
+		free(rcommq_ptr); \
+		rcommq_ptr = NULL; \
+	} \
+	MTX_UNLOCK(&spec->rcommonq_mtx); \
+}
+
+#define handle_some_ios_aborted() { \
+	rcommq_ptr->status = -1; \
+	for (i=1; i < rcommq_ptr->iovcnt + 1; i++) { \
+		xfree(rcommq_ptr->iov[i].iov_base); \
+	} \
+	MTX_LOCK(&spec->rcommonq_mtx); \
+	if(rcommq_ptr->state == CMD_ENQUEUED_TO_PENDINGQ) {\
+		TAILQ_REMOVE(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next); \
+	} else if(rcommq_ptr->state == CMD_ENQUEUED_TO_WAITQ) {\
+		TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next); \
+	} \
+	rcommq_ptr->state = CMD_EXECUTION_COMPLETED; \
+	MTX_UNLOCK(&spec->rcommonq_mtx); \
+	signal_luworker(); \
 }
 
 int
@@ -592,7 +662,7 @@ handle_write_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp)
 			break;
 		}
 	}
-	if(rep_cmd == NULL) { 
+	if(rep_cmd == NULL) {
 		REPLICA_ERRLOG("rep_cmd not found io_seq:%lu\n", io_rsp->io_seq);
 		MTX_UNLOCK(&replica->r_mtx);
 		return -1;
@@ -611,38 +681,12 @@ handle_write_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp)
 
 				rcommq_ptr->bitset &= ~(1 << replica->id);
 				if (rcommq_ptr->acks_recvd == spec->consistency_factor) {
-					rcommq_ptr->status = 1;
-					//Transfer cmd from waitq to pendingq and wakeup luworker
-					MTX_LOCK(&spec->rcommonq_mtx);
-					TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next);
-					if (rcommq_ptr->acks_recvd != rcommq_ptr->copies_sent) {
-						TAILQ_INSERT_TAIL(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next);
-					} else {
-						/* we can leave this free to lbwrite */
-						for (i=1; i < rcommq_ptr->iovcnt + 1; i++) {
-							xfree(rcommq_ptr->iov[i].iov_base);
-						}
-						/* add the logic to free if already completed */
-						rcommq_ptr->completed = 1;
-					}
-					MTX_UNLOCK(&spec->rcommonq_mtx);
-
-					MTX_LOCK(&spec->luworker_rmutex[luworker_id]);
-					pthread_cond_signal(&spec->luworker_rcond[luworker_id]);
-					MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]);
-
-				} /* This else is not correct and not required */
-				else if (rcommq_ptr->acks_recvd == rcommq_ptr->copies_sent) {
-					MTX_LOCK(&spec->rcommonq_mtx);
-					TAILQ_REMOVE(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next);
-					for (i=1; i < rcommq_ptr->iovcnt + 1; i++) {
-						xfree(rcommq_ptr->iov[i].iov_base);
-					}
-					if(rcommq_ptr->completed == 1) {
-						free(rcommq_ptr);
-						rcommq_ptr = NULL;
-					}
-					MTX_UNLOCK(&spec->rcommonq_mtx);
+					handle_consistency_met();
+				} else if (rcommq_ptr->acks_recvd == rcommq_ptr->copies_sent) {
+					handle_all_resp_recvd();
+				} else if (rcommq_ptr->acks_recvd + rcommq_ptr->ios_aborted
+						== rcommq_ptr->copies_sent) {
+					handle_some_ios_aborted();
 				}
 				MTX_LOCK(&replica->r_mtx);
 				TAILQ_REMOVE(&replica->waitq, rep_cmd, rwait_cmd_next);
@@ -785,12 +829,7 @@ create_replica_entry(spec_t *spec, int iofd, char *replicaip, int replica_port) 
 	write(replica->iofd, spec->lu->volname, strlen(spec->lu->volname));
 	free(rio);
 	rio = NULL;
-	if((spec->healthy_rcount >= spec->consistency_factor) ||
-			(MAX(spec->replication_factor - spec->consistency_factor + 1, spec->consistency_factor) >=
-			 spec->healthy_rcount  + spec->degraded_rcount)) {
-		spec->ready = true;
-		pthread_cond_broadcast(&spec->rq_cond);
-	}
+	update_volstate(spec);
 	return replica;
 }
 
@@ -908,12 +947,12 @@ start_replication(void *arg __attribute__((__unused__))) {
 	}
 	events = calloc(MAXEVENTS, sizeof(event));
 
-	while (1) {	
+	while (1) {
 		//Wait for management connections(on sfd) and management commands(on mgmt_rfds[]) from replicas
 		event_count = epoll_wait(epfd, events, MAXEVENTS, -1);
 		for(i=0; i< event_count; i++) {
 			if ((events[i].events & EPOLLERR) ||
-					(events[i].events & EPOLLHUP) 
+					(events[i].events & EPOLLHUP)
 					|| (!(events[i].events & EPOLLIN))) {
 				REPLICA_LOG("epoll error\n");
 				close(events[i].data.fd);
@@ -994,7 +1033,7 @@ remove_volume(spec_t *spec) {
 	cmd = TAILQ_FIRST(&spec->rcommon_sendq);
 	while (cmd) {
 		cmd->status = -1;
-		cmd->completed = 1;
+		cmd->state = CMD_EXECUTION_COMPLETED; \
 		next_cmd = TAILQ_NEXT(cmd, send_cmd_next);
 		TAILQ_REMOVE(&rcommon_sendq, cmd, send_cmd_next);
 		cmd = next_cmd;
@@ -1002,7 +1041,7 @@ remove_volume(spec_t *spec) {
 	cmd = TAILQ_FIRST(&spec->rcommon_waitq);
 	while (cmd) {
 		cmd->status = -1;
-		cmd->completed = 1;
+		cmd->state = CMD_EXECUTION_COMPLETED; \
 		next_cmd = TAILQ_NEXT(cmd, wait_cmd_next);
 		TAILQ_REMOVE(&rcommon_waitq, cmd, wait_cmd_next);
 		cmd = next_cmd;
@@ -1010,7 +1049,7 @@ remove_volume(spec_t *spec) {
 	cmd = TAILQ_FIRST(&spec->rcommon_pendingq);
 	while (cmd) {
 		cmd->status = -1;
-		cmd->completed = 1;
+		cmd->state = CMD_EXECUTION_COMPLETED; \
 		next_cmd = TAILQ_NEXT(cmd, pending_cmd_next);
 		TAILQ_REMOVE(&rcommon_pendingq, cmd, pending_cmd_next);
 		cmd = next_cmd;
@@ -1031,7 +1070,7 @@ remove_volume(spec_t *spec) {
 
 int
 initialize_replication() {
-	//Global initializers for replication library	
+	//Global initializers for replication library
 	int rc;
 	TAILQ_INIT(&spec_q);
 	rc = pthread_mutex_init(&specq_mtx, NULL);
@@ -1081,13 +1120,13 @@ initialize_volume(spec_t *spec) {
 	if (rc != 0) {
 		ISTGT_ERRLOG("pthread_create(replicator_thread) failed\n");
 		return -1;
-	}	
+	}
 	rc = pthread_create(&replica_receiver_thread, NULL, &replica_receiver,
 			(void *)spec);
 	if (rc != 0) {
 		ISTGT_ERRLOG("pthread_create(replicator_thread) failed\n");
 		return -1;
-	}	
+	}
 
 	MTX_LOCK(&specq_mtx);
 	TAILQ_INSERT_TAIL(&spec_q, spec, spec_next);

--- a/src/replication.c
+++ b/src/replication.c
@@ -632,7 +632,6 @@ handle_write_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp)
 					MTX_UNLOCK(&spec->luworker_rmutex[luworker_id]);
 
 				} /* This else is not correct and not required */
-#if 0
 				else if (rcommq_ptr->acks_recvd == rcommq_ptr->copies_sent) {
 					MTX_LOCK(&spec->rcommonq_mtx);
 					TAILQ_REMOVE(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next);
@@ -645,7 +644,6 @@ handle_write_resp(spec_t *spec, replica_t *replica, zvol_io_hdr_t *io_rsp)
 					}
 					MTX_UNLOCK(&spec->rcommonq_mtx);
 				}
-#endif
 				MTX_LOCK(&replica->r_mtx);
 				TAILQ_REMOVE(&replica->waitq, rep_cmd, rwait_cmd_next);
 				free(rep_cmd);

--- a/src/replication.h
+++ b/src/replication.h
@@ -66,6 +66,7 @@ typedef struct rcommon_cmd_s {
 	uint64_t data_len;
 	uint64_t total_len;
 	int status;
+	bool completed;
 	cmd_state_t state;
 	void *data;
 	uint64_t total;

--- a/src/replication.h
+++ b/src/replication.h
@@ -21,6 +21,8 @@
 #define MAXIPLEN 56
 #define MAXNAMELEN 256
 
+#define MAX(a,b) (((a)>(b))?(a):(b))
+
 typedef enum zvol_op_code_e {
 	ZVOL_OPCODE_HANDSHAKE = 1,
 	ZVOL_OPCODE_READ,
@@ -51,7 +53,7 @@ typedef struct rcommon_cmd_s {
 	int luworker_id;
 	int acks_recvd;
 	int completed;
-
+	int copies_sent;
 	zvol_op_code_t opcode;
 	uint64_t io_seq;
 	uint64_t lun_id;

--- a/src/replication.h
+++ b/src/replication.h
@@ -48,7 +48,7 @@ typedef enum cmd_state_s {
 	CMD_CREATED = 1,
 	CMD_ENQUEUED_TO_WAITQ,
 	CMD_ENQUEUED_TO_PENDINGQ,
-	CMD_EXECUTION_COMPLETED,
+	CMD_EXECUTION_DONE,
 } cmd_state_t;
 
 typedef struct rcommon_cmd_s {

--- a/src/replication.h
+++ b/src/replication.h
@@ -44,7 +44,12 @@ typedef struct mgmt_ack_data_s {
 	int port;
 } mgmt_ack_data_t;
 
-
+typedef enum cmd_state_s {
+	CMD_CREATED = 1,
+	CMD_ENQUEUED_TO_WAITQ,
+	CMD_ENQUEUED_TO_PENDINGQ,
+	CMD_EXECUTION_COMPLETED,
+} cmd_state_t;
 
 typedef struct rcommon_cmd_s {
 	TAILQ_ENTRY(rcommon_cmd_s)  send_cmd_next; /* for rcommon_sendq */
@@ -52,7 +57,7 @@ typedef struct rcommon_cmd_s {
 	TAILQ_ENTRY(rcommon_cmd_s)  pending_cmd_next; /* for rcommon_pendingq */
 	int luworker_id;
 	int acks_recvd;
-	int completed;
+	int ios_aborted;
 	int copies_sent;
 	zvol_op_code_t opcode;
 	uint64_t io_seq;
@@ -61,6 +66,7 @@ typedef struct rcommon_cmd_s {
 	uint64_t data_len;
 	uint64_t total_len;
 	int status;
+	cmd_state_t state;
 	void *data;
 	uint64_t total;
 	int64_t iovcnt;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -137,20 +137,21 @@ send_io_resp(int fd, zvol_io_hdr_t *io_hdr, void *buf)
 int
 main(int argc, char **argv)
 {
-	if(argc < 4) {
+	if(argc < 5) {
 		exit(EXIT_FAILURE);
 	}
 	char *ctrl_ip = argv[1];
 	int ctrl_port = atoi(argv[2]);
 	char *replicaip = argv[3];
-	int replica_port = atoi(argv[4]); 
+	int replica_port = atoi(argv[4]);
+	char *test_vol = argv[5];
 	int iofd, mgmtfd, sfd, rc, epfd, event_count, i;
 	int64_t count;
 	struct epoll_event event, *events;
 	uint8_t *data, *data_ptr_cpy;
 	uint64_t data_len, nbytes = 0;
 	char *volname;
-	int vol_fd = open("test_vol", O_RDWR, 0666);
+	int vol_fd = open(test_vol, O_RDWR, 0666);
 	zvol_op_code_t opcode;
 	zvol_io_hdr_t *io_hdr = malloc(sizeof(zvol_io_hdr_t));
 	zvol_io_hdr_t *mgmtio = malloc(sizeof(zvol_io_hdr_t));

--- a/src/setup_istgt.sh
+++ b/src/setup_istgt.sh
@@ -2,9 +2,10 @@ ulimit -c unlimited
 sudo rm -rf core
 sudo mkdir -p /usr/local/etc/istgt
 sudo mkdir -p /tmp/cstor
+make clean
 make
 sudo cp istgt.conf istgtcontrol.conf /tmp/cstor/
 sudo cp istgt.conf istgtcontrol.conf /usr/local/etc/istgt/
 sudo cp istgt istgtcontrol /usr/local/bin/
 ps -aux | grep "\./istgt" | grep -v grep | sudo kill -9 `awk '{print $2}'`
-sudo ./init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=1 consistency_factor=1
+sudo ./init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=3 consistency_factor=2

--- a/src/setup_istgt.sh
+++ b/src/setup_istgt.sh
@@ -2,8 +2,6 @@ ulimit -c unlimited
 sudo rm -rf core
 sudo mkdir -p /usr/local/etc/istgt
 sudo mkdir -p /tmp/cstor
-make clean
-make
 sudo cp istgt.conf istgtcontrol.conf /tmp/cstor/
 sudo cp istgt.conf istgtcontrol.conf /usr/local/etc/istgt/
 sudo cp istgt istgtcontrol /usr/local/bin/

--- a/src/setup_istgt.sh
+++ b/src/setup_istgt.sh
@@ -7,4 +7,4 @@ sudo cp istgt.conf istgtcontrol.conf /tmp/cstor/
 sudo cp istgt.conf istgtcontrol.conf /usr/local/etc/istgt/
 sudo cp istgt istgtcontrol /usr/local/bin/
 ps -aux | grep "\./istgt" | grep -v grep | sudo kill -9 `awk '{print $2}'`
-sudo ./init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=3 consistency_factor=2
+sudo ./init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=1 consistency_factor=1

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -94,7 +94,7 @@ sleep 5
 run_data_integrity_test
 
 sudo kill -9 $controller_pid $replica1_pid $replica2_pid $replica3_pid
-ps -aux | grep replication_test | grep -v grep | awk '{print "kill -9 "$2}' | sudo sh
-ps -aux | grep istgt | grep -v grep | awk '{print "kill -9 "$2}' | sudo sh
+ps -aux | grep -w replication_test | grep -v grep | awk '{print "kill -9 "$2}' | sudo sh
+ps -aux | grep -w istgt | grep -v grep | awk '{print "kill -9 "$2}' | sudo sh
 
 exit 0

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1,5 +1,24 @@
+#!/bin/bash
 
-# Wait for iSCSI device node (scsi device) to be created
+CONTROLLER_IP="127.0.0.1"
+CONTROLLER_PORT="6060"
+REPLICA1_IP="127.0.0.1"
+REPLICA2_IP="127.0.0.1"
+REPLICA3_IP="127.0.0.1"
+REPLICA1_PORT="6161"
+REPLICA2_PORT="6162"
+REPLICA3_PORT="6163"
+
+login_to_volume() {
+	sudo iscsiadm -m discovery -t st -p $1
+	sudo iscsiadm -m node -l
+}
+
+logout_of_volume() {
+	sudo iscsiadm -m node -u
+	sudo iscsiadm -m node -o delete
+}
+
 get_scsi_disk() {
 	device_name=$(sudo iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
 	i=0
@@ -16,39 +35,49 @@ get_scsi_disk() {
 	done
 }
 
-cd src
-sudo sh ./setup_istgt.sh &
+run_data_integrity_test(){
+	login_to_volume "$CONTROLLER_IP:3260"
+	sleep 5
+	get_scsi_disk
+	if [ "$device_name"!="" ]; then
+		sudo mkfs.ext2 -F /dev/$device_name
 
-sleep 5
+		sudo mount /dev/$device_name /mnt/store
 
+		sudo dd if=/dev/urandom of=file1 bs=4k count=10000
+		hash1=$(sudo md5sum file1 | awk '{print $1}')
+		sudo cp file1 /mnt/store
+		hash2=$(sudo md5sum /mnt/store/file1 | awk '{print $1}')
+		if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
+		else
+			echo "DI Test: FAILED"; exit 1
+		fi
+
+		sudo umount /mnt/store
+		logout_of_volume
+		sleep 5
+	else
+		echo "Unable to detect iSCSI device, login failed"; exit 1
+	fi
+}
+
+prepare_test_env() {
+	sudo rm -f /tmp/test_vol*
+	sudo mkdir -p /mnt/store
+	sudo truncate -s 20G /tmp/test_vol1 /tmp/test_vol2 /tmp/test_vol3
+	logout_of_volume
+}
+
+prepare_test_env
+
+./configure --with-replication; cd src; sudo sh ./setup_istgt.sh &
 cd ..
-sudo truncate -s 20G test_vol
-
-sudo ./src/replication_test 127.0.0.1 6060 127.0.0.1 6161 &
+sleep 120
+echo "START--------------------------------------"
+sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA1_IP" "$REPLICA1_PORT" "/tmp/test_vol1" &
+sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA2_IP" "$REPLICA2_PORT" "/tmp/test_vol2" &
+sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA3_IP" "$REPLICA3_PORT" "/tmp/test_vol3" &
 
 sleep 15
 
-sudo iscsiadm -m discovery -t st -p 127.0.0.1:3260
-
-sudo iscsiadm -m node -l
-
-sudo iscsiadm -m session -P 3
-
-get_scsi_disk
-
-echo $device_name
-
-if [ "$device_name" != "" ]; then
-	sudo mkdir -p /mnt/store
-	sudo mount /dev/$device_name /mnt/store
-
-	sudo dd if=/dev/urandom of=/mnt/store/file1 bs=4k count=10000
-	sudo dd if=/mnt/store/file1 of=/dev/zero bs=4k count=10000
-
-	sudo umount /mnt/store
-fi
-
-sudo iscsiadm -m node -u
-
-sudo iscsiadm -m node -o delete
-
+run_data_integrity_test

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -75,7 +75,6 @@ sudo sh ./setup_istgt.sh &
 controller_pid=$!
 cd ..
 sleep 15
-echo "START--------------------------------------"
 sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA1_IP" "$REPLICA1_PORT" "/tmp/test_vol1" &
 replica1_pid=$!
 sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA2_IP" "$REPLICA2_PORT" "/tmp/test_vol2" &
@@ -86,7 +85,16 @@ replica3_pid=$!
 sleep 15
 
 run_data_integrity_test
+sudo kill -9 $replica3_pid
+sleep 5
+run_data_integrity_test
+sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA3_IP" "$REPLICA3_PORT" "/tmp/test_vol3" &
+replica3_pid=$!
+sleep 5
+run_data_integrity_test
 
 sudo kill -9 $controller_pid $replica1_pid $replica2_pid $replica3_pid
 ps -aux | grep replication | awk '{print "kill -9 "$2}' | sudo sh
 ps -aux | grep istgt | awk '{print "kill -9 "$2}' | sudo sh
+
+exit 0

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -70,14 +70,23 @@ prepare_test_env() {
 
 prepare_test_env
 
-./configure --with-replication; cd src; sudo sh ./setup_istgt.sh &
+cd src
+sudo sh ./setup_istgt.sh &
+controller_pid=$!
 cd ..
-sleep 120
+sleep 15
 echo "START--------------------------------------"
 sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA1_IP" "$REPLICA1_PORT" "/tmp/test_vol1" &
+replica1_pid=$!
 sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA2_IP" "$REPLICA2_PORT" "/tmp/test_vol2" &
+replica2_pid=$!
 sudo ./src/replication_test "$CONTROLLER_IP" "$CONTROLLER_PORT" "$REPLICA3_IP" "$REPLICA3_PORT" "/tmp/test_vol3" &
+replica3_pid=$!
 
 sleep 15
 
 run_data_integrity_test
+
+sudo kill -9 $controller_pid $replica1_pid $replica2_pid $replica3_pid
+ps -aux | grep replication | awk '{print "kill -9 "$2}' | sudo sh
+ps -aux | grep istgt | awk '{print "kill -9 "$2}' | sudo sh

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -94,7 +94,7 @@ sleep 5
 run_data_integrity_test
 
 sudo kill -9 $controller_pid $replica1_pid $replica2_pid $replica3_pid
-ps -aux | grep replication | awk '{print "kill -9 "$2}' | sudo sh
-ps -aux | grep istgt | awk '{print "kill -9 "$2}' | sudo sh
+ps -aux | grep replication_test | grep -v grep | awk '{print "kill -9 "$2}' | sudo sh
+ps -aux | grep istgt | grep -v grep | awk '{print "kill -9 "$2}' | sudo sh
 
 exit 0


### PR DESCRIPTION
Add degraded and healthy modes for replica.
Start serving IOs only when consistency factor has been met.
Signed-off-by: Payes <payes.anand@cloudbyte.com>