### PR TITLE
Changed `size_t` to `ssize_t` because `size_t` is unsigned integer type.

### DIFF
--- a/src/istgt_md5.c
+++ b/src/istgt_md5.c
@@ -61,7 +61,7 @@ istgt_md5final(void *md5, ISTGT_MD5CTX *md5ctx)
 }
 
 int
-istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, size_t len)
+istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, int len)
 {
 	int rc;
 

--- a/src/istgt_md5.c
+++ b/src/istgt_md5.c
@@ -61,7 +61,7 @@ istgt_md5final(void *md5, ISTGT_MD5CTX *md5ctx)
 }
 
 int
-istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, int len)
+istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, ssize_t len)
 {
 	int rc;
 

--- a/src/istgt_md5.h
+++ b/src/istgt_md5.h
@@ -44,6 +44,6 @@ typedef struct istgt_md5ctx_t {
 
 int istgt_md5init(ISTGT_MD5CTX *md5ctx);
 int istgt_md5final(void *md5, ISTGT_MD5CTX *md5ctx);
-int istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, size_t len);
+int istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, int len);
 
 #endif /* ISTGT_MD5_H */

--- a/src/istgt_md5.h
+++ b/src/istgt_md5.h
@@ -44,6 +44,6 @@ typedef struct istgt_md5ctx_t {
 
 int istgt_md5init(ISTGT_MD5CTX *md5ctx);
 int istgt_md5final(void *md5, ISTGT_MD5CTX *md5ctx);
-int istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, int len);
+int istgt_md5update(ISTGT_MD5CTX *md5ctx, const void *data, ssize_t len);
 
 #endif /* ISTGT_MD5_H */


### PR DESCRIPTION
Value of `size_t` cannot be negative because it is an unsigned integer type. Thus, `len <= 0` when `len` is `size_t` type makes no sense (except the case when `len == 0`). Changed it to `int` instead.

Changes made in `istgt_md5.c` (function definition) and `istgt_md5.h` (function prototype declaration) files.