### PR TITLE
Iostats command implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install --yes -qq gcc-6 g++-6
     - sudo apt-get install libssl-dev open-iscsi docker.io
+    - sudo apt-get install libjson-c-dev
     # use gcc-6 by default
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -759,7 +759,10 @@ typedef struct istgt_lu_disk_t {
 	uint32_t rshiftreal;
 	uint32_t max_unmap_sectors;
 	struct IO_types IO_size[10];	
-
+        uint64_t writes;
+        uint64_t reads;
+        uint64_t readbytes;
+        uint64_t writebytes;
 	/* modify lun */
 	int dofake;
 	pthread_t diskmod_thr;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -758,11 +758,11 @@ typedef struct istgt_lu_disk_t {
 	uint32_t rshift;
 	uint32_t rshiftreal;
 	uint32_t max_unmap_sectors;
-	struct IO_types IO_size[10];	
-        uint64_t writes;
-        uint64_t reads;
-        uint64_t readbytes;
-        uint64_t writebytes;
+	struct IO_types IO_size[10];
+	uint64_t writes;
+	uint64_t reads;
+	uint64_t readbytes;
+	uint64_t writebytes;
 	/* modify lun */
 	int dofake;
 	pthread_t diskmod_thr;

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -2848,8 +2848,6 @@ _verb_istat ISCSIstat_rslt[ISCSI_ARYSZ] = { {0,0,0} };
 static int
 istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 {
-        const char *delim = ARGS_DELIM;
-        char *arg;
         ISTGT_LU_Ptr lu;       
         int rc;
         int i, j;
@@ -2863,12 +2861,16 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
                 	spec = (ISTGT_LU_DISK *) lu->lun[j].spec;
 			if (spec == NULL)
 				continue;
-                	istgt_uctl_snprintf(uctl, "%s  IQN=%s Blockcount=%lu Blocklength=%lu Writes=%lu Reads=%lu TotalReadBytes=%lu TotalWriteBytes=%lu Size=%lu\n", uctl->cmd, lu->name, spec->blockcnt, spec->blocklen, spec->writes, spec->reads, spec->readbytes, spec->writebytes, spec->size);
-                	rc = istgt_uctl_writeline(uctl);
+                	istgt_uctl_snprintf(uctl, "%s  IQN=%s Blockcount=%lu Blocklength=%lu "
+				"Writes=%lu Reads=%lu TotalReadBytes=%lu TotalWriteBytes=%lu "
+				"Size=%lu\n", uctl->cmd, lu->name, spec->blockcnt, spec->blocklen,
+				 spec->writes, spec->reads, spec->readbytes, spec->writebytes, spec->size);
+			rc = istgt_uctl_writeline(uctl);
+			if (rc != UCTL_CMD_OK)
+				return rc;
+
                 }
-                if (rc != UCTL_CMD_OK)
-                     return rc;
-        }
+	}
 	istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);
 	rc = istgt_uctl_writeline(uctl);
 	if (rc != UCTL_CMD_OK) {
@@ -3087,7 +3089,7 @@ static ISTGT_UCTL_CMD_TABLE istgt_uctl_cmd_table[] =
 	{ "RSV", istgt_uctl_cmd_rsv},
 	{ "QUE", istgt_uctl_cmd_que},
 	{ "STATS", istgt_uctl_cmd_stats},
-        { "IOSTATS", istgt_uctl_cmd_iostats},
+	{ "IOSTATS", istgt_uctl_cmd_iostats},
 	{ "SET", istgt_uctl_cmd_set},
 	{ "MAXTIME", istgt_uctl_cmd_maxtime},
 	{ NULL,      NULL },

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -28,7 +28,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-
+#include <json-c/json_object.h>
 #include <inttypes.h>
 #include <stdint.h>
 
@@ -2901,11 +2901,23 @@ _verb_stat SCSIstat_rslt[SCSI_ARYSZ] = { {0,0,0} };
 _verb_istat ISCSIstat_last[ISCSI_ARYSZ] = { {0,0,0} };
 _verb_istat ISCSIstat_now[ISCSI_ARYSZ] = { {0,0,0} };
 _verb_istat ISCSIstat_rslt[ISCSI_ARYSZ] = { {0,0,0} };
+
+// istgt_uctl_cmd_iostats collects the iostats from the spec structure
+// and marshal them into json format using json-c library.The returned
+// string memory is managed by the json_object and will be freed when
+// the reference count of the json_object drops to zero.
+// TODO: Add the fields for getting the latency, used capacity etc.
+
 static int
 istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 {
         ISTGT_LU_Ptr lu;       
-        int rc;
+        int rc, length;
+	// instantiate json_object from json-c library.
+        struct json_object *jobj;
+	// these are utility variables that will be freed at the end of the 
+	// function.
+        char *writes, *reads, *totalreadbytes, *totalwritebytes, *size;
         int i, j;
         ISTGT_LU_DISK *spec;
         ISTGT_Ptr istgt = uctl->istgt;
@@ -2917,21 +2929,59 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
                 	spec = (ISTGT_LU_DISK *) lu->lun[j].spec;
 			if (spec == NULL)
 				continue;
-			istgt_uctl_snprintf(uctl, "%s  IQN=%s Blockcount=%lu Blocklength=%lu "
-				"Writes=%lu Reads=%lu TotalReadBytes=%lu TotalWriteBytes=%lu "
-				"Size=%lu\n", uctl->cmd, lu->name, spec->blockcnt, spec->blocklen,
-				 spec->writes, spec->reads, spec->readbytes, spec->writebytes, spec->size);
+			jobj = json_object_new_object();	// create new object
+			json_object *jIQN = json_object_new_string(lu->name);
+			json_object_object_add(jobj, "iqn", jIQN);
+
+			length = snprintf(NULL, 0, "%"PRIu64, spec->writes);	// get the length 
+			writes = malloc(length + 1);
+			snprintf(writes, length + 1, "%"PRIu64, spec->writes);	// uint64 to string
+
+			length = snprintf(NULL, 0, "%"PRIu64, spec->reads);
+			reads = malloc(length + 1);
+			snprintf(reads, length + 1, "%"PRIu64, spec->reads);
+
+			length = snprintf(NULL, 0, "%"PRIu64, spec->readbytes);
+			totalreadbytes = malloc(length + 1);
+			snprintf(totalreadbytes, length + 1, "%"PRIu64, spec->readbytes);
+
+			length = snprintf(NULL, 0, "%"PRIu64, spec->writebytes);
+			totalwritebytes = malloc(length + 1);
+			snprintf(totalwritebytes, length + 1, "%"PRIu64, spec->writebytes);
+
+			length = snprintf(NULL, 0, "%"PRIu64, spec->size);
+			size = malloc(length + 1);
+			snprintf(size, length + 1, "%"PRIu64, spec->size);
+
+			json_object *jreads = json_object_new_string(reads);	// instantiate object
+			json_object *jwrites = json_object_new_string(writes);
+			json_object *jtotalreadbytes = json_object_new_string(totalreadbytes);
+			json_object *jtotalwritebytes = json_object_new_string(totalwritebytes);
+			json_object *jsize = json_object_new_string(size);
+
+			json_object_object_add(jobj, "writes", jwrites);	// add values to object field
+			json_object_object_add(jobj, "reads", jreads);
+			json_object_object_add(jobj, "totalwritebytes", jtotalwritebytes);
+			json_object_object_add(jobj, "totalreadbytes", jtotalreadbytes);
+			json_object_object_add(jobj, "size", jsize);
+
+			istgt_uctl_snprintf(uctl, "%s  %s\n", uctl->cmd, json_object_to_json_string(jobj));
 			rc = istgt_uctl_writeline(uctl);
 			if (rc != UCTL_CMD_OK)
 				return rc;
-                }
+		}
 	}
