### PR TITLE
[cstor#134] error handling in read/write on mgmt connections

### DIFF
--- a/src/istgt.c
+++ b/src/istgt.c
@@ -2859,7 +2859,7 @@ main(int argc, char **argv)
 		ISTGT_ERRLOG("initialize_replication() failed\n");
 		goto initialize_error;
 	}
-        rc = pthread_create(&replication_thread, &istgt->attr, &start_replication,
+        rc = pthread_create(&replication_thread, &istgt->attr, &init_replication,
                         (void *)NULL);
         if (rc != 0) {
                 ISTGT_ERRLOG("pthread_create(replication_thread) failed\n");

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -24,8 +24,22 @@ typedef enum replica_state_s {
 	NEED_REMOVAL_FROM_EPOLL,
 } replica_state_t;
 
+/* replica state on mgmt thread for mgmt IOs
+ * set in mgmt_io_state
+ */
+
+/* to read mgmt IO hdr */
+#define READ_MGMT_ACK_HDR	1
+
+/* to read handshake msg data */
+#define READ_MGMT_ACK_DATA	2
+
+typedef struct zvol_io_hdr_s zvol_io_hdr_t;
+typedef struct mgmt_ack_data_s mgmt_ack_data_t;
+
 typedef struct replica_s {
 	TAILQ_ENTRY(replica_s) r_next;
+	TAILQ_ENTRY(replica_s) r_waitnext;
 	TAILQ_HEAD(, rcmd_s) sendq;
 	TAILQ_HEAD(, rcmd_s) waitq;
 	TAILQ_HEAD(, rcmd_s) blockedq;
@@ -36,7 +50,7 @@ typedef struct replica_s {
 	spec_t *spec;
 	int id;
 	int iofd;
-	int mgmtfd;
+	int mgmt_fd;
 	int port;
 	char *ip;
 	uint64_t least_recvd;
@@ -51,6 +65,10 @@ typedef struct replica_s {
 	bool read_rem_data;
 	bool read_rem_hdr;
 	bool removed;
+	int mgmt_io_state;
+	int mgmt_io_read; //amount of data read in current state
+	zvol_io_hdr_t *mgmt_ack;
+	mgmt_ack_data_t *mgmt_ack_data;
 } replica_t;
 
 typedef struct cstor_conn_ops {
@@ -70,5 +88,10 @@ int handle_read_resp(spec_t *, replica_t *, zvol_io_hdr_t *, void *);
 int update_replica_list(int, spec_t *, int);
 int remove_replica_from_list(spec_t *, int);
 void unblock_blocked_cmds(replica_t *);
-replica_t *create_replica_entry(spec_t *, int, char *, int);
+
+replica_t *create_replica_entry(spec_t *, int);
+replica_t *update_replica_entry(spec_t *, replica_t *, int, char *, int);
+
+replica_t * get_replica(int mgmt_fd, spec_t **);
+void handle_read_data_event(int fd);
 #endif

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -15,6 +15,7 @@ pthread_mutex_t specq_mtx;
 
 typedef ISTGT_QUEUE *cmd_ptr;
 typedef struct istgt_lu_disk_t spec_t;
+typedef struct rcmd_s rcmd_t;
 
 typedef enum replica_state_s {
 	ADDED_TO_SPEC,

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -817,6 +817,7 @@ typedef struct istgt_lu_disk_t {
 	TAILQ_HEAD(, rcommon_cmd_s) rcommon_waitq; //Contains IOs waiting for acks from atleast n(consistency level) replicas
 	TAILQ_HEAD(, rcommon_cmd_s) rcommon_pendingq; //Contains IOs waiting for acks from remaining replicas
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
+	TAILQ_HEAD(, replica_s) rwaitq; //Queue of replicas completed handshake, and yet to have data connection to this spec(volume)
 	int replica_count;
 	int consistency_count;
 	int replication_factor;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1055,7 +1055,7 @@ read_mgmt_ack_hdr:
 
 		case READ_MGMT_ACK_DATA:
 			if(replica->mgmt_ack->len != sizeof (mgmt_ack_data_t)) {
-				REPLICA_ERRLOG("mgmt_ack_len %d not matching with size of mgmt_ack_data..\n",
+				REPLICA_ERRLOG("mgmt_ack_len %lu not matching with size of mgmt_ack_data..\n",
 				    replica->mgmt_ack->len);
 				replica->mgmt_ack->len = sizeof (mgmt_ack_data_t);
 			}

--- a/src/replication.h
+++ b/src/replication.h
@@ -12,6 +12,8 @@
 #include <sys/uio.h>
 #include <syslog.h>
 #include <stdbool.h>
+#include "istgt_integration.h"
+#include "istgt_lu.h"
 
 #ifndef REPLICA_INITIALIZE
 #define REPLICA_INITIALIZE 1
@@ -98,15 +100,18 @@ typedef struct zvol_io_hdr_s {
 	zvol_op_status_t status;
 } zvol_io_hdr_t;
 
-void *start_replication(void *);
+typedef struct replica_s replica_t;
+typedef struct istgt_lu_disk_t spec_t;
+
+void *init_replication(void *);
 int sendio(int, int, rcommon_cmd_t *, rcmd_t *);
 int send_mgmtio(int, zvol_op_code_t, void *, uint64_t);
 int make_socket_non_blocking(int);
 int send_mgmtack(int, zvol_op_code_t, void *, char *, int);
 int wait_for_fd(int);
-int64_t read_data(int, uint8_t *, uint64_t);
-int zvol_handshake(char *, char *, int);
-int accept_mgmt_conns(int, int);
+int64_t read_data(int, uint8_t *, uint64_t, int *, int *);
+int zvol_handshake(spec_t *, replica_t *);
+void accept_mgmt_conns(int, int);
 int send_io_resp(int fd, zvol_io_hdr_t *, void *);
 
 #define REPLICA_LOG(fmt, ...)  syslog(LOG_NOTICE, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -29,8 +29,10 @@ __thread char  tinfo[20] =  {0};
 	mgmt_ack_data->port = replica_port;\
 }
 
+int64_t test_read_data(int fd, uint8_t *data, uint64_t len);
+
 int64_t
-read_data(int fd, uint8_t *data, uint64_t len) {
+test_read_data(int fd, uint8_t *data, uint64_t len) {
 	int rc;
 	uint64_t nbytes = 0;
 	while((rc = read(fd, data + nbytes, len - nbytes))) {
@@ -201,7 +203,7 @@ main(int argc, char **argv)
 				fprintf (stderr, "epoll error\n");
 				continue;
 			} else if (events[i].data.fd == mgmtfd) {
-				count = read_data(events[i].data.fd, (uint8_t *)mgmtio, sizeof(zvol_io_hdr_t));
+				count = test_read_data(events[i].data.fd, (uint8_t *)mgmtio, sizeof(zvol_io_hdr_t));
 				if (count<0)
 				{
 					if (errno != EAGAIN)
@@ -214,7 +216,7 @@ main(int argc, char **argv)
 				if(mgmtio->len) {
 					data = data_ptr_cpy = malloc(mgmtio->len);
 					data_len = mgmtio->len;
-					count = read_data(events[i].data.fd, (uint8_t *)data, mgmtio->len);
+					count = test_read_data(events[i].data.fd, (uint8_t *)data, mgmtio->len);
 				}
 				opcode = mgmtio->opcode;
 				volname = (char *)data;
@@ -257,7 +259,7 @@ main(int argc, char **argv)
 			} else if(events[i].data.fd == iofd) {
 				while(1) {
 					if(read_rem_data) {
-						count = read_data(events[i].data.fd, (uint8_t *)data + recv_len, total_len - recv_len);
+						count = test_read_data(events[i].data.fd, (uint8_t *)data + recv_len, total_len - recv_len);
 						if(count < 0 && errno == EAGAIN) {
 							break;
 						}else if(((uint64_t)count < total_len - recv_len) && errno == EAGAIN) {
@@ -271,7 +273,7 @@ main(int argc, char **argv)
 						}
 
 					} else if(read_rem_hdr) {
-						count = read_data(events[i].data.fd, (uint8_t *)io_hdr + recv_len, total_len - recv_len);
+						count = test_read_data(events[i].data.fd, (uint8_t *)io_hdr + recv_len, total_len - recv_len);
 						if(count < 0 && errno == EAGAIN) {
 							break;
 						} else if(((uint64_t)count < total_len - recv_len) && errno == EAGAIN) {
@@ -283,7 +285,7 @@ main(int argc, char **argv)
 							total_len = 0;
 						}
 					} else {
-						count = read_data(events[i].data.fd, (uint8_t *)io_hdr, io_hdr_len);
+						count = test_read_data(events[i].data.fd, (uint8_t *)io_hdr, io_hdr_len);
 						if((count < 0) && (errno == EAGAIN)) {
 							break;
 						} else if(((uint64_t)count < io_hdr_len) && (errno == EAGAIN)) {
@@ -299,7 +301,7 @@ main(int argc, char **argv)
 						if(io_hdr->len) {
 							data = malloc(io_hdr->len);
 							nbytes = 0;
-							count = read_data(events[i].data.fd, (uint8_t *)data, io_hdr->len);
+							count = test_read_data(events[i].data.fd, (uint8_t *)data, io_hdr->len);
 							if (count == -1 && errno == EAGAIN) {
 								read_rem_data = true;
 								recv_len = 0;


### PR DESCRIPTION
init_replication creates listener to accept connections from replicas. These connections are used to do handshake and to send management commands.
This PR address issues in handling errors while reading/writing on these connections. Data will be read on fd till EAGAIN comes, and data that is read till now is stored to continue for next time read.
Having negative test cases is not scope of this PR, as such infra doesn't exists currently.