### PR TITLE
DE18 : marking replica as down in target

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -40,7 +40,7 @@ source   = istgt.c istgt_iscsi.c istgt_iscsi_param.c \
 	istgt_lu_ctl.c \
 	istgt_log.c istgt_conf.c istgt_sock.c istgt_misc.c \
 	istgt_queue.c istgt_crc32c.c istgt_md5.c replication.c replication_misc.c \
-	ring_mempool.c rte_ring.c
+	ring_mempool.c rte_ring.c data_conn.c
 header   = istgt_ver.h istgt.h istgt_iscsi.h istgt_iscsi_xcopy.h istgt_iscsi_param.h \
 	istgt_scsi.h istgt_proto.h istgt_lu.h \
 	istgt_log.h istgt_conf.h istgt_sock.h \

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -120,7 +120,7 @@ inform_mgmt_conn(replica_t *r)
 {
 	uint64_t num = 1;
 	r->disconnect_conn = 1;
-	write(r->mgmt_eventfd1, &num, sizeof (num));
+	(void) write(r->mgmt_eventfd1, &num, sizeof (num));
 }
 
 static rcmd_t *

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -120,7 +120,8 @@ inform_mgmt_conn(replica_t *r)
 {
 	uint64_t num = 1;
 	r->disconnect_conn = 1;
-	(void) write(r->mgmt_eventfd1, &num, sizeof (num));
+	if (write(r->mgmt_eventfd1, &num, sizeof (num)) != sizeof (num))
+		REPLICA_NOTICELOG("Failed report err to mgmt_conn for replica(%p)\n", r);
 }
 
 static rcmd_t *

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -1,0 +1,654 @@
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/prctl.h>
+#include <stdbool.h>
+#include "istgt.h"
+#include "zrepl_prot.h"
+#include "istgt_integration.h"
+#include "replication.h"
+#include "ring_mempool.h"
+
+#define	READ_PARTIAL	1
+#define	READ_COMPLETED	2
+
+#define	WRITE_PARTIAL	1
+#define	WRITE_COMPLETED	2
+
+extern rte_smempool_t rcmd_mempool;
+
+bool unblock_cmds(replica_t *r);
+void move_to_blocked_or_ready_q(replica_t *r, rcmd_t *cmd);
+void respond_with_error_for_all_outstanding_ios(replica_t *r);
+int handle_data_conn_error(replica_t *r);
+int handle_epoll_out_event(replica_t *r);
+static ssize_t perform_read_on_fd(int fd, uint8_t *data, uint64_t len);
+rcmd_t * find_replica_cmd(replica_t *r, uint64_t ioseq);
+int read_cmd(replica_t *r);
+int write_cmd(int fd, rcmd_t *cmd);
+int handle_data_eventfd(void *arg);
+int do_drainfd(int data_eventfd);
+int handle_epoll_in_event(replica_t *r);
+void *replica_thread(void *arg);
+
+#if 0
+	parsed = 0;
+	data_node = TAILQ_FIRST(&cmd->data_list);
+	while (data_node != NULL) {
+		next_node = TAILQ_NEXT(data_node);
+		ret = write_data_segment(data_node, parsed, written);
+		if (ret == WRITE_COMPLETED) {
+			data_node = next_node;
+			continue;
+		}
+		else
+			break;
+	}
+}
+
+write_status_t
+write_data_segment(data_node, parsed, written)
+{
+	len = data_node->len;
+	if ((parsed + len) <= written) {
+		parsed += len;
+		data_node = next_node;
+		continue;
+	}
+	offset_to_write = (written - parsed);
+	len_to_write = (parsed + len - written);
+	rc = write(data_node->data_ptr, offset_to_write, len_to_write);
+}
+#endif
+
+#define check_for_blockage() { \
+	uint64_t current_lba = cmd->offset; \
+	uint64_t current_lbE = current_lba + cmd->data_len; \
+	uint64_t pending_lba = pending_rcmd->offset; \
+	uint64_t pending_lbE = pending_lba + pending_rcmd->data_len; \
+	if ((current_lbE < pending_lba)  || (pending_lbE < current_lba)) { \
+		cmd_blocked = false; \
+	} else { \
+		cmd_blocked = true; \
+	} \
+}
+
+#define CHECK_BLOCKAGE_IN_Q(queue, next) { \
+	if(cmd_blocked == false) { \
+		TAILQ_FOREACH(pending_rcmd, queue, next) { \
+			check_for_blockage(); \
+			if(cmd_blocked == true) \
+				break; \
+		} \
+	} \
+}
+
+#define SEND_ERROR_RESPONSES(head) { \
+	cmd = TAILQ_FIRST(head); \
+	while (cmd != NULL) { \
+		next_cmd = TAILQ_NEXT(cmd, next); \
+		TAILQ_REMOVE(head, cmd, next); \
+		idx = cmd->idx; \
+		rcomm_cmd = cmd->rcommq_ptr; \
+		rcomm_cmd->resp_list[idx].io_resp_hdr.status = ZVOL_OP_STATUS_FAILED; \
+		rcomm_cmd->resp_list[idx].data_ptr = NULL; \
+		rcomm_cmd->resp_list[idx].data_len = 0; \
+		mtx = rcomm_cmd->mutex;			\
+		cond_var = rcomm_cmd->cond_var;		\
+		rcomm_cmd->resp_list[idx].status = -1; \
+		MTX_LOCK(mtx); \
+		pthread_cond_signal(cond_var); \
+		MTX_UNLOCK(mtx); \
+		cmd = next_cmd; \
+	} \
+}
+
+bool
+unblock_cmds(replica_t *r)
+{
+	bool cmd_blocked = false;
+	rcmd_t *pending_rcmd, *cmd, *next_cmd;
+	bool unblocked = false;
+
+	for (cmd = TAILQ_FIRST(&r->blockedq); cmd; cmd = next_cmd) {
+		next_cmd = TAILQ_NEXT(cmd, next);
+		cmd_blocked = false;
+		CHECK_BLOCKAGE_IN_Q(&r->readyq, next);
+		if (cmd_blocked == true)
+			continue;
+		CHECK_BLOCKAGE_IN_Q(&r->waitq, next);
+		if (cmd_blocked == true)
+			continue;
+		TAILQ_REMOVE(&r->blockedq, cmd, next);
+		TAILQ_INSERT_TAIL(&r->readyq, cmd, next);
+		unblocked = true;
+	}
+	return unblocked;
+}
+
+void
+move_to_blocked_or_ready_q(replica_t *r, rcmd_t *cmd)
+{
+	bool cmd_blocked = false;
+	rcmd_t *pending_rcmd;
+
+	if (!TAILQ_EMPTY(&r->blockedq)) {
+		TAILQ_INSERT_TAIL(&r->blockedq, cmd, next);
+		goto done;
+	}
+	CHECK_BLOCKAGE_IN_Q(&r->readyq, next);
+	CHECK_BLOCKAGE_IN_Q(&r->waitq, next);
+	if (cmd_blocked == true)
+		TAILQ_INSERT_TAIL(&r->blockedq, cmd, next);
+	else
+		TAILQ_INSERT_TAIL(&r->readyq, cmd, next);
+done:
+	return;
+}
+
+#if 0
+void
+inform_mgmt_conn(replica_t *r)
+{
+	uint64_t num = 10;
+
+	zvol_io_hdr_t *cmd;
+	cmd->opcode = DESTROY;
+	add_to_linked_list(&r->mgmt_cmd_list, cmd);
+	write(r->mgmt_event_fd, &num, sizeof (num));
+}
+#endif
+
+void *
+dequeue_replica_cmdq(replica_t *replica)
+{
+	unsigned count = 0;
+
+	count = get_num_entries_from_mempool(&(replica->cmdq));
+	if (count)
+		return get_from_mempool(&(replica->cmdq));
+	else
+		return NULL;
+}
+
+void
+respond_with_error_for_all_outstanding_ios(replica_t *r)
+{
+	rcmd_t *cmd, *next_cmd;
+	int idx;
+	rcommon_cmd_t *rcomm_cmd;
+	pthread_mutex_t *mtx;
+	pthread_cond_t *cond_var;
+
+	while ((cmd = dequeue_replica_cmdq(r) != NULL))
+		move_to_blocked_or_ready_q(r, cmd);
+
+	SEND_ERROR_RESPONSES((&(r->waitq)));
+	SEND_ERROR_RESPONSES((&(r->readyq)));
+	SEND_ERROR_RESPONSES((&(r->blockedq)));
+}
+
+/*
+ * TODO:
+ * need spec lock to update replica vars also
+ */
+int
+handle_data_conn_error(replica_t *r)
+{
+	int fd, data_eventfd, mgmt_eventfd, epollfd;
+	spec_t *spec;
+
+	MTX_LOCK(&r->spec->rq_mtx);
+	spec = r->spec;
+	TAILQ_REMOVE(&spec->rq, r, r_next);
+
+	if (r->state == ZVOL_STATUS_HEALTHY)
+		spec->healthy_rcount--;
+	else if (r->state == ZVOL_STATUS_DEGRADED)
+		spec->degraded_rcount--;
+
+	update_volstate(r->spec);
+	MTX_UNLOCK(&spec->rq_mtx);
+
+	if (epoll_ctl(r->epollfd, EPOLL_CTL_DEL, r->iofd, NULL) == -1) {
+		perror("epoll_ctl");
+		return -1;
+	}
+
+	fd = r->iofd;
+	r->iofd = 0;
+
+        if (r->io_resp_hdr)
+                free(r->io_resp_hdr);
+        if (r->ongoing_io_buf)
+                free(r->ongoing_io_buf);
+
+	close(fd);
+
+	data_eventfd = r->data_eventfd;
+	r->data_eventfd = 0;
+	close(data_eventfd);
+
+	respond_with_error_for_all_outstanding_ios(r);
+
+#if 0
+	MTX_LOCK(&r->conn_lock);
+	r->conn_closed++;
+	if (r->conn_closed != 2) {
+		inform_mgmt_conn(r);
+		pthread_mutex_wait(&r->cv, &r->conn_lock);
+	}
+	else
+	/*
+	 * no one else should signal this cv other than replica thread,
+	 * and mgmt_conn thread
+	 */
+		pthread_signal(&r->cv);
+	MTX_UNLOCK(&r->conn_lock);
+#endif
+
+	mgmt_eventfd = r->mgmt_eventfd;
+	r->mgmt_eventfd = 0;
+	close(mgmt_eventfd);
+
+	epollfd = r->epollfd;
+	r->epollfd = 0;
+	close(epollfd);
+	return 0;
+}
+
+int
+handle_epoll_out_event(replica_t *r)
+{
+	rcmd_t *cmd;
+	int ret;
+
+	while ((cmd = TAILQ_FIRST(&r->readyq)) != NULL) {
+		ret = write_cmd(r->iofd, cmd);
+		if (ret < 0)
+			return -1;
+		if (ret == WRITE_COMPLETED) {
+			TAILQ_REMOVE(&r->readyq, cmd, next);
+			TAILQ_INSERT_TAIL(&r->waitq, cmd, next);
+			continue;
+		}
+		else {
+			//ASSERT(ret == WRITE_PARTIAL); TODO
+			break;
+		}
+	}
+	return 0;
+}
+
+static ssize_t
+perform_read_on_fd(int fd, uint8_t *data, uint64_t len)
+{
+	ssize_t rc, nbytes = 0;
+
+	while(1) {
+		rc = read(fd, data + nbytes, len - nbytes);
+
+		if(rc < 0) {
+			if (errno == EINTR)
+				continue;
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				return nbytes;
+			return -1;
+		} else if (rc == 0) {
+			REPLICA_ERRLOG("received EOF on fd %d, closing it..\n", fd);
+			/* Return -1 here as entire data is not read, and, connection got closed */
+			return -1;
+		}
+
+		nbytes += rc;
+		if(nbytes == (ssize_t )len)
+			break;
+	}
+	return nbytes;
+}
+
+rcmd_t *
+find_replica_cmd(replica_t *r, uint64_t ioseq)
+{
+	rcmd_t *cmd;
+
+	TAILQ_FOREACH(cmd, &(r->waitq), next) {
+		if (cmd->io_seq == ioseq)
+			return cmd;
+	}
+
+	return NULL;
+}
+
+/*
+ * TODO:
+ * ongoing_io
+ * ongoing_io_len, and ongoing_io_buf
+ */
+int
+read_cmd(replica_t *r)
+{
+	int fd = r->iofd;
+	int state = r->io_state;
+	zvol_io_hdr_t *resp_hdr = r->io_resp_hdr;
+	uint8_t *resp_data = NULL;
+	uint64_t reqlen;
+	ssize_t count;
+	rcmd_t *cmd;
+
+	switch(state) {
+		case READ_IO_RESP_HDR:
+			reqlen = sizeof (zvol_io_hdr_t) - (r->io_read);
+			count = perform_read_on_fd(fd, ((uint8_t *)resp_hdr) + (r->io_read), reqlen);
+			if (count == -1)
+				return -1;
+
+			r->io_read += count;
+			if (count != (ssize_t)reqlen)
+				return READ_PARTIAL;
+
+			if (resp_hdr->status != ZVOL_OP_STATUS_OK)
+				return -1;
+
+			cmd = find_replica_cmd(r, resp_hdr->io_seq);
+			if (cmd == NULL)
+				return -1;
+
+			r->ongoing_io = cmd;
+
+			r->io_state = READ_IO_RESP_DATA;
+			r->io_read = 0;
+			if ((resp_hdr->len == 0) || (resp_hdr->opcode == ZVOL_OPCODE_WRITE)) {
+				r->ongoing_io_len = 0;
+				r->ongoing_io_buf = NULL;
+			}
+			else {
+				r->ongoing_io_len = resp_hdr->len;
+				r->ongoing_io_buf = malloc(resp_hdr->len);
+			}
+			/* Fall through */
+		case READ_IO_RESP_DATA:
+			reqlen = r->ongoing_io_len - (r->io_read);
+			resp_data = r->ongoing_io_buf;
+			if (reqlen != 0) {
+				count = perform_read_on_fd(fd, ((uint8_t *)(resp_data)) + (r->io_read),
+				    reqlen);
+
+				if (count == -1)
+					return -1;
+				r->io_read += count;
+				if (count != (ssize_t)reqlen)
+					return READ_PARTIAL;
+			}
+			return READ_COMPLETED;
+	}
+	return -1;
+}
+
+int
+write_cmd(int fd, rcmd_t *cmd)
+{
+	ssize_t rc;
+	int err, i;
+
+start:
+	rc = writev(fd, cmd->iov, cmd->iovcnt);
+	err = errno;
+	if (rc < 0) {
+		if (err == EINTR)
+			goto start;
+		if ((err != EAGAIN) && (err != EWOULDBLOCK))
+			return -1;
+		return WRITE_PARTIAL;
+	}
+
+	for (i = 0; i < cmd->iovcnt; i++) {
+		if (cmd->iov[i].iov_len != 0 && cmd->iov[i].iov_len > (size_t)rc) {
+			cmd->iov[i].iov_base = (void *)(((uint8_t *)cmd->iov[i].iov_base) + rc);
+			cmd->iov[i].iov_len -= rc;
+			break;
+		}
+		else {
+			rc -= cmd->iov[i].iov_len;
+			cmd->iov[i].iov_len = 0;
+		}
+	}
+
+	if (i == cmd->iovcnt)
+		return WRITE_COMPLETED;
+
+	/* This is the case where
+	 * - writev wrote less
+	 * - there is more data to write
+	 * - and writev can write more */
+	goto start;
+}
+
+#if 0
+		if (is_destroy_cmd(cmd)) {
+			//handle_data_conn_error(r);
+			return -1;
+		}
+#endif
+
+/*
+ * TODO:
+ * dequeue_replica_cmdq
+ * lockless cmdq in replica
+ * blockedq, readyq, waitq
+ */
+int
+handle_data_eventfd(void *arg)
+{
+	replica_t *r = (replica_t *)arg;
+	rcmd_t *cmd;
+	int ret;
+
+	while ((cmd = dequeue_replica_cmdq(r)) != NULL)
+		move_to_blocked_or_ready_q(r, cmd);
+	ret = handle_epoll_out_event(r);
+	return ret;
+}
+
+int
+do_drainfd(int data_eventfd)
+{
+	uint64_t value;
+	int rc, err;
+	while (1) {
+		rc = read(data_eventfd, &value, sizeof (value));
+		err = errno;
+		if (rc < 0) {
+			if (err == EINTR)
+				continue;
+			if (err != EAGAIN && err != EWOULDBLOCK)
+				return -1;
+			break;
+		}
+		if (rc == 0) {
+			//TODO chk whether rc is 0 means EOF on fd
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/*
+ * TODO:
+ * idx in rcmd
+ * mutex, cond_var in rcommon_cmd_t
+ * resp_list[].io_resp_hdr, data_ptr, data_len, status in rcommon_cmd_t
+ */
+int
+handle_epoll_in_event(replica_t *r)
+{
+	int ret, idx;
+	rcommon_cmd_t *rcomm_cmd;
+	bool task_completed = false;
+	bool unblocked = false;
+	pthread_mutex_t *mtx;
+	pthread_cond_t *cond_var;
+
+start:
+	ret = read_cmd(r);
+	if (ret < 0)
+		return -1;
+
+	if (ret == READ_COMPLETED) {
+		idx = r->ongoing_io->idx;
+		TAILQ_REMOVE(&r->waitq, r->ongoing_io, next);
+		rcomm_cmd = r->ongoing_io->rcommq_ptr;
+
+		mtx = rcomm_cmd->mutex;
+		cond_var = rcomm_cmd->cond_var;
+
+		rcomm_cmd->resp_list[idx].io_resp_hdr = *(r->io_resp_hdr);
+		rcomm_cmd->resp_list[idx].data_ptr = r->ongoing_io_buf;
+		if (rcomm_cmd->opcode == ZVOL_OPCODE_WRITE)
+			rcomm_cmd->resp_list[idx].data_len = rcomm_cmd->data_len;
+		else
+			rcomm_cmd->resp_list[idx].data_len = r->ongoing_io_len;
+		rcomm_cmd->resp_list[idx].status = 1;
+
+		if (rcomm_cmd->opcode == ZVOL_OPCODE_WRITE)
+			REPLICA_ERRLOG("%p : rcomm:%p resp recv for write : i:%d st(%d)\n", r, rcomm_cmd, idx, rcomm_cmd->status);
+
+		MTX_LOCK(mtx);
+		if (rcomm_cmd->status != 5) {
+			pthread_cond_signal(cond_var);
+		}
+		MTX_UNLOCK(mtx);
+
+		free(r->ongoing_io->iov_data);
+		put_to_mempool(&rcmd_mempool, r->ongoing_io);
+		r->ongoing_io = NULL;
+		r->io_read = 0;
+		r->ongoing_io_buf = NULL;
+		r->io_state = READ_IO_RESP_HDR;
+
+		task_completed = true;
+		goto start;
+	}
+	else {
+		//ASSERT(ret == READ_PARTIAL);
+		//break;
+	}
+
+	ret = 0;
+	if (task_completed == true) {
+		unblocked = unblock_cmds(r);
+		if (unblocked == true)
+			ret = handle_epoll_out_event(r);
+	}
+
+	return ret;
+}
+
+/*
+ * TODO:
+ * added data_eventfd, mgmt_eventfd, epollfd to replica
+ */
+#define	MAX_EVENTS	64
+void *
+replica_thread(void *arg)
+{
+	int r_data_eventfd, r_mgmt_eventfd, r_epollfd;
+	struct epoll_event ev, events[MAX_EVENTS];
+	int i, nfds, fd, ret = 0;
+	void *ptr;
+	replica_t *r = (replica_t *)arg;
+
+	r->data_eventfd = r_data_eventfd = eventfd(0, EFD_NONBLOCK);
+	if (r_data_eventfd < 0) {
+		perror("r_data_eventfd");
+		return NULL;
+	}
+
+	r->mgmt_eventfd = r_mgmt_eventfd = eventfd(0, EFD_NONBLOCK);
+	if (r_mgmt_eventfd < 0) {
+		perror("r_mgmt_eventfd");
+		return NULL;
+	}
+
+	r->epollfd = r_epollfd = epoll_create1(0);
+	if (r_epollfd < 0) {
+		perror("epoll_create");
+		return NULL;
+	}
+
+	ev.events = EPOLLIN;
+	ev.data.fd = r_data_eventfd;
+	if (epoll_ctl(r_epollfd, EPOLL_CTL_ADD, r_data_eventfd, &ev) == -1) {
+		perror("epoll_ctl_data_eventfd");
+		return NULL;
+	}
+
+	ev.data.fd = r_mgmt_eventfd;
+	if (epoll_ctl(r_epollfd, EPOLL_CTL_ADD, r_mgmt_eventfd, &ev) == -1) {
+		perror("epoll_ctl_mgmt_eventfd");
+		return NULL;
+	}
+
+	ev.events = EPOLLIN | EPOLLOUT | EPOLLHUP | EPOLLERR | EPOLLET | EPOLLRDHUP;
+	ev.data.ptr = NULL;
+	if (epoll_ctl(r_epollfd, EPOLL_CTL_ADD, r->iofd, &ev) == -1) {
+		perror("epoll_ctl_data_eventfd");
+		return NULL;
+	}
+
+	prctl(PR_SET_NAME, "replica", 0, 0, 0);
+
+	while (1) {
+		nfds = epoll_wait(r_epollfd, events, MAX_EVENTS, -1);
+		if (nfds == -1) {
+			if (errno == EINTR)
+				continue;
+			perror("epoll_wait");
+			ret = -1;
+			goto exit;
+		}
+		for (i = 0; i < nfds; i++) {
+			fd = events[i].data.fd;
+			if ((fd == r_data_eventfd) || (fd == r_mgmt_eventfd)) {
+				ret = do_drainfd(fd);
+				if (ret == -1)
+					goto exit;
+				if (fd == r_data_eventfd)
+					ret = handle_data_eventfd(arg);
+				//else
+					//ret = handle_mgmt_eventfd(arg);
+				if (ret == -1)
+					goto exit;
+				continue;
+			}
+
+			ret = -1;
+			ptr = events[i].data.ptr;
+			if (ptr != NULL)
+				goto exit;
+
+			if (events[i].events & (EPOLLERR | EPOLLRDHUP | EPOLLHUP))
+				goto exit;
+
+			ret = 0;
+			if (events[i].events & EPOLLIN)
+				ret = handle_epoll_in_event(arg);
+
+			if (ret == -1)
+				goto exit;
+
+			if (events[i].events & EPOLLOUT)
+				ret = handle_epoll_out_event(arg);
+
+			if (ret == -1)
+				goto exit;
+		}
+		/* Need to handle wait IOs that are taking more than IO timeout */
+		// handle_data_conn_error(r);
+		// return -1;
+	}
+exit:
+	if (ret == -1)
+		handle_data_conn_error(r);
+	return NULL;
+}
+

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -1,15 +1,13 @@
+#ifndef _ISTGT_INTEGRATION_H
+#define	_ISTGT_INTEGRATION_H
 
-#ifndef ISCSI
-#define ISCSI 1
+#include <stdbool.h>
 #include "istgt_lu.h"
 #include "istgt_sock.h"
-#include <stdbool.h>
 #include "ring_mempool.h"
 
 typedef int (*cstor_listen)(const char *, int, int);
 typedef int (*cstor_connect)(const char *, int);
-typedef void (*cstor_read)(void *, void *, void *, void *, uint64_t);
-typedef void (*cstor_close)(void *, void *, void *, void *, uint64_t);
 
 TAILQ_HEAD(, istgt_lu_disk_t) spec_q;
 pthread_mutex_t specq_mtx;
@@ -36,46 +34,36 @@ typedef struct replica_s {
 	TAILQ_ENTRY(replica_s) r_waitnext;
 	rte_smempool_t cmdq;	/* list of IOs queued from spec to replica */
 	TAILQ_HEAD(, rcmd_s) readyq;	/* list of IOs (non-blocking IOs) ready to sent to replica */
-	TAILQ_HEAD(, rcmd_s) sendq;
 	TAILQ_HEAD(, rcmd_s) waitq;
 	TAILQ_HEAD(, rcmd_s) blockedq;
-	TAILQ_HEAD(, rcmd_s) read_waitq;
 	pthread_cond_t r_cond;
 	pthread_mutex_t r_mtx;
 	replica_state_t state;
 	spec_t *spec;
-	int id;
 	int iofd;
 	int mgmt_fd;
-	int sender_epfd;
-	int io_efd;	/* epoll fd for managing data connection */
 	int port;
 	char *ip;
-	uint64_t least_recvd;
 	uint64_t pool_guid;
 	uint64_t zvol_guid;
-	int cur_recvd;
-	uint64_t rrio_seq;
-	uint64_t wrio_seq;
 
 	void *ongoing_io_buf;	// data received from replica
 	uint64_t ongoing_io_len;	// number of bytes received from replica
 	rcmd_t *ongoing_io;		// cmd for which we are receiving response
-	int mgmt_eventfd;
+	void *m_event1;
 	int mgmt_eventfd1;
+	void *m_event2;
 	int mgmt_eventfd2;
 	int disconnect_conn;
 	int conn_closed;
 	int epollfd;
 	int data_eventfd;
-	int eventfd;	/* eventfd for cmd notification from spec */
 	int epfd;
+	int dont_free;
 
 	zvol_io_hdr_t *io_resp_hdr;	// header recieved on data connection
-	void *io_resp_data;		// data recieved on data connection
 	int io_state;			// state of command on data connection
 	int io_read;			// amount of IO data read in current IO state for data connection
-	bool removed;			// If replica is removed from spec queue or not
 	zvol_io_hdr_t *mgmt_io_resp_hdr;// header recieved on management connection
 	void *mgmt_io_resp_data;	// data recieved on management connection
 	TAILQ_HEAD(, mgmt_cmd_s) mgmt_cmd_queue;	// command queue for management connection
@@ -85,29 +73,16 @@ typedef struct replica_s {
 typedef struct cstor_conn_ops {
 	cstor_listen conn_listen;
 	cstor_connect conn_connect;
-	//	cstor_read conn_read;
-	//	cstor_close conn_close;
 } cstor_conn_ops_t;
 
-int initialize_volume(spec_t *);
-void *replicator(void *);
-void *replica_sender(void *);
-void *replica_receiver(void *);
 void *cleanup_deadlist(void *);
 int initialize_replication(void);
 int handle_write_resp(spec_t *, replica_t *);
 int handle_read_resp(spec_t *, replica_t *);
 int update_replica_list(int, spec_t *, int);
-int remove_replica_from_list(spec_t *, int);
-void unblock_blocked_cmds(replica_t *);
-
 replica_t *create_replica_entry(spec_t *, int, int);
 int update_replica_entry(spec_t *, replica_t *, int);
-
-replica_t * get_replica(int mgmt_fd, spec_t **);
 int handle_read_data_event(replica_t *);
 int handle_write_data_event(replica_t *replica);
-
 void update_volstate(spec_t *);
-void clear_replica_cmd(spec_t *, rcmd_t *);
-#endif
+#endif /* _ISTGT_INTEGRATION_H */

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -62,9 +62,14 @@ typedef struct replica_s {
 	uint64_t ongoing_io_len;	// number of bytes received from replica
 	rcmd_t *ongoing_io;		// cmd for which we are receiving response
 	int mgmt_eventfd;
+	int mgmt_eventfd1;
+	int mgmt_eventfd2;
+	int disconnect_conn;
+	int conn_closed;
 	int epollfd;
 	int data_eventfd;
 	int eventfd;	/* eventfd for cmd notification from spec */
+	int epfd;
 
 	zvol_io_hdr_t *io_resp_hdr;	// header recieved on data connection
 	void *io_resp_data;		// data recieved on data connection
@@ -96,11 +101,11 @@ int update_replica_list(int, spec_t *, int);
 int remove_replica_from_list(spec_t *, int);
 void unblock_blocked_cmds(replica_t *);
 
-replica_t *create_replica_entry(spec_t *, int);
-replica_t *update_replica_entry(spec_t *, replica_t *, int);
+replica_t *create_replica_entry(spec_t *, int, int);
+int update_replica_entry(spec_t *, replica_t *, int);
 
 replica_t * get_replica(int mgmt_fd, spec_t **);
-void handle_read_data_event(replica_t *);
+int handle_read_data_event(replica_t *);
 int handle_write_data_event(replica_t *replica);
 
 void update_volstate(spec_t *);

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -814,27 +814,20 @@ typedef struct istgt_lu_disk_t {
 
 #ifdef REPLICATION
 	TAILQ_ENTRY(istgt_lu_disk_t)  spec_next;
-	TAILQ_HEAD(, rcommon_cmd_s) rcommon_sendq; //Contains IOs to be sent to replicas
-	TAILQ_HEAD(, rcommon_cmd_s) rcommon_wait_readq; //Contains IOs waiting for acks from replicas
 	TAILQ_HEAD(, rcommon_cmd_s) rcommon_waitq; //Contains IOs waiting for acks from atleast n(consistency level) replicas
-	TAILQ_HEAD(, rcommon_cmd_s) rcommon_pendingq; //Contains IOs waiting for acks from remaining replicas
 	rte_smempool_t rcommon_deadlist;	// Contains completed IOs
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
 	TAILQ_HEAD(, replica_s) rwaitq; //Queue of replicas completed handshake, and yet to have data connection to this spec(volume)
 	int replica_count;
-	uint64_t replica_index_list;
 	int replication_factor;
 	int consistency_factor;
 	int healthy_rcount;
 	int degraded_rcount;
 	bool ready;
-	int receiver_epfd;
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/
-	pthread_cond_t rq_cond;
 	pthread_mutex_t rq_mtx; 
 	pthread_mutex_t rcommonq_mtx; 
-	pthread_cond_t rcommonq_cond; 
 	pthread_mutex_t luworker_rmutex[ISTGT_MAX_NUM_LUWORKERS];
 	pthread_cond_t luworker_rcond[ISTGT_MAX_NUM_LUWORKERS];
 #endif

--- a/src/mempool_test.c
+++ b/src/mempool_test.c
@@ -82,7 +82,7 @@ verify_mempool_values_n_destroy(rte_smempool_t *mempool)
 }
 
 int
-main()
+main(void)
 {
 	rte_smempool_t mempool;
 

--- a/src/mempool_test.c
+++ b/src/mempool_test.c
@@ -90,7 +90,7 @@ main()
 
 	if (init_mempool(&mempool, 100, sizeof (struct test_node_entry),
 	    offsetof(struct test_node_entry, node), "test_mempool",
-	    NULL, NULL, NULL)) {
+	    NULL, NULL, NULL, true)) {
 		destroy_mempool(&mempool);
 		return 0;
 	}

--- a/src/replication.c
+++ b/src/replication.c
@@ -369,8 +369,8 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 	rio->version = REPLICA_VERSION;
 
 	rc = write(replica->iofd, rio, sizeof(zvol_io_hdr_t));
-	write(replica->iofd, spec->lu->volname, strlen(spec->lu->volname));
-	read(replica->iofd, &handshake_resp, sizeof (handshake_resp));
+	(void) write(replica->iofd, spec->lu->volname, strlen(spec->lu->volname));
+	(void) read(replica->iofd, &handshake_resp, sizeof (handshake_resp));
 	free(rio);
 
 	if(init_mempool(&replica->cmdq, rcmd_mempool_count, sizeof (rcmd_t), 0,
@@ -639,14 +639,14 @@ accept_mgmt_conns(int epfd, int sfd)
 			continue;
 		}
 
+		mevent1 = (mgmt_event_t *)malloc(sizeof(mgmt_event_t));
+		mevent2 = (mgmt_event_t *)malloc(sizeof(mgmt_event_t));
+
 		replica->mgmt_eventfd1 = eventfd(0, EFD_NONBLOCK);
 		if (replica->mgmt_eventfd1 < 0) {
 			perror("r_mgmt_eventfd1");
 			goto cleanup;
 		}
-
-		mevent1 = (mgmt_event_t *)malloc(sizeof(mgmt_event_t));
-		mevent2 = (mgmt_event_t *)malloc(sizeof(mgmt_event_t));
 
 		mevent1->fd = replica->mgmt_eventfd1;
 		mevent1->r_ptr = replica;
@@ -875,7 +875,7 @@ inform_data_conn(replica_t *r)
 {
 	uint64_t num = 1;
 	r->disconnect_conn = 1;
-	write(r->mgmt_eventfd2, &num, sizeof (num));
+	(void) write(r->mgmt_eventfd2, &num, sizeof (num));
 }
 
 static void

--- a/src/replication.h
+++ b/src/replication.h
@@ -46,8 +46,8 @@ struct replica_rcomm_resp {
 	zvol_io_hdr_t io_resp_hdr;
 	uint8_t *data_ptr;
 	uint64_t data_len;
-	int status;
-} __attribute__((packed));
+	uint64_t status;
+} __attribute__((packed));// || aligned(1)));
 
 typedef struct replica_rcomm_resp replica_rcomm_resp_t;
 
@@ -93,6 +93,7 @@ typedef struct rcmd_s {
 	uint64_t rrio_seq;
 	uint64_t wrio_seq;
 	void *rcommq_ptr;
+	uint8_t *iov_data;	/* for header to be sent to replica */
 	bool ack_recvd;
 	int healthy_count;	/* number of healthy replica when cmd queued */
 	int status;
@@ -136,7 +137,7 @@ int initialize_replication_mempool(bool should_fail);
 int destroy_relication_mempool(void);
 void clear_rcomm_cmd(rcommon_cmd_t *);
 void ask_replica_status(spec_t *spec, replica_t *replica);
-void get_all_read_resp_data_chunk(void *, struct io_data_chunk_list_t *);
+void get_all_read_resp_data_chunk(replica_rcomm_resp_t *, struct io_data_chunk_list_t *);
 uint8_t *process_chunk_read_resp(struct io_data_chunk_list_t  *io_chunk_list, uint64_t len);
 
 #define REPLICA_LOG(fmt, ...)  syslog(LOG_NOTICE, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)

--- a/src/replication.h
+++ b/src/replication.h
@@ -142,7 +142,6 @@ void clear_rcomm_cmd(rcommon_cmd_t *);
 void ask_replica_status(spec_t *spec, replica_t *replica);
 void get_all_read_resp_data_chunk(replica_rcomm_resp_t *, struct io_data_chunk_list_t *);
 uint8_t *process_chunk_read_resp(struct io_data_chunk_list_t  *io_chunk_list, uint64_t len);
-uint8_t * get_read_resp_data(void *data, uint64_t *datalen);
 extern void * replica_thread(void *);
 extern int do_drainfd(int );
 void close_fd(int epollfd, int fd);

--- a/src/replication.h
+++ b/src/replication.h
@@ -1,5 +1,5 @@
-#ifndef REPLICA_INITIALIZE
-#define REPLICA_INITIALIZE 1
+#ifndef _REPLICATION_H
+#define _REPLICATION_H
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -24,12 +24,15 @@
 #define BUFSIZE 1024
 #define MAXIPLEN 56
 #define MAXNAMELEN 256
+#define RCMD_MEMPOOL_ENTRIES    100000
 
 #define MAX(a,b) (((a)>(b))?(a):(b))
+
 typedef enum zvol_cmd_type_e {
 	CMD_IO = 1,
 	CND_MGMT,
 } zvol_cmd_type_t;
+
 typedef enum cmd_state_s {
 	CMD_CREATED = 1,
 	CMD_ENQUEUED_TO_WAITQ,
@@ -46,21 +49,14 @@ struct replica_rcomm_resp {
 	zvol_io_hdr_t io_resp_hdr;
 	uint8_t *data_ptr;
 	uint64_t data_len;
-	uint64_t status;
-} __attribute__((packed));// || aligned(1)));
+	int64_t status;
+} __attribute__((packed));
 
 typedef struct replica_rcomm_resp replica_rcomm_resp_t;
 
 typedef struct rcommon_cmd_s {
-	TAILQ_ENTRY(rcommon_cmd_s)  ready_cmd_next; /* for rcommon_sendq */
-	TAILQ_ENTRY(rcommon_cmd_s)  send_cmd_next; /* for rcommon_sendq */
 	TAILQ_ENTRY(rcommon_cmd_s)  wait_cmd_next; /* for rcommon_waitq */
-	TAILQ_ENTRY(rcommon_cmd_s)  pending_cmd_next; /* for rcommon_pendingq */
-	TAILQ_ENTRY(rcommon_cmd_s)  dead_cmd_next; /* for rcommon_pendingq */
 	int luworker_id;
-	pthread_mutex_t rcommand_mtx;
-	int acks_recvd;
-	int ios_aborted;
 	int copies_sent;
 	zvol_op_code_t opcode;
 	int healthy_count;	/* number of healthy replica when cmd queued */
@@ -83,18 +79,10 @@ typedef struct rcommon_cmd_s {
 
 typedef struct rcmd_s {
 	TAILQ_ENTRY(rcmd_s)  next;
-	TAILQ_ENTRY(rcmd_s)  rcmd_cmd_next; /* for rcommon_sendq */
-	TAILQ_ENTRY(rcmd_s)  rsend_cmd_next; /* for replica sendq */
-	TAILQ_ENTRY(rcmd_s)  rwait_cmd_next; /* for replica waitq */
-	TAILQ_ENTRY(rcmd_s)  rblocked_cmd_next; /* for replica blockedq */
-	TAILQ_ENTRY(rcmd_s)  rread_cmd_next; /* for replica read_waitq */
 	zvol_op_code_t opcode;
 	uint64_t io_seq;
-	uint64_t rrio_seq;
-	uint64_t wrio_seq;
 	void *rcommq_ptr;
 	uint8_t *iov_data;	/* for header to be sent to replica */
-	bool ack_recvd;
 	int healthy_count;	/* number of healthy replica when cmd queued */
 	int status;
 	int idx;		/* index for rcommon_cmd in resp_list */
@@ -103,7 +91,9 @@ typedef struct rcmd_s {
 	uint64_t data_len;
 	struct iovec iov[41];
 } rcmd_t;
+
 typedef struct replica_s replica_t;
+
 typedef struct istgt_lu_disk_t spec_t;
 
 typedef struct io_data_chunk {
@@ -117,19 +107,32 @@ TAILQ_HEAD(io_data_chunk_list_t, io_data_chunk);
 
 typedef struct mgmt_cmd_s {
 	TAILQ_ENTRY(mgmt_cmd_s) mgmt_cmd_next;
-	zvol_io_hdr_t *io_hdr;	// management command header
-	void *data;		// cmd data
-	int mgmt_cmd_state;	// current state of cmd
-	int io_bytes;   // amount of IO data written/read in current command state
+	zvol_io_hdr_t *io_hdr;			/* management command header */
+	void *data;				/* cmd data */
+	int mgmt_cmd_state;			/* current state of cmd */
+
+	/*
+	 * amount of IO data written/read in current command state
+	 */
+	int io_bytes;
 } mgmt_cmd_t;
 
+typedef struct io_event {
+	int fd;
+	int *state;
+	zvol_io_hdr_t *io_hdr;
+	void **io_data;
+	int *byte_count;
+} io_event_t;
+
+typedef struct mgmt_event {
+	int fd;
+	replica_t *r_ptr;
+} mgmt_event_t;
+
 void *init_replication(void *);
-int sendio(int, int, rcommon_cmd_t *, rcmd_t *);
-int send_mgmtio(int, zvol_op_code_t, void *, uint64_t);
 int make_socket_non_blocking(int);
 int send_mgmtack(int, zvol_op_code_t, void *, char *, int);
-int wait_for_fd(int);
-int64_t read_data(int, uint8_t *, uint64_t, int *, int *);
 int zvol_handshake(spec_t *, replica_t *);
 void accept_mgmt_conns(int, int);
 int send_io_resp(int fd, zvol_io_hdr_t *, void *);
@@ -139,10 +142,14 @@ void clear_rcomm_cmd(rcommon_cmd_t *);
 void ask_replica_status(spec_t *spec, replica_t *replica);
 void get_all_read_resp_data_chunk(replica_rcomm_resp_t *, struct io_data_chunk_list_t *);
 uint8_t *process_chunk_read_resp(struct io_data_chunk_list_t  *io_chunk_list, uint64_t len);
+uint8_t * get_read_resp_data(void *data, uint64_t *datalen);
+extern void * replica_thread(void *);
+extern int do_drainfd(int );
+void close_fd(int epollfd, int fd);
 
-#define REPLICA_LOG(fmt, ...)  syslog(LOG_NOTICE, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
-#define REPLICA_NOTICELOG(fmt, ...) syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
-#define REPLICA_ERRLOG(fmt, ...) syslog(LOG_ERR,  	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
-#define REPLICA_WARNLOG(fmt, ...) syslog(LOG_ERR, 	 "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
+#define REPLICA_LOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
+#define REPLICA_NOTICELOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
+#define REPLICA_ERRLOG(fmt, ...)	syslog(LOG_ERR, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
+#define REPLICA_WARNLOG(fmt, ...)	syslog(LOG_ERR, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 
-#endif
+#endif /* _REPLICATION_H */

--- a/src/replication_misc.h
+++ b/src/replication_misc.h
@@ -1,2 +1,7 @@
+#ifndef _REPLICATION_MISC_H
+#define	_REPLICATION_MISC_H
+
 int replication_connect(const char *, int);
 int replication_listen(const char *, int, int);
+
+#endif /* _REPLICATION_MISC_H */

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -147,6 +147,10 @@ send_io_resp(int fd, zvol_io_hdr_t *io_hdr, void *buf)
 	int iovcnt, i, nbytes = 0;
 	int rc = 0;
 	io_hdr->status = ZVOL_OP_STATUS_OK;
+
+	if (fd < 0)
+		return -1;
+
 	if(io_hdr->opcode == ZVOL_OPCODE_READ) {
 		iovcnt = 3;
 		io_rw_hdr.io_num = 2000;
@@ -212,12 +216,11 @@ main(int argc, char **argv)
 		if_healthy = 0;
 //		sleeptime = atoi(argv[6]);
 	}
-	int iofd, mgmtfd, sfd, rc, epfd, event_count, i;
+	int iofd = -1, mgmtfd, sfd, rc, epfd, event_count, i;
 	int64_t count;
 	struct epoll_event event, *events;
 	uint8_t *data, *data_ptr_cpy;
-	uint64_t data_len, nbytes = 0;
-	char *volname;
+	uint64_t nbytes = 0;
 	int vol_fd = open(test_vol, O_RDWR, 0666);
 	zvol_op_code_t opcode;
 	zvol_io_hdr_t *io_hdr = malloc(sizeof(zvol_io_hdr_t));
@@ -281,11 +284,9 @@ main(int argc, char **argv)
 				}
 				if(mgmtio->len) {
 					data = data_ptr_cpy = malloc(mgmtio->len);
-					data_len = mgmtio->len;
 					count = test_read_data(events[i].data.fd, (uint8_t *)data, mgmtio->len);
 				}
 				opcode = mgmtio->opcode;
-				volname = (char *)data;
 				send_mgmtack(mgmtfd, opcode, data, replicaip, replica_port);
 			} else if (events[i].data.fd == sfd) {
 				struct sockaddr saddr;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -137,7 +137,7 @@ out:
 int
 send_io_resp(int fd, zvol_io_hdr_t *io_hdr, void *buf)
 {
-	struct iovec iovec[2];
+	struct iovec iovec[3];
 	struct zvol_io_rw_hdr io_rw_hdr;
 	int iovcnt, i, nbytes = 0;
 	int rc = 0;

--- a/src/ring_mempool.h
+++ b/src/ring_mempool.h
@@ -1,6 +1,7 @@
 #ifndef	_RING_MEMPOOL_H
 #define	_RING_MEMPOOL_H
 
+#include <stdbool.h>
 #include "rte_ring.h"
 
 typedef int mempool_constructor_t(void *, void *, int);
@@ -17,9 +18,10 @@ typedef struct {
 } rte_smempool_t;
 
 int init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size, size_t offset, const char *mempool_name,
-		mempool_constructor_t *create, mempool_destructor_t *free, mempool_reclaim_t *reclaim);
+		mempool_constructor_t *create, mempool_destructor_t *free, mempool_reclaim_t *reclaim, bool initialize);
 int destroy_mempool(rte_smempool_t *obj);
 void * get_from_mempool(rte_smempool_t *obj);
 void put_to_mempool(rte_smempool_t *obj, void *node);
+unsigned get_num_entries_from_mempool(rte_smempool_t *obj);
 
 #endif

--- a/src/ring_mempool.h
+++ b/src/ring_mempool.h
@@ -24,4 +24,4 @@ void * get_from_mempool(rte_smempool_t *obj);
 void put_to_mempool(rte_smempool_t *obj, void *node);
 unsigned get_num_entries_from_mempool(rte_smempool_t *obj);
 
-#endif
+#endif /* _RING_MEMPOOL_H */


### PR DESCRIPTION
This is an initial version of this PR which addresses 
         1. Error handling in ISTGT's replica interface (if the replica get disconnected)
          2. Optimization in LUN worker and replica interface regarding the handling of command queues.