### PR TITLE
Added functionality in iSCSI controller to own dataset on data-io con…

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <sys/prctl.h>
 #include <sys/eventfd.h>
+#include </usr/include/assert.h>
 #include "zrepl_prot.h"
 #include "replication.h"
 #include "istgt_integration.h"
@@ -296,10 +297,11 @@ int
 update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 {
 	int rc;
-	zvol_io_hdr_t *rio;
+	zvol_io_hdr_t *rio_hdr;
 	pthread_t r_thread;
 	zvol_io_hdr_t *ack_hdr;
 	mgmt_ack_t *ack_data;
+	zvol_op_open_data_t *rio_payload;
 	int i;
 
 	ack_hdr = replica->mgmt_io_resp_hdr;	
@@ -323,34 +325,48 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 	replica->zvol_guid = ack_data->zvol_guid;
 
 	replica->spec = spec;
-	replica->io_resp_hdr = (zvol_io_hdr_t *)malloc(sizeof(zvol_io_hdr_t));
+	replica->io_resp_hdr = (zvol_io_hdr_t *) malloc(sizeof (zvol_io_hdr_t));
 	replica->io_state = READ_IO_RESP_HDR;
 	replica->io_read = 0;
 
-	rio = (zvol_io_hdr_t *)malloc(sizeof(zvol_io_hdr_t));
-	rio->opcode = ZVOL_OPCODE_HANDSHAKE;
-	rio->io_seq = 0;
-	rio->offset = 0;
-	rio->len = strlen(spec->lu->volname);
-	rio->version = REPLICA_VERSION;
+	rio_hdr = (zvol_io_hdr_t *) malloc(sizeof (zvol_io_hdr_t));
+	rio_hdr->opcode = ZVOL_OPCODE_OPEN;
+	rio_hdr->io_seq = 0;
+	rio_hdr->offset = 0;
+	rio_hdr->len = sizeof (zvol_op_open_data_t);
+	rio_hdr->version = REPLICA_VERSION;
 
-	if (write(replica->iofd, rio, sizeof(zvol_io_hdr_t)) != sizeof(zvol_io_hdr_t)) {
+	rio_payload = (zvol_op_open_data_t *) malloc(
+	    sizeof (zvol_op_open_data_t));
+	rio_payload->timeout = (10 *60);
+	rio_payload->tgt_block_size = spec->lu->blocklen;
+	strncpy(rio_payload->volname, spec->lu->volname,
+	    sizeof (rio_payload->volname));
+
+	if (write(replica->iofd, rio_hdr, sizeof (*rio_hdr)) !=
+	    sizeof (*rio_hdr)) {
 		REPLICA_ERRLOG("failed to send io hdr to replica\n");
 		goto replica_error;
 	}
 
-	if (write(replica->iofd, spec->lu->volname,
-		strlen(spec->lu->volname)) != (ssize_t)strlen(spec->lu->volname)) {
-		REPLICA_ERRLOG("failed to send volname to replica\n");
+	if (write(replica->iofd, rio_payload, sizeof (zvol_op_open_data_t)) !=
+	    sizeof (zvol_op_open_data_t)) {
+		REPLICA_ERRLOG("failed to send data-open payload to replica\n");
 		goto replica_error;
 	}
 
-	if (read(replica->iofd, rio, sizeof (*rio)) != sizeof (*rio)) {
-		REPLICA_ERRLOG("failed to read handshake response from replica\n");
+	if (read(replica->iofd, rio_hdr, sizeof (*rio_hdr)) !=
+	    sizeof (*rio_hdr)) {
+		REPLICA_ERRLOG("failed to read data-open response from replica\n");
 		goto replica_error;
 	}
 
-	if(init_mempool(&replica->cmdq, rcmd_mempool_count, sizeof (rcmd_t), 0,
+	if (rio_hdr->status != ZVOL_OP_STATUS_OK) {
+		REPLICA_ERRLOG("data-open response is not OK\n");
+		goto replica_error;
+	}
+
+	if (init_mempool(&replica->cmdq, rcmd_mempool_count, sizeof (rcmd_t), 0,
 	    "replica_cmd_mempool", NULL, NULL, NULL, false)) {
 		REPLICA_ERRLOG("Failed to initialize replica cmdq\n");
 		goto replica_error;
@@ -369,11 +385,13 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 replica_error:
 		replica->iofd = -1;
 		close(iofd);
-		free(rio);
+		free(rio_hdr);
+		free(rio_payload);
 		return -1;
 	}
 
-	free(rio);
+	free(rio_hdr);
+	free(rio_payload);
 
 	for (i = 0; (i < 10) && (replica->mgmt_eventfd2 == -1); i++)
 		sleep(1);

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -210,6 +210,7 @@ main(int argc, char **argv)
 	char *test_vol = argv[5];
 	int sleeptime = 0;
 	struct zvol_io_rw_hdr *io_rw_hdr;
+	zvol_op_open_data_t *open_ptr;
 
 	if (argv[6] != NULL) {
 		printf("got 6th arg.. not setting healthy\n");
@@ -364,8 +365,10 @@ main(int argc, char **argv)
 						read_rem_hdr = false;
 					}
 
-					if(io_hdr->opcode == ZVOL_OPCODE_WRITE || io_hdr->opcode == ZVOL_OPCODE_HANDSHAKE) {
-						if(io_hdr->len) {
+					if (io_hdr->opcode == ZVOL_OPCODE_WRITE ||
+					    io_hdr->opcode == ZVOL_OPCODE_HANDSHAKE ||
+					    io_hdr->opcode == ZVOL_OPCODE_OPEN) {
+						if (io_hdr->len) {
 							data = malloc(io_hdr->len);
 							nbytes = 0;
 							count = test_read_data(events[i].data.fd, (uint8_t *)data, io_hdr->len);
@@ -374,7 +377,7 @@ main(int argc, char **argv)
 								recv_len = 0;
 								total_len = io_hdr->len;
 								break;
-							} else if((uint64_t)count < io_hdr->len && errno == EAGAIN) {
+							} else if ((uint64_t)count < io_hdr->len && errno == EAGAIN) {
 								read_rem_data = true;
 								recv_len = count;
 								total_len = io_hdr->len;
@@ -382,6 +385,12 @@ main(int argc, char **argv)
 							}
 							read_rem_data = false;
 						}
+					}
+
+					if (io_hdr->opcode == ZVOL_OPCODE_OPEN) {
+						open_ptr = (zvol_op_open_data_t *)data;
+						REPLICA_LOG("Volume name:%s blocksize:%d timeout:%d\n",
+						    open_ptr->volname, open_ptr->tgt_block_size, open_ptr->timeout);
 					}
 execute_io:
 					if(io_hdr->opcode == ZVOL_OPCODE_WRITE) {

--- a/src/zrepl_prot.h
+++ b/src/zrepl_prot.h
@@ -40,6 +40,9 @@ extern "C" {
  * version number. If replica does not support the version, then it replies
  * with "version mismatch" error, puts supported version in version field
  * and closes the connection.
+ *
+ * If you modify the struct definitions in this file make sure they are
+ * properly aligned (and packed).
  */
 
 #define	REPLICA_VERSION	1
@@ -47,12 +50,23 @@ extern "C" {
 #define	MAX_IP_LEN	64
 #define	TARGET_PORT	6060
 
+#define	ZVOL_OP_FLAG_REBUILD 0x01
+
 enum zvol_op_code {
+	// Used to obtain info about a zvol on mgmt connection
 	ZVOL_OPCODE_HANDSHAKE = 0,
+	// Following 4 requests are used on data connection
+	ZVOL_OPCODE_OPEN,
 	ZVOL_OPCODE_READ,
 	ZVOL_OPCODE_WRITE,
-	ZVOL_OPCODE_UNMAP,
 	ZVOL_OPCODE_SYNC,
+	// Following commands apply to mgmt connection
+	ZVOL_OPCODE_UNMAP,
+	ZVOL_OPCODE_PREPARE_FOR_REBUILD,
+	ZVOL_OPCODE_START_REBUILD,
+	ZVOL_OPCODE_REBUILD_STEP,
+	ZVOL_OPCODE_REBUILD_STEP_DONE,
+	ZVOL_OPCODE_REBUILD_COMPLETE,
 	ZVOL_OPCODE_SNAP_CREATE,
 	ZVOL_OPCODE_SNAP_ROLLBACK,
 	ZVOL_OPCODE_REPLICA_STATUS,
@@ -75,20 +89,32 @@ typedef enum zvol_op_status zvol_op_status_t;
 struct zvol_io_hdr {
 	uint16_t	version;
 	zvol_op_code_t	opcode;
+	zvol_op_status_t status;
+	uint8_t 	flags;
+	uint8_t 	padding[3];
 	uint64_t	io_seq;
 	/* only used for read/write */
 	uint64_t	offset;
 	/*
-	 * Length of data in payload.
-	 * (for read/write that includes size of io headers with meta data).
+	 * Length of data in payload, with following exceptions:
+	 *  1) for read request: size of data to read (payload has zero length)
+	 *  2) for write reply: size of data written (payload has zero length)
+	 * Note that for write request it includes size of io headers with
+	 * meta data.
 	 */
 	uint64_t	len;
 	uint64_t	checkpointed_io_seq;
-	uint8_t 	flags;
-	zvol_op_status_t status;
 } __attribute__((packed));
 
 typedef struct zvol_io_hdr zvol_io_hdr_t;
+
+struct zvol_op_open_data {
+	uint32_t	tgt_block_size;	// used block size for rw in bytes
+	uint32_t	timeout;	// replica timeout in seconds
+	char		volname[MAX_NAME_LEN];
+} __attribute__((packed));
+
+typedef struct zvol_op_open_data zvol_op_open_data_t;
 
 /*
  * Payload data send in response to handshake on control connection. It tells
@@ -99,7 +125,8 @@ struct mgmt_ack {
 	uint64_t zvol_guid;
 	uint16_t port;
 	char	ip[MAX_IP_LEN];
-	char	volname[MAX_NAME_LEN];
+	char	volname[MAX_NAME_LEN]; // Replica helping rebuild
+	char	dw_volname[MAX_NAME_LEN]; // Replica being rebuilt
 } __attribute__((packed));
 
 typedef struct mgmt_ack mgmt_ack_t;
@@ -110,7 +137,8 @@ typedef struct mgmt_ack mgmt_ack_t;
 enum zvol_rebuild_status {
 	ZVOL_REBUILDING_INIT,		/* rebuilding initiated on zvol */
 	ZVOL_REBUILDING_IN_PROGRESS,	/* zvol is rebuilding */
-	ZVOL_REBUILDING_DONE		/* done with rebuilding */
+	ZVOL_REBUILDING_DONE,		/* done with rebuilding */
+	ZVOL_REBUILDING_FAILED		/* Rebuilding failed */
 } __attribute__((packed));
 
 typedef enum zvol_rebuild_status zvol_rebuild_status_t;


### PR DESCRIPTION
Implemented ZVOL_OPCODE_OPEN at iSCSI controller side. Now iSCSI controller will share timeout & block size info with uZFS at time of data_io connection handshake.
Unit test: Modified existing UT case to send ZVOL_OPCODE_OPEN with required info.