### PR TITLE
[cstor#131,132,159] using messages format from replica and honoring messages members

### DIFF
--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -33,8 +33,7 @@ typedef enum replica_state_s {
 /* to read handshake msg data */
 #define READ_IO_RESP_DATA	2
 
-typedef struct zvol_io_hdr_s zvol_io_hdr_t;
-typedef struct mgmt_ack_data_s mgmt_ack_data_t;
+typedef struct mgmt_ack mgmt_ack_data_t;
 
 typedef struct replica_s {
 	TAILQ_ENTRY(replica_s) r_next;
@@ -54,6 +53,8 @@ typedef struct replica_s {
 	int port;
 	char *ip;
 	uint64_t least_recvd;
+	uint64_t pool_guid;
+	uint64_t zvol_guid;
 	int cur_recvd;
 	uint64_t rrio_seq;
 	uint64_t wrio_seq;
@@ -67,6 +68,7 @@ typedef struct replica_s {
 	int mgmt_io_read; //amount of data read in current state
 	zvol_io_hdr_t *mgmt_ack;
 	mgmt_ack_data_t *mgmt_ack_data;
+	uint64_t initial_checkpointed_io_seq;
 } replica_t;
 
 typedef struct cstor_conn_ops {
@@ -88,11 +90,11 @@ int remove_replica_from_list(spec_t *, int);
 void unblock_blocked_cmds(replica_t *);
 
 replica_t *create_replica_entry(spec_t *, int);
-replica_t *update_replica_entry(spec_t *, replica_t *, int, char *, int);
+replica_t *update_replica_entry(spec_t *, replica_t *, int);
 
 replica_t * get_replica(int mgmt_fd, spec_t **);
 void handle_read_data_event(int fd);
 
 void update_volstate(spec_t *);
-void clear_replica_cmd(spec_t *, replica_t *, rcmd_t *);
+void clear_replica_cmd(spec_t *, rcmd_t *);
 #endif

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -896,6 +896,7 @@ typedef struct istgt_lu_disk_t {
 	uint8_t percent_count;
 	uint8_t percent_val[32];
 	uint8_t percent_latency[32];
+	uint64_t io_seq;
 
 	/* entry */
 	int (*open)(struct istgt_lu_disk_t *spec, int flags, int mode);

--- a/src/replication.h
+++ b/src/replication.h
@@ -12,6 +12,7 @@
 #include <sys/uio.h>
 #include <syslog.h>
 #include <stdbool.h>
+#include "zrepl_prot.h"
 #include "istgt_integration.h"
 #include "istgt_lu.h"
 
@@ -24,28 +25,10 @@
 #define MAXNAMELEN 256
 
 #define MAX(a,b) (((a)>(b))?(a):(b))
-
-typedef enum zvol_op_code_e {
-	ZVOL_OPCODE_HANDSHAKE = 1,
-	ZVOL_OPCODE_READ,
-	ZVOL_OPCODE_WRITE,
-	ZVOL_OPCODE_UNMAP,
-	ZVOL_OPCODE_SYNC,
-	ZVOL_OPCODE_SNAP_CREATE,
-	ZVOL_OPCODE_SNAP_ROLLBACK,
-} zvol_op_code_t;
-
 typedef enum zvol_cmd_type_e {
 	CMD_IO = 1,
 	CND_MGMT,
 } zvol_cmd_type_t;
-
-typedef struct mgmt_ack_data_s {
-	char volname[MAXNAMELEN];
-	char ip[MAXIPLEN];
-	int port;
-} mgmt_ack_data_t;
-
 typedef enum cmd_state_s {
 	CMD_CREATED = 1,
 	CMD_ENQUEUED_TO_WAITQ,
@@ -94,21 +77,6 @@ typedef struct rcmd_s {
 	uint64_t data_len;
 	struct iovec iov[41];
 } rcmd_t;
-
-typedef enum zvol_op_status_e {
-	ZVOL_OP_STATUS_OK = 1,
-	ZVOL_OP_STATUS_FAILED,
-} zvol_op_status_t;
-
-typedef struct zvol_io_hdr_s {
-	zvol_op_code_t opcode;
-	uint64_t io_seq;
-	uint64_t offset;
-	uint64_t len;
-	rcmd_t *q_ptr;
-	zvol_op_status_t status;
-} zvol_io_hdr_t;
-
 typedef struct replica_s replica_t;
 typedef struct istgt_lu_disk_t spec_t;
 

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -19,7 +19,10 @@ __thread char  tinfo[20] =  {0};
 #define build_mgmt_ack_hdr {\
 	mgmt_ack_hdr = (zvol_io_hdr_t *)malloc(sizeof(zvol_io_hdr_t));\
 	mgmt_ack_hdr->opcode = opcode;\
+	mgmt_ack_hdr->version = REPLICA_VERSION;\
 	mgmt_ack_hdr->len = sizeof(mgmt_ack_data_t);\
+	mgmt_ack_hdr->status = ZVOL_OP_STATUS_OK;\
+	mgmt_ack_hdr->checkpointed_io_seq = 1000;\
 }
 
 #define build_mgmt_ack_data {\
@@ -27,6 +30,8 @@ __thread char  tinfo[20] =  {0};
 	strcpy(mgmt_ack_data->ip, replicaip);\
 	strcpy(mgmt_ack_data->volname, buf);\
 	mgmt_ack_data->port = replica_port;\
+	mgmt_ack_data->pool_guid = 100;\
+	mgmt_ack_data->zvol_guid = 500;\
 }
 
 int64_t test_read_data(int fd, uint8_t *data, uint64_t len);
@@ -111,15 +116,26 @@ int
 send_io_resp(int fd, zvol_io_hdr_t *io_hdr, void *buf)
 {
 	struct iovec iovec[2];
+	struct zvol_io_rw_hdr io_rw_hdr;
 	int iovcnt, i, nbytes = 0;
 	int rc = 0;
+	io_hdr->status = ZVOL_OP_STATUS_OK;
 	if(io_hdr->opcode == ZVOL_OPCODE_READ) {
-		iovcnt = 2;
+		iovcnt = 3;
+		io_rw_hdr.io_num = 2000;
+		io_rw_hdr.len = io_hdr->len;
 		iovec[0].iov_base = io_hdr;
 		nbytes = iovec[0].iov_len = sizeof(zvol_io_hdr_t);
-		iovec[1].iov_base = buf;
-		iovec[1].iov_len = io_hdr->len;
+		iovec[1].iov_base = &io_rw_hdr;
+		iovec[1].iov_len = sizeof(struct zvol_io_rw_hdr);
+		iovec[2].iov_base = buf;
+		iovec[2].iov_len = io_hdr->len;
+		io_hdr->len += (sizeof(struct zvol_io_rw_hdr));
 		nbytes += io_hdr->len;
+	} else if(io_hdr->opcode == ZVOL_OPCODE_WRITE) {
+		iovcnt = 1;
+		iovec[0].iov_base = io_hdr;
+		nbytes = iovec[0].iov_len = sizeof(zvol_io_hdr_t);
 	} else {
 		iovcnt = 1;
 		iovec[0].iov_base = io_hdr;
@@ -161,6 +177,11 @@ main(int argc, char **argv)
 	char *replicaip = argv[3];
 	int replica_port = atoi(argv[4]);
 	char *test_vol = argv[5];
+	int sleeptime = 0;
+	struct zvol_io_rw_hdr *io_rw_hdr;
+
+	if (argv[6] != NULL)
+		sleeptime = atoi(argv[6]);
 	int iofd, mgmtfd, sfd, rc, epfd, event_count, i;
 	int64_t count;
 	struct epoll_event event, *events;
@@ -333,7 +354,9 @@ main(int argc, char **argv)
 					}
 execute_io:
 					if(io_hdr->opcode == ZVOL_OPCODE_WRITE) {
-						while((rc = pwrite(vol_fd, data + nbytes, io_hdr->len - nbytes, io_hdr->offset + nbytes))) {
+						io_rw_hdr = (struct zvol_io_rw_hdr *)data;
+						data += sizeof(struct zvol_io_rw_hdr);
+						while((rc = pwrite(vol_fd, data + nbytes, io_rw_hdr->len - nbytes, io_hdr->offset + nbytes))) {
 							if(rc == -1 ) {
 								if(errno == 11) {
 									sleep(1);
@@ -342,10 +365,12 @@ execute_io:
 								break;
 							}
 							nbytes += rc;
-							if(nbytes == io_hdr->len) {
+							if(nbytes == io_rw_hdr->len) {
 								break;
 							}
 						}
+						data -= sizeof(struct zvol_io_rw_hdr);
+						usleep(sleeptime);
 					} else if(io_hdr->opcode == ZVOL_OPCODE_READ) {
 						if(io_hdr->len) {
 							data = malloc(io_hdr->len);
@@ -366,6 +391,7 @@ execute_io:
 						}
 					}
 					send_io_resp(iofd, io_hdr, data);
+					free(data);
 				}
 			}
 		}

--- a/src/zrepl_prot.h
+++ b/src/zrepl_prot.h
@@ -1,0 +1,126 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2018 Cloudbyte. All rights reserved.
+ */
+
+#ifndef	ZREPL_PROT_H
+#define	ZREPL_PROT_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/*
+ * Over the wire spec for replica protocol.
+ *
+ * We don't expect replica protocol to be used between nodes with different
+ * architecture nevertheless we try to be precise in defining size of members
+ * and all number values are supposed to be little endian.
+ *
+ * Version can be negotiated on mgmt conn. Target sends handshake message with
+ * version number. If replica does not support the version, then it replies
+ * with "version mismatch" error, puts supported version in version field
+ * and closes the connection.
+ */
+
+#define	REPLICA_VERSION	1
+#define	MAX_NAME_LEN	256
+#define	MAX_IP_LEN	64
+#define	TARGET_PORT	6060
+
+enum zvol_op_code {
+	ZVOL_OPCODE_HANDSHAKE = 0,
+	ZVOL_OPCODE_READ,
+	ZVOL_OPCODE_WRITE,
+	ZVOL_OPCODE_UNMAP,
+	ZVOL_OPCODE_SYNC,
+	ZVOL_OPCODE_SNAP_CREATE,
+	ZVOL_OPCODE_SNAP_ROLLBACK,
+} __attribute__((packed));
+
+typedef enum zvol_op_code zvol_op_code_t;
+
+enum zvol_op_status {
+	ZVOL_OP_STATUS_OK = 0,
+	ZVOL_OP_STATUS_FAILED,
+	ZVOL_OP_STATUS_VERSION_MISMATCH,
+} __attribute__((packed));
+
+typedef enum zvol_op_status zvol_op_status_t;
+
+/*
+ * Future protocol versions need to respect that the first field must be
+ * 2-byte version number. The rest of struct is version dependent.
+ */
+struct zvol_io_hdr {
+	uint16_t	version;
+	zvol_op_code_t	opcode;
+	uint64_t	io_seq;
+	/* only used for read/write */
+	uint64_t	offset;
+	/*
+	 * Length of data in payload.
+	 * (for read/write that includes size of io headers with meta data).
+	 */
+	uint64_t	len;
+	uint64_t	checkpointed_io_seq;
+	uint8_t 	flags;
+	zvol_op_status_t status;
+} __attribute__((packed));
+
+typedef struct zvol_io_hdr zvol_io_hdr_t;
+
+/*
+ * Payload data send in response to handshake on control connection. It tells
+ * IP, port where replica listens for data connection to zvol.
+ */
+struct mgmt_ack {
+	uint64_t pool_guid;
+	uint64_t zvol_guid;
+	uint16_t port;
+	char	ip[MAX_IP_LEN];
+	char	volname[MAX_NAME_LEN];
+} __attribute__((packed));
+
+typedef struct mgmt_ack mgmt_ack_t;
+
+/*
+ * Describes chunk of data following this header.
+ *
+ * The length in zvol_io_hdr designates the length of the whole payload
+ * including other headers in the payload itself. The length in this
+ * header designates the lenght of data chunk following this header.
+ *
+ * ---------------------------------------------------------------------
+ * | zvol_io_hdr | zvol_io_rw_hdr | .. data .. | zvol_io_rw_hdr | .. data ..
+ * ---------------------------------------------------------------------
+ */
+struct zvol_io_rw_hdr {
+	uint64_t	io_num;
+	uint64_t	len;
+} __attribute__((packed));
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
target and replicas need to follow same message format between them for their communication.
This PR makes sure that target is following the format updated in replica code. Over all, this PR addresses:
- handshake message format from replica
- read IO response format from replica
- write IO request format from replica
- ignoring 'len' in write IO response header
- considering 'status' flag in IO responses to mark it as success/failure
- 'pool_guid', 'zvol_guid' are stored in replica
- 'checkpointed_io_num' from handshake to calculate next IO seq number
- updated testcases to follow this format
- created issue#161 to handle non-responsive and erroring-out replicas
istgt was ordering write IOs, but, its not required. So, removed the code that does this re-ordering.
Fixed a 'mege' issue that happened with previous checkins where 'ios_aborted' was getting incremented at multiple places.