+	free(reads);
+	free(writes);
+	free(totalreadbytes);
+	free(totalwritebytes);
+	free(size);
 	istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);
 	rc = istgt_uctl_writeline(uctl);
 	if (rc != UCTL_CMD_OK) {
 		return rc;
 	}
-        return UCTL_CMD_OK;
+   return UCTL_CMD_OK;
 }
 static int
 istgt_uctl_cmd_stats(UCTL_Ptr uctl)

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -2917,14 +2917,13 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
                 	spec = (ISTGT_LU_DISK *) lu->lun[j].spec;
 			if (spec == NULL)
 				continue;
-                	istgt_uctl_snprintf(uctl, "%s  IQN=%s Blockcount=%lu Blocklength=%lu "
+			istgt_uctl_snprintf(uctl, "%s  IQN=%s Blockcount=%lu Blocklength=%lu "
 				"Writes=%lu Reads=%lu TotalReadBytes=%lu TotalWriteBytes=%lu "
 				"Size=%lu\n", uctl->cmd, lu->name, spec->blockcnt, spec->blocklen,
 				 spec->writes, spec->reads, spec->readbytes, spec->writebytes, spec->size);
 			rc = istgt_uctl_writeline(uctl);
 			if (rc != UCTL_CMD_OK)
 				return rc;
-
                 }
 	}
 	istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -114,9 +114,14 @@ size_t rcommon_cmd_mempool_count = RCOMMON_CMD_MEMPOOL_ENTRIES;
 		if(cmd_write) {\
 			rcomm_cmd->opcode = ZVOL_OPCODE_WRITE;\
 			rcomm_cmd->iovcnt = cmd->iobufindx+1;\
+                        __sync_add_and_fetch(&spec->writes, 1);\
+			__sync_add_and_fetch(&spec->writebytes, nbytes);\
 		} else {\
 			rcomm_cmd->opcode = ZVOL_OPCODE_READ;\
 			rcomm_cmd->iovcnt = 0;\
+			printf("got read\n");	\
+			__sync_add_and_fetch(&spec->reads, 1); \
+			__sync_add_and_fetch(&spec->writebytes, nbytes);\
 		}\
 		if(cmd_write) {\
 			for (i=1; i < iovcnt + 1; i++) {\

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -114,14 +114,13 @@ size_t rcommon_cmd_mempool_count = RCOMMON_CMD_MEMPOOL_ENTRIES;
 		if(cmd_write) {\
 			rcomm_cmd->opcode = ZVOL_OPCODE_WRITE;\
 			rcomm_cmd->iovcnt = cmd->iobufindx+1;\
-                        __sync_add_and_fetch(&spec->writes, 1);\
+			__sync_add_and_fetch(&spec->writes, 1);\
 			__sync_add_and_fetch(&spec->writebytes, nbytes);\
 		} else {\
 			rcomm_cmd->opcode = ZVOL_OPCODE_READ;\
 			rcomm_cmd->iovcnt = 0;\
-			printf("got read\n");	\
 			__sync_add_and_fetch(&spec->reads, 1); \
-			__sync_add_and_fetch(&spec->writebytes, nbytes);\
+			__sync_add_and_fetch(&spec->readbytes, nbytes);\
 		}\
 		if(cmd_write) {\
 			for (i=1; i < iovcnt + 1; i++) {\

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -1070,8 +1070,8 @@ static int
 exec_iostats(UCTL_Ptr uctl)
 {
         const char *delim = ARGS_DELIM;
-        char *arg, buf[1000];
-        char *result, *var;
+        char *arg;
+        char *result;
         int rc;
 
         uctl_snprintf(uctl, "IOSTATS\n");
@@ -1080,30 +1080,28 @@ exec_iostats(UCTL_Ptr uctl)
                 return rc;
         }
         /* receive result */
-        while(1) {
-           rc = uctl_readline(uctl);
-           if (rc != UCTL_CMD_OK) {
-              return rc;
-           }
-           arg = trim_string(uctl->recvbuf);
-           result = strsepq(&arg, delim);
-           strupr(result);
-           if (strcmp(result, uctl->cmd) !=0){
-              break;
-           }
-           if (uctl->iqn != NULL) {
-		printf("%s\n", arg);
- 	   } else {
-		printf("%s\n", arg);
-	   }
-        }
-        if (strcmp(result, "OK") != 0) {
-		if (is_err_req_auth(uctl, arg))
-			return UCTL_CMD_REQAUTH;
+	while(1) {
+		rc = uctl_readline(uctl);
+		if (rc != UCTL_CMD_OK) {
+			return rc;
+		}
+		arg = trim_string(uctl->recvbuf);
+		result = strsepq(&arg, delim);
+		strupr(result);
+		if (strcmp(result, uctl->cmd) !=0){
+			break;
+		}
+		if (uctl->iqn != NULL) {
+			printf("%s\n", arg);
+		} else {
+			printf("%s\n", arg);
+		}
+	}
+	if (strcmp(result, "OK") != 0) {
 		fprintf(stderr, "ERROR %s\n", arg);
 		return UCTL_CMD_ERR;
-	}       
-        return UCTL_CMD_OK;
+	}
+	return UCTL_CMD_OK;
 }
 
 static int
@@ -1389,10 +1387,10 @@ static EXEC_TABLE exec_table[] =
 	{"LOG", exec_log, 0, 0 },
 	{"RSV", exec_rsv, 0, 0 },
 	{"QUE", exec_que, 0, 0 },
-        {"STATS", exec_stats, 0, 0 },
-        {"SET", exec_set, 0, 1},
-       	{"IOSTATS", exec_iostats, 0, 0 },
-       	{"MAXTIME", exec_maxtime, 0, 0},
+	{"STATS", exec_stats, 0, 0 },
+	{"SET", exec_set, 0, 1},
+	{"IOSTATS", exec_iostats, 0, 0 },
+	{"MAXTIME", exec_maxtime, 0, 0},
 	{ NULL,      NULL,          0, 0 },
 };
 

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -1067,6 +1067,46 @@ exec_dump(UCTL_Ptr uctl)
 }
 
 static int
+exec_iostats(UCTL_Ptr uctl)
+{
+        const char *delim = ARGS_DELIM;
+        char *arg, buf[1000];
+        char *result, *var;
+        int rc;
+
+        uctl_snprintf(uctl, "IOSTATS\n");
+        rc = uctl_writeline(uctl);
+        if (rc != UCTL_CMD_OK) {
+                return rc;
+        }
+        /* receive result */
+        while(1) {
+           rc = uctl_readline(uctl);
+           if (rc != UCTL_CMD_OK) {
+              return rc;
+           }
+           arg = trim_string(uctl->recvbuf);
+           result = strsepq(&arg, delim);
+           strupr(result);
+           if (strcmp(result, uctl->cmd) !=0){
+              break;
+           }
+           if (uctl->iqn != NULL) {
+		printf("%s\n", arg);
+ 	   } else {
+		printf("%s\n", arg);
+	   }
+        }
+        if (strcmp(result, "OK") != 0) {
+		if (is_err_req_auth(uctl, arg))
+			return UCTL_CMD_REQAUTH;
+		fprintf(stderr, "ERROR %s\n", arg);
+		return UCTL_CMD_ERR;
+	}       
+        return UCTL_CMD_OK;
+}
+
+static int
 exec_stats(UCTL_Ptr uctl)
 {
 	const char *delim = ARGS_DELIM;
@@ -1349,9 +1389,10 @@ static EXEC_TABLE exec_table[] =
 	{"LOG", exec_log, 0, 0 },
 	{"RSV", exec_rsv, 0, 0 },
 	{"QUE", exec_que, 0, 0 },
-	{"STATS", exec_stats, 0, 0 },
-	{"SET", exec_set, 0, 1},
-	{"MAXTIME", exec_maxtime, 0, 0},
+        {"STATS", exec_stats, 0, 0 },
+        {"SET", exec_set, 0, 1},
+       	{"IOSTATS", exec_iostats, 0, 0 },
+       	{"MAXTIME", exec_maxtime, 0, 0},
 	{ NULL,      NULL,          0, 0 },
 };
 
@@ -1830,6 +1871,7 @@ usage(void)
 	printf(" info       show connections of target\n");
 	printf(" maxtime    list the IOs which took maximum time to process\n");
 	printf(" set        set values for variables:\n");
+        printf(" iostats    displays iostats of volume\n");
 	printf("            Syntax: istgtcontrol -t <iqn(ALL to set globally)> set <variable number> <value>\n");
 	printf("            Variables :\n");
 	printf("            1\tsend_abrt_resp(Yes->1 No->0)\n");

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -1091,11 +1091,7 @@ exec_iostats(UCTL_Ptr uctl)
 		if (strcmp(result, uctl->cmd) !=0){
 			break;
 		}
-		if (uctl->iqn != NULL) {
-			printf("%s\n", arg);
-		} else {
-			printf("%s\n", arg);
-		}
+		fprintf(stdout, "%s\n", arg);
 	}
 	if (strcmp(result, "OK") != 0) {
 		fprintf(stderr, "ERROR %s\n", arg);

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -177,10 +177,6 @@ run_data_integrity_test() {
 	replica3_pid=$!
 	sleep 15
 
-	run_and_verify_iostats
-
-	sleep 15
-
 	$TEST_SNAPSHOT 1 &
 	test_snapshot_pid=$!
 
@@ -189,7 +185,7 @@ run_data_integrity_test() {
 	wait_for_pids $test_snapshot_pid
 
 	$TEST_SNAPSHOT 1
-
+        
 	sudo pkill -9 -P $replica1_pid
 	sleep 5
 	write_and_verify_data
@@ -208,6 +204,10 @@ run_data_integrity_test() {
 	sleep 65
 	ps -auxwww
 	$TEST_SNAPSHOT 1
+	
+	run_and_verify_iostats
+
+	sleep 15
 
 	sudo kill -9 $replica1_pid $replica2_pid $replica3_pid
 	cleanup_test_env

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -71,14 +71,16 @@ run_and_verify_iostats() {
 
 		sudo dd if=/dev/urandom of=/mnt/store/file1 bs=4k count=10000 oflag=direct
 		sudo istgtcontrol iostats
-		var1="$(sudo istgtcontrol iostats |  awk '{ print $7 }' | cut -d '=' -f 2)"
+		#var1="$(sudo istgtcontrol iostats |  awk '{ print $7 }' | cut -d '=' -f 2)"
+		var1="$(sudo istgtcontrol iostats | grep -oP "(?<=totalwritebytes\": \")[^ ]+" | cut -d '"' -f 1)"
 		if [ $var1 -eq 0 ]; then
 			echo "iostats command failed" && exit 1
 		fi
 
 		sudo dd if=/dev/urandom of=/mnt/store/file1 bs=4k count=10000 oflag=direct
 		sudo istgtcontrol iostats
-		var2="$(sudo istgtcontrol iostats |  awk '{ print $7 }' | cut -d '=' -f 2)"
+		#var2="$(sudo istgtcontrol iostats |  awk '{ print $7 }' | cut -d '=' -f 2)"
+		var2="$(sudo istgtcontrol iostats | grep -oP "(?<=totalwritebytes\": \")[^ ]+" | cut -d '"' -f 1)"
 		if [ $var2 -eq 0 ]; then
 			echo "iostats command failed" && exit 1
 		fi

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 DIR=$PWD
 SETUP_ISTGT=$DIR/src/setup_istgt.sh
 REPLICATION_TEST=$DIR/src/replication_test


### PR DESCRIPTION
This commit adds the command iostats in istgtcontrol to get
the iostats from istgt.

On branch iostats-command-implemantation
Changes to be committed:
	modified:   istgt_lu.h
	modified:   istgt_lu_ctl.c
	modified:   istgt_lu_disk.c
	modified:   istgtcontrol.c

1. Why is this change necessary ?
-  There is no such command in istgtcontrol to get these details
   so this command adds the additional functionality to get iostats

2. How to verify this change ?
-  Build the binary and run `sudo istgtcontrol iostats` and you
   will get the output something like given below.
```
$ sudo istgtcontrol iostats
{ "iqn": "iqn.2017-08.OpenEBS.cstor:vol1", "writes": "0", "reads": "0", "totalwritebytes": "0", "totalreadbytes": "0", "size": "10737418240" } DONE IOSTATS command
```

3. What side effects does this change have ?
-  none

Special notes for the reviewer :
- This does not displays the complets iostats but only displays the
  available stats.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>