### PR TITLE
TA343: error path of lbwrite, memory should not be deleted

### DIFF
--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -6019,14 +6019,18 @@ freeiovcnt:
 				conn->id, markedForFree, markedForReturn, conn, conn->cid, diskIoPendingL, nbytes, rc, lba, len);
 		if (diskIoPendingL == 0 && markedForFree == 1)
 			lu_cmd->connGone = 1;
+#ifndef REPLICATION
 		for (i=0; i<iovcnt; ++i)
 			xfree(iov[i].iov_base);
+#endif
 		return -1;
 	}
 	if (rc < 0)  {
 		errlog(lu_cmd, "c#%d lu_disk_write() failed wrote:%lu of %lu+%lu (%lu) lba:%lu+%u", conn->id, rc, offset, nbytes, l_offset, lba, len)
+#ifndef REPLICATION
 		for (i=0; i<iovcnt; ++i)
 			xfree(iov[i].iov_base);
+#endif
 		return -1;
 	}
 	ISTGT_TRACELOG(ISTGT_TRACE_SCSI, "c#%d Wrote %lu/%lu bytes (lba:%lu+%u) %s\n",

--- a/src/replication.c
+++ b/src/replication.c
@@ -1298,7 +1298,6 @@ cleanup_deadlist(void *arg)
 
 			if (count == rcomm_cmd->copies_sent) {
 				destroy_resp_list(rcomm_cmd);
-				free(rcomm_cmd->iov[0].iov_base);
 
 				for (i=1; i<rcomm_cmd->iovcnt + 1; i++)
 					xfree(rcomm_cmd->iov[i].iov_base);


### PR DESCRIPTION
This is as per the review comment on PR https://github.com/openebs/istgt/pull/19
- In lbwrite function call, memory should not be deleted as it will be handled in replicate module. But, in error path, memory is being freed.
- During destroy of common IO structure (rcommon_cmd_t) for replication, iov[0] has been deleted even though its not initialized to any location.
This PR addresses both the above issues.
Testing infra need to be added for integration testing to do error injection.
Signed-off-by: Vishnu Itta <vitta@mayadata.io>