### PR TITLE
[cstor-124]Fix issues with replica ids and replica cleanup

### DIFF
--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -48,6 +48,7 @@ typedef struct replica_s {
 	replica_state_t state;
 	spec_t *spec;
 	int id;
+	int refcount;
 	int iofd;
 	int mgmt_fd;
 	int sender_epfd;

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -18,9 +18,9 @@ typedef struct istgt_lu_disk_t spec_t;
 typedef struct rcmd_s rcmd_t;
 
 typedef enum replica_state_s {
-	REPLICA_DEGRADED = 1,
-	REPLICA_HELATHY,
-	REPLICA_ERRORED,
+	REPLICA_DEGRADED = 1, //Every replica is attached in degraded state
+	REPLICA_HEALTHY,      //Replica is moved to this state when replica state enquiry returns healthy
+	REPLICA_ERRORED,      //When there is an error on any of the fds, replica is moved to this state
 } replica_state_t;
 
 /* replica state on mgmt thread for mgmt IOs
@@ -85,7 +85,7 @@ int initialize_replication(void);
 int handle_write_resp(spec_t *, replica_t *);
 int handle_read_resp(spec_t *, replica_t *);
 int update_replica_list(int, spec_t *, int);
-int remove_replica_from_list(spec_t *, int);
+void remove_replica_from_list(spec_t *, replica_t *);
 void unblock_blocked_cmds(replica_t *);
 
 replica_t *create_replica_entry(spec_t *, int);

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -818,11 +818,11 @@ typedef struct istgt_lu_disk_t {
 	TAILQ_HEAD(, rcommon_cmd_s) rcommon_pendingq; //Contains IOs waiting for acks from remaining replicas
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
 	TAILQ_HEAD(, replica_s) rwaitq; //Queue of replicas completed handshake, and yet to have data connection to this spec(volume)
-	int replica_count;
 	int replication_factor;
 	int consistency_factor;
 	int healthy_rcount;
 	int degraded_rcount;
+	uint64_t replica_ids;
 	bool ready;
 	int receiver_epfd;
 	/*Common for both the above queues,

--- a/src/replication.h
+++ b/src/replication.h
@@ -124,7 +124,10 @@ void accept_mgmt_conns(int, int);
 int send_io_resp(int fd, zvol_io_hdr_t *, void *);
 int initialize_replication_mempool(bool should_fail);
 int destroy_relication_mempool(void);
-
+int allocate_replica_id(spec_t *);
+void release_replica_id(spec_t *, int);
+void cleanup_replica(replica_t *);
+replica_t *get_next_replica(spec_t *, replica_t *);
 #define REPLICA_LOG(fmt, ...)  syslog(LOG_NOTICE, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_NOTICELOG(fmt, ...) syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_ERRLOG(fmt, ...) syslog(LOG_ERR,  	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)

--- a/src/replication.h
+++ b/src/replication.h
@@ -128,6 +128,7 @@ int allocate_replica_id(spec_t *);
 void release_replica_id(spec_t *, int);
 void cleanup_replica(replica_t *);
 replica_t *get_next_replica(spec_t *, replica_t *);
+replica_t *get_replica_from_iofd(spec_t *, int);
 #define REPLICA_LOG(fmt, ...)  syslog(LOG_NOTICE, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_NOTICELOG(fmt, ...) syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_ERRLOG(fmt, ...) syslog(LOG_ERR,  	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)

--- a/src/replication.h
+++ b/src/replication.h
@@ -127,7 +127,6 @@ int destroy_relication_mempool(void);
 int allocate_replica_id(spec_t *);
 void release_replica_id(spec_t *, int);
 void cleanup_replica(replica_t *);
-replica_t *get_next_replica(spec_t *, replica_t *);
 replica_t *get_replica_from_iofd(spec_t *, int);
 #define REPLICA_LOG(fmt, ...)  syslog(LOG_NOTICE, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_NOTICELOG(fmt, ...) syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)


### PR DESCRIPTION
In istgt, replica's id is set to spec's (spec is data structure for a LUN specification) 'replica_count', where, 'replica_count' is the number of connected replicas.
So, if a replica gets disconnected and a new replica gets connected, there are chances that two replicas can have same replica id.
replica id is used to find the replicas on which a given IO is waiting, based on which new IOs will be added to blocked queue or command queue.
replica->id need to be made unique across replicas and almost sequential by filling out gap if any during addition of replica.
Signed-off-by: Payes <payes.anand@cloudbyte.com>