### PR TITLE
Changed `size_t` to `int` because `size_t` is unsigned integer type.

### DIFF
--- a/src/istgt_md5.c
+++ b/src/istgt_md5.c
@@ -61,7 +61,7 @@ istgt_md5final(void *md5, ISTGT_MD5CTX *md5ctx)
 }
 
 int
-istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, size_t len)
+istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, int len)
 {
 	int rc;
 


### PR DESCRIPTION
Value of `size_t` cannot be negative because it is an unsigned integer type. Thus, `len <= 0` when `len` is `size_t` type makes no sense (except the case when `len == 0`). Changed it to `int` instead.