### PR TITLE
[cstor#136] data structure related to replication rcommand_t is not thread safe

### DIFF
--- a/src/istgt_iscsi.h
+++ b/src/istgt_iscsi.h
@@ -211,7 +211,7 @@ typedef struct istgt_r2t_task_t {
 
 	uint64_t iobufsize;
 	int iobufindx;
-	struct iovec iobuf[20];
+	struct iovec iobuf[40];
 	//int iobufoff[20]; int iobufsize[20]; uint8_t *iobuf[20];
 
 	uint32_t R2TSN;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -399,7 +399,7 @@ typedef struct istgt_lu_cmd_t {
 
 	uint64_t iobufsize;
 	int iobufindx;
-	struct iovec iobuf[20];
+	struct iovec iobuf[40];
 	//int iobufoff[20]; int iobufsize[20]; uint8_t *iobuf[20];
 
 	uint8_t *data;

--- a/src/replication.c
+++ b/src/replication.c
@@ -551,7 +551,7 @@ handle_read_resp(spec_t *spec, replica_t *replica)
 #define handle_consistency_met() {\
 	rcommq_ptr->status = 1; \
 	TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next); \
-	if (rcommq_ptr->acks_recvd != rcommq_ptr->copies_sent) { \
+	if ((rcommq_ptr->acks_recvd + rcommq_ptr->ios_aborted) != rcommq_ptr->copies_sent) { \
 		rcommq_ptr->state = CMD_ENQUEUED_TO_PENDINGQ; \
 		TAILQ_INSERT_TAIL(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next); \
 	} else { \

--- a/src/replication.c
+++ b/src/replication.c
@@ -30,11 +30,10 @@ extern size_t rcommon_cmd_mempool_count;
 
 #define build_replica_io_hdr() \
 {\
-	rio = (zvol_io_hdr_t *)malloc(sizeof(zvol_io_hdr_t));\
-	rio->opcode = cmd->opcode;\
-	rio->io_seq = cmd->io_seq;\
-	rio->offset = cmd->offset;\
-	rio->len    = cmd->data_len;\
+	rio.opcode = cmd->opcode;\
+	rio.io_seq = cmd->io_seq;\
+	rio.offset = cmd->offset;\
+	rio.len    = cmd->data_len;\
 }
 #define build_replica_mgmt_hdr() \
 {\
@@ -134,13 +133,13 @@ replicator(void *arg) {
 	spec_t *spec = (spec_t *)arg;
 	replica_t *replica;
 	bool read_cmd_sent;
-	uint64_t bitset;
 	int i = 0;
 	rcommon_cmd_t *cmd = NULL;
 	rcmd_t *rcmd = NULL;
 	bool cmd_blocked = false;
 	uint64_t io_seq = 0;
 	rcommon_cmd_t *pending_cmd;
+	rcmd_t *pending_rcmd;
 
 	while(1) {
 		MTX_LOCK(&spec->rcommonq_mtx);
@@ -152,18 +151,9 @@ dequeue_common_sendq:
 		}
 		cmd->io_seq = ++io_seq;
 		cmd->acks_recvd = 0;
-		cmd->bitset = 0;
 		TAILQ_REMOVE(&spec->rcommon_sendq, cmd, send_cmd_next);
-		cmd->state = CMD_ENQUEUED_TO_WAITQ; \
+		cmd->state = CMD_ENQUEUED_TO_WAITQ;
 		TAILQ_INSERT_TAIL(&spec->rcommon_waitq, cmd, wait_cmd_next);
-		//Check for blockage in rcommon_pendingq and set corresponding blocked replica bits
-		bitset = 0;
-		TAILQ_FOREACH(pending_cmd, &spec->rcommon_pendingq, pending_cmd_next) {
-			check_for_blockage();
-			if(cmd_blocked == true) {
-				bitset |= pending_cmd->bitset;
-			}
-		}
 		MTX_UNLOCK(&spec->rcommonq_mtx);
 
 		//Enqueue to individual replica cmd queues and send on the respective fds
@@ -182,16 +172,37 @@ dequeue_common_sendq:
 				MTX_UNLOCK(&replica->r_mtx);
 				continue;
 			}
-			cmd->bitset |= (1 << replica->id);
 			cmd->copies_sent++;
-			if(bitset & (1 << replica->id)) {
+
+			if (!TAILQ_EMPTY(&replica->blockedq))
 				TAILQ_INSERT_TAIL(&replica->blockedq, rcmd, rblocked_cmd_next);
-			} else {
-				TAILQ_INSERT_TAIL(&replica->sendq, rcmd, rsend_cmd_next);
-				if(rcmd->opcode == ZVOL_OPCODE_READ) {
-					read_cmd_sent = true;
+			else {
+				cmd_blocked = false;
+				TAILQ_FOREACH(pending_rcmd, &replica->sendq, rsend_cmd_next) {
+					pending_cmd = pending_rcmd->rcommq_ptr;
+					check_for_blockage();
+					if(cmd_blocked == true) {
+						TAILQ_INSERT_TAIL(&replica->blockedq, rcmd, rblocked_cmd_next);
+						break;
+					}
 				}
-				pthread_cond_signal(&replica->r_cond);
+				if(cmd_blocked == false) {
+					TAILQ_FOREACH(pending_rcmd, &replica->waitq, rwait_cmd_next) {
+						pending_cmd = pending_rcmd->rcommq_ptr;
+						check_for_blockage();
+						if(cmd_blocked == true) {
+							TAILQ_INSERT_TAIL(&replica->blockedq, rcmd, rblocked_cmd_next);
+							break;
+						}
+					}
+				}
+				if(cmd_blocked == false) {
+					TAILQ_INSERT_TAIL(&replica->sendq, rcmd, rsend_cmd_next);
+					if(rcmd->opcode == ZVOL_OPCODE_READ) {
+						read_cmd_sent = true;
+					}
+					pthread_cond_signal(&replica->r_cond);
+				}
 			}
 			MTX_UNLOCK(&replica->r_mtx);
 			if((rcmd->opcode == ZVOL_OPCODE_READ) && read_cmd_sent) {
@@ -206,11 +217,17 @@ int
 wait_for_fd(int epfd) {
 	int event_count = 0;
 	struct epoll_event event;
+epollwait:
 	event_count = epoll_wait(epfd, &event, 1, -1);
-	if ((event.events & EPOLLERR) ||
-			(event.events & EPOLLHUP) ||
-			(!(event.events & EPOLLOUT))) {
-		REPLICA_LOG("epoll error: %d\n", errno);
+
+	if (event_count < 0) {
+		if (errno == EINTR)
+			goto epollwait;
+		REPLICA_ERRLOG("epoll_wait ret %d err %d.. better to restart..\n", event_count, errno);
+		goto epollwait;
+	}
+	if (!(event.events & EPOLLOUT)) {
+		REPLICA_LOG("epoll err event %d on fd %d..\n", event.events, event.data.fd);
 		return -1;
 	} else {
 		return 0;
@@ -219,13 +236,13 @@ wait_for_fd(int epfd) {
 
 int
 sendio(int epfd, int fd, rcommon_cmd_t *cmd, rcmd_t *rcmd) {
-	zvol_io_hdr_t *rio = NULL;
+	zvol_io_hdr_t rio;
 	int i = 0;
 	int64_t rc = 0;
 	int64_t nbytes = 0;
 	nbytes = cmd->total_len;
 	build_replica_io_hdr();
-	rcmd->iov[0].iov_base = rio;
+	rcmd->iov[0].iov_base = &rio;
 	rcmd->iov[0].iov_len = sizeof(zvol_io_hdr_t);
 	nbytes += sizeof(zvol_io_hdr_t);
 	while (nbytes) {
@@ -233,15 +250,16 @@ write_to_socket:
 		rc = writev(fd, rcmd->iov, rcmd->iovcnt+1);
 		if (rc < 0) {
 			if (errno == EAGAIN) {
-				wait_for_fd(epfd);
-				goto write_to_socket;
+				rc = wait_for_fd(epfd);
+				if (rc == 0)
+					goto write_to_socket;
+				return -1;
 			} else {
-				//REPLICA_LOG("write error %d on replica %s\n", rc, rcmd->r->ip);
-				free(rio);
-				rio = NULL;
+				REPLICA_LOG("write error %ld on fd %d\n", rc, fd);
 				return -1;
 			}
-		}
+		} else if (rc == 0)
+			REPLICA_LOG("fd %d returned 0\n", fd);
 		nbytes -= rc;
 		if (nbytes <= 0)
 			break;
@@ -257,8 +275,6 @@ write_to_socket:
 			}
 		}
 	}
-	free(rio);
-	rio = NULL;
 	return 0;
 }
 
@@ -356,41 +372,46 @@ void update_volstate(spec_t *spec) {
 		spec->ready = false;
 	}
 }
-//TODO Use locks for accessing rcommq_ptr, common waitq and common pendingq
+
 void clear_replica_cmd(spec_t *spec, replica_t *replica, rcmd_t *rep_cmd) {
-	int i;
 	rcommon_cmd_t *rcommq_ptr = rep_cmd->rcommq_ptr;
 	int luworker_id = rcommq_ptr->luworker_id;
-	rcommq_ptr->bitset &= ~(1 << replica->id);
 	//TODO Add check for acks_received in read also, same as write
 	if(rep_cmd->opcode == ZVOL_OPCODE_READ) {
+		MTX_LOCK(&rcommq_ptr->rcommand_mtx);
 		rcommq_ptr->state = CMD_EXECUTION_DONE;
 		rcommq_ptr->status = -1;
 		rcommq_ptr->completed = true;
+		MTX_UNLOCK(&rcommq_ptr->rcommand_mtx);
 		signal_luworker();
 	} else if(rep_cmd->opcode == ZVOL_OPCODE_WRITE) {
+		MTX_LOCK(&spec->rcommonq_mtx);
+		MTX_LOCK(&rcommq_ptr->rcommand_mtx);
 		rcommq_ptr->ios_aborted++;
 		if(rcommq_ptr->acks_recvd + rcommq_ptr->ios_aborted
 				== rcommq_ptr->copies_sent) {
-			for (i=1; i < rcommq_ptr->iovcnt + 1; i++) {
-				xfree(rcommq_ptr->iov[i].iov_base);
-			}
 			rcommq_ptr->ios_aborted++;
-			if(rcommq_ptr->state == CMD_ENQUEUED_TO_PENDINGQ) {
+			if(rcommq_ptr->state == CMD_ENQUEUED_TO_PENDINGQ)
 				TAILQ_REMOVE(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next);
-			} else if(rcommq_ptr->state == CMD_ENQUEUED_TO_WAITQ) {
+			else if(rcommq_ptr->state == CMD_ENQUEUED_TO_WAITQ)
 				TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next);
-			}
+			MTX_UNLOCK(&spec->rcommonq_mtx);
 			rcommq_ptr->state = CMD_EXECUTION_DONE;
 			if(rcommq_ptr->completed) {
-				put_to_mempool(&rcommon_cmd_mempool, rcommq_ptr);
+				MTX_UNLOCK(&rcommq_ptr->rcommand_mtx);
+				clear_rcomm_cmd(rcommq_ptr);
 			} else {
 				rcommq_ptr->completed = true;
 				if (rcommq_ptr->acks_recvd < spec->consistency_factor) {
 					rcommq_ptr->status = -1;
 					signal_luworker();
 				}
+				MTX_UNLOCK(&rcommq_ptr->rcommand_mtx);
 			}
+		}
+		else {
+			MTX_UNLOCK(&rcommq_ptr->rcommand_mtx);
+			MTX_UNLOCK(&spec->rcommonq_mtx);
 		}
 	}
 }
@@ -427,10 +448,12 @@ remove_replica_from_list(spec_t *spec, int iofd) {
 			update_volstate(spec);
 			TAILQ_REMOVE(&spec->rq, replica, r_next);
 			close(replica->iofd);
+			break;
 		}
 	}
 	MTX_UNLOCK(&spec->rq_mtx);
-	REPLICA_LOG("%d IOs aborted for replica %d", ios_aborted, replica->id);
+	if (replica != NULL)
+		REPLICA_LOG("%d IOs aborted for replica %d", ios_aborted, replica->id);
 	return 0;
 }
 
@@ -469,10 +492,7 @@ read_data(int fd, uint8_t *data, uint64_t len, int *errorno, int *fd_closed) {
 			}
 		}
 		else if (rc == 0) {
-			REPLICA_ERRLOG("received EOF on fd %d, closing it..\n", fd);
-			close(fd);
-			if (fd_closed != NULL)
-				*fd_closed = 1;
+			REPLICA_ERRLOG("received EOF on fd %d..\n", fd);
 			break;
 		}
 		nbytes += rc;
@@ -531,7 +551,9 @@ handle_read_resp(spec_t *spec, replica_t *replica)
 			rep_cmd->ack_recvd = true;
 			TAILQ_REMOVE(&replica->read_waitq, rep_cmd, rread_cmd_next);
 			MTX_UNLOCK(&replica->r_mtx);
+			MTX_LOCK(&spec->rcommonq_mtx);
 			rcommq_ptr = rep_cmd->rcommq_ptr;
+			MTX_LOCK(&rcommq_ptr->rcommand_mtx);
 			rcommq_ptr->status = 1;
 			rcommq_ptr->data = data;
 			rcommq_ptr->data_len = io_rsp->len;
@@ -540,14 +562,15 @@ handle_read_resp(spec_t *spec, replica_t *replica)
 
 			signal_luworker();
 
-			MTX_LOCK(&spec->rcommonq_mtx);
 			TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next);
 			rcommq_ptr->state = CMD_EXECUTION_DONE;
 			if(rcommq_ptr->completed) {
+				MTX_UNLOCK(&rcommq_ptr->rcommand_mtx);
 				MTX_UNLOCK(&spec->rcommonq_mtx);
-				put_to_mempool(&rcommon_cmd_mempool, rcommq_ptr);
+				clear_rcomm_cmd(rcommq_ptr);
 			} else {
 				rcommq_ptr->completed = true;
+				MTX_UNLOCK(&rcommq_ptr->rcommand_mtx);
 				MTX_UNLOCK(&spec->rcommonq_mtx);
 			}
 			return 0;
@@ -563,27 +586,19 @@ handle_read_resp(spec_t *spec, replica_t *replica)
 
 #define handle_consistency_met() {\
 	rcommq_ptr->status = 1; \
-	MTX_LOCK(&spec->rcommonq_mtx); \
 	TAILQ_REMOVE(&spec->rcommon_waitq, rcommq_ptr, wait_cmd_next); \
 	if (rcommq_ptr->acks_recvd != rcommq_ptr->copies_sent) { \
 		rcommq_ptr->state = CMD_ENQUEUED_TO_PENDINGQ; \
 		TAILQ_INSERT_TAIL(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next); \
 	} else { \
-		for (i=1; i < rcommq_ptr->iovcnt + 1; i++) { \
-			xfree(rcommq_ptr->iov[i].iov_base); \
-		} \
 		rcommq_ptr->state = CMD_EXECUTION_DONE; \
 		rcommq_ptr->completed = true; \
 	} \
-	MTX_UNLOCK(&spec->rcommonq_mtx); \
+	MTX_UNLOCK(&rcommq_ptr->rcommand_mtx); \
 	signal_luworker(); \
 }
 
 #define handle_all_resp_recvd() { \
-	MTX_LOCK(&spec->rcommonq_mtx); \
-	for (i=1; i < rcommq_ptr->iovcnt + 1; i++) { \
-		xfree(rcommq_ptr->iov[i].iov_base); \
-	} \
 	if(rcommq_ptr->state == CMD_ENQUEUED_TO_PENDINGQ) { \
 		TAILQ_REMOVE(&spec->rcommon_pendingq, rcommq_ptr, pending_cmd_next); \
 	} else if(rcommq_ptr->state == CMD_ENQUEUED_TO_WAITQ) { \
@@ -591,7 +606,8 @@ handle_read_resp(spec_t *spec, replica_t *replica)
 	} \
 	rcommq_ptr->state = CMD_EXECUTION_DONE; \
 	if(rcommq_ptr->completed) { \
-		put_to_mempool(&rcommon_cmd_mempool, rcommq_ptr); \
+		MTX_UNLOCK(&rcommq_ptr->rcommand_mtx); \
+		clear_rcomm_cmd(rcommq_ptr); \
 		rcommq_ptr = NULL; \
 	} else { \
 		rcommq_ptr->completed = true; \
@@ -599,14 +615,14 @@ handle_read_resp(spec_t *spec, replica_t *replica)
 			rcommq_ptr->status = -1; \
 			signal_luworker(); \
 		} \
+		MTX_UNLOCK(&rcommq_ptr->rcommand_mtx); \
 	} \
-	MTX_UNLOCK(&spec->rcommonq_mtx); \
 }
 
 int
 handle_write_resp(spec_t *spec, replica_t *replica)
 {
-	int luworker_id, i;
+	int luworker_id;
 	rcmd_t *rep_cmd = NULL;
 	rcommon_cmd_t *rcommq_ptr;
 	zvol_io_hdr_t *io_rsp = replica->io_resp_hdr;
@@ -631,16 +647,20 @@ handle_write_resp(spec_t *spec, replica_t *replica)
 			if(rep_cmd->ack_recvd == true) {
 				replica->least_recvd++;
 				MTX_UNLOCK(&replica->r_mtx);
+				MTX_LOCK(&spec->rcommonq_mtx);
+				MTX_LOCK(&rcommq_ptr->rcommand_mtx);
 				rcommq_ptr->acks_recvd++;
 				luworker_id = rcommq_ptr->luworker_id;
 
-				rcommq_ptr->bitset &= ~(1 << replica->id);
 				if (rcommq_ptr->acks_recvd == spec->consistency_factor) {
 					handle_consistency_met();
 				} else if (rcommq_ptr->acks_recvd + rcommq_ptr->ios_aborted
 						== rcommq_ptr->copies_sent) {
 					handle_all_resp_recvd();
 				}
+				else
+					MTX_UNLOCK(&rcommq_ptr->rcommand_mtx);
+				MTX_UNLOCK(&spec->rcommonq_mtx);
 				MTX_LOCK(&replica->r_mtx);
 				TAILQ_REMOVE(&replica->waitq, rep_cmd, rwait_cmd_next);
 				put_to_mempool(&rcmd_mempool, rep_cmd);
@@ -693,9 +713,7 @@ replica_receiver(void *arg) {
 		event_count = epoll_wait(epfd, events, MAXEVENTS, -1);
 		for(i=0; i< event_count; i++) {
 			//Remove the replica from queue
-			if ((events[i].events & EPOLLERR) ||
-					(events[i].events & EPOLLHUP) ||
-					(!(events[i].events & EPOLLIN))) {
+			if (!(events[i].events & EPOLLIN)) {
 				remove_replica_from_list(spec, events[i].data.fd);
 				REPLICA_LOG("epoll error\n");
 				continue;
@@ -877,13 +895,6 @@ accept_mgmt_conns(int epfd, int sfd) {
 			REPLICA_LOG("Accepted connection on descriptor %d "
 					"(host=%s, port=%s)\n", mgmt_fd, hbuf, sbuf);
 		}
-		rc = make_socket_non_blocking(mgmt_fd);
-		if (rc == -1) {
-			REPLICA_ERRLOG("make_socket_non_blocking() failed on fd %d, errno:%d.. closing it..", mgmt_fd, errno);
-			close(mgmt_fd);
-			continue;
-		}
-
 		MTX_LOCK(&specq_mtx);
 		TAILQ_FOREACH(spec, &spec_q, spec_next) {
 			data_len = snprintf(buf, BUFSIZE, "%s", spec->lu->volname) + 1;
@@ -897,7 +908,12 @@ accept_mgmt_conns(int epfd, int sfd) {
 			close(mgmt_fd);
 			continue;
 		}
-
+		rc = make_socket_non_blocking(mgmt_fd);
+		if (rc == -1) {
+			REPLICA_ERRLOG("make_socket_non_blocking() failed on fd %d, errno:%d.. closing it..", mgmt_fd, errno);
+			close(mgmt_fd);
+			continue;
+		}
 		event.data.fd = mgmt_fd;
 		event.events = EPOLLIN | EPOLLHUP | EPOLLERR | EPOLLET;
 		rc = epoll_ctl(epfd, EPOLL_CTL_ADD, mgmt_fd, &event);

--- a/src/replication.c
+++ b/src/replication.c
@@ -172,6 +172,9 @@ dequeue_common_sendq:
 		//Enqueue to individual replica cmd queues and send on the respective fds
 		read_cmd_sent = false;
 		MTX_LOCK(&spec->rq_mtx);
+
+		//this lock is required to make sure copies_sent is incremented before processing the responses and exiting
+		MTX_LOCK(&cmd->rcommand_mtx);
 		TAILQ_FOREACH(replica, &spec->rq, r_next) {
 			if(replica == NULL) {
 				REPLICA_LOG("Replica not present");
@@ -208,6 +211,7 @@ dequeue_common_sendq:
 				break;
 			}
 		}
+		MTX_UNLOCK(&cmd->rcommand_mtx);
 		MTX_UNLOCK(&spec->rq_mtx);
 	}
 }

--- a/src/replication.h
+++ b/src/replication.h
@@ -74,7 +74,6 @@ typedef struct rcommon_cmd_s {
 	void *data;
 	uint64_t total;
 	int64_t iovcnt;
-	uint64_t bitset;
 	struct iovec iov[41];
 } rcommon_cmd_t;
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -58,6 +58,7 @@ typedef struct rcommon_cmd_s {
 	TAILQ_ENTRY(rcommon_cmd_s)  wait_cmd_next; /* for rcommon_waitq */
 	TAILQ_ENTRY(rcommon_cmd_s)  pending_cmd_next; /* for rcommon_pendingq */
 	int luworker_id;
+	pthread_mutex_t rcommand_mtx;
 	int acks_recvd;
 	int ios_aborted;
 	int copies_sent;
@@ -74,7 +75,7 @@ typedef struct rcommon_cmd_s {
 	uint64_t total;
 	int64_t iovcnt;
 	uint64_t bitset;
-	struct iovec iov[21];
+	struct iovec iov[41];
 } rcommon_cmd_t;
 
 typedef struct rcmd_s {
@@ -92,7 +93,7 @@ typedef struct rcmd_s {
 	int64_t iovcnt;
 	uint64_t offset;
 	uint64_t data_len;
-	struct iovec iov[21];
+	struct iovec iov[41];
 } rcmd_t;
 
 typedef enum zvol_op_status_e {
@@ -124,6 +125,7 @@ void accept_mgmt_conns(int, int);
 int send_io_resp(int fd, zvol_io_hdr_t *, void *);
 int initialize_replication_mempool(bool should_fail);
 int destroy_relication_mempool(void);
+void clear_rcomm_cmd(rcommon_cmd_t *);
 
 #define REPLICA_LOG(fmt, ...)  syslog(LOG_NOTICE, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_NOTICELOG(fmt, ...) syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -123,12 +123,12 @@ run_data_integrity_test() {
 	sleep 15
 	write_and_verify_data
 
-	sudo kill -9 $replica3_pid
+	sudo kill -9 $replica1_pid
 	sleep 5
 	write_and_verify_data
 
-	sudo $REPLICATION_TEST "$CONTROLLER_IP" "$CONTROLLER_PORT" "$replica3_ip" "$replica3_port" "/tmp/test_vol3" &
-	replica3_pid=$!
+	sudo $REPLICATION_TEST "$CONTROLLER_IP" "$CONTROLLER_PORT" "$replica1_ip" "$replica1_port" "/tmp/test_vol1" &
+	replica1_pid=$!
 	sleep 5
 	write_and_verify_data
 


### PR DESCRIPTION
1. rcommand_t is not thread safe.
For ex, 'acks_recvd' is counter in rcommand_t, which stores the number of replicas responded for this IO.
This gets updated in handle_write_resp which is in thread replica_receiver() that receives response from all replicas.
This gets accessed in 'remove_replica_from_list' which can get called from 'replica_receiver()' thread or 'replica_sender()' thread which sends requests to replicas.
Similarly, ios_aborted is another counter to store error responses. 'completed' is another variable.
Added a lock in rcommand_t structure. This lock will be taken whenever these variables are accessed in threads.
2. Also added change to cleanup read commands when a replica gets disconnected
3. Increased iovec to handle 40 data segments from client
4. Removed bitset to find pending command on a replica to check blockage, and started looking at replica's queues to check blockage
5. Updated testcase to kill first replication_test binary rather than third one