### PR TITLE
[US1299] Rebuild functionality added in iSCSI controller.

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -226,11 +226,11 @@ handle_data_conn_error(replica_t *r)
 	else if (r->state == ZVOL_STATUS_DEGRADED)
 		spec->degraded_rcount--;
 
-	if (spec->master_replica == r) {
-		REPLICA_ERRLOG("Replica %s %d was under rebuild,"
+	if (spec->target_replica == r) {
+		REPLICA_ERRLOG("Replica:%s port:%d was under rebuild,"
 		    " seting master_replica to NULL\n",
 		    r->ip, r->port);
-		spec->master_replica = NULL;
+		spec->target_replica = NULL;
 		spec->rebuild_in_progress = false;
 	}
 

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -225,15 +225,6 @@ handle_data_conn_error(replica_t *r)
 		spec->healthy_rcount--;
 	else if (r->state == ZVOL_STATUS_DEGRADED)
 		spec->degraded_rcount--;
-
-	if (spec->target_replica == r) {
-		REPLICA_ERRLOG("Replica:%s port:%d was under rebuild,"
-		    " seting master_replica to NULL\n",
-		    r->ip, r->port);
-		spec->target_replica = NULL;
-		spec->rebuild_in_progress = false;
-	}
-
 	update_volstate(r->spec);
 
 	mgmt_eventfd2 = r->mgmt_eventfd2;

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -226,6 +226,14 @@ handle_data_conn_error(replica_t *r)
 	else if (r->state == ZVOL_STATUS_DEGRADED)
 		spec->degraded_rcount--;
 
+	if (spec->master_replica == r) {
+		REPLICA_ERRLOG("Replica %s %d was under rebuild,"
+		    " seting master_replica to NULL\n",
+		    r->ip, r->port);
+		spec->master_replica = NULL;
+		spec->rebuild_in_progress = false;
+	}
+
 	update_volstate(r->spec);
 
 	mgmt_eventfd2 = r->mgmt_eventfd2;
@@ -641,5 +649,6 @@ replica_thread(void *arg)
 exit:
 	if (ret == -1)
 		handle_data_conn_error(r);
+	REPLICA_ERRLOG("replica_thread exiting ...\n");
 	return NULL;
 }

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -3107,7 +3107,7 @@ main(int argc, char **argv)
 	istgt_close_log();
 
 	/* Destroy mempool created for replication */
-	(void)destroy_relication_mempool();
+	(void)destroy_replication_mempool();
 
 	config = istgt->config;
 	istgt->config = NULL;

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -61,6 +61,7 @@ typedef struct replica_s {
 	int epfd;
 	int dont_free;
 
+	struct timespec create_time;
 	/*
 	 * this variable will be updated by only replica_thread,
 	 * so no lock required while updating this

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -18,6 +18,13 @@
 
 __thread char tinfo[50] = {0};
 int g_trace_flag = 0;
+typedef struct rebuild_test_s {
+	pthread_cond_t test_state_cv;
+	pthread_mutex_t test_mtx;
+	spec_t *spec;
+	bool replica_killing;
+	bool reregister_replica_test;
+} rebuild_test_t;
 
 typedef struct rargs_s {
 	/* IP:Port on which replica is listening */
@@ -64,8 +71,13 @@ typedef struct rargs_s {
 	char volname[MAX_NAME_LEN];
 	char file_path[MAX_NAME_LEN];
 
+	zvol_status_t 	zrepl_status;
+	zvol_rebuild_status_t zrepl_rebuild_status;
+	
+	int rebuild_status_enquiry;
 	/* flag to stop replica threads once this is set to 1 */
 	int kill_replica;
+	int kill_is_over;
 } rargs_t;
 
 
@@ -89,7 +101,9 @@ zio_cmd_alloc(zvol_io_hdr_t *hdr)
 	if ((hdr->opcode == ZVOL_OPCODE_WRITE) ||
 	    (hdr->opcode == ZVOL_OPCODE_HANDSHAKE) ||
 	    (hdr->opcode == ZVOL_OPCODE_REPLICA_STATUS) ||
-	    (hdr->opcode == ZVOL_OPCODE_OPEN)) {
+	    (hdr->opcode == ZVOL_OPCODE_OPEN) ||
+	    (hdr->opcode == ZVOL_OPCODE_START_REBUILD) ||
+	    (hdr->opcode == ZVOL_OPCODE_PREPARE_FOR_REBUILD)) {
 		zio_cmd->buf = malloc(sizeof (char) * hdr->len);
 	} else
 		zio_cmd->buf = NULL;
@@ -139,12 +153,13 @@ pthread_t *all_rthrds;
 /*
  * Handles ZVOL_OPCODE_OPEN mgmt command
  */
-static void handle_open(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
+static void
+handle_open(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 {
 	zvol_io_hdr_t *hdr = &(zio_cmd->hdr);
 	zvol_op_open_data_t *data = zio_cmd->buf;
 
-	REPLICA_ERRLOG("%d %s %d %d %d %s\n", rargs->replica_port, rargs->file_path, rargs->file_fd,
+	REPLICA_LOG("%d %s %d %d %d %s\n", rargs->replica_port, rargs->file_path, rargs->file_fd,
 	    data->timeout, data->tgt_block_size, data->volname);
 	free(zio_cmd->buf);
 	hdr->len = 0;
@@ -155,14 +170,43 @@ static void handle_open(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 /*
  * Handles ZVOL_OPCODE_REPLICA_STATUS mgmt command
  */
-static void handle_replica_status(zvol_io_cmd_t *zio_cmd)
+static void
+handle_replica_start_rebuild(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
+{
+	zvol_io_hdr_t *hdr = &(zio_cmd->hdr);
+
+	/* Mark rebuild is in progress */
+	rargs->zrepl_rebuild_status = ZVOL_REBUILDING_IN_PROGRESS;
+
+	if (zio_cmd->buf)
+		free(zio_cmd->buf);
+	hdr->len = 0;
+	zio_cmd->buf = NULL;
+	hdr->status = ZVOL_OP_STATUS_OK;
+}
+
+/*
+ * Handles ZVOL_OPCODE_REPLICA_STATUS mgmt command
+ */
+static void
+handle_replica_status(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 {
 	zvol_io_hdr_t *hdr = &(zio_cmd->hdr);
 	zrepl_status_ack_t *zrepl_status;
 
 	zrepl_status = malloc(sizeof (*zrepl_status));
-	zrepl_status->state = ZVOL_STATUS_HEALTHY;
-	zrepl_status->rebuild_status = ZVOL_REBUILDING_INIT;
+	/* After 2 enquiries, mark replica healthy */	
+	if ((rargs->zrepl_status != ZVOL_STATUS_HEALTHY) &&
+	    (rargs->rebuild_status_enquiry >= 2)) {
+		rargs->zrepl_status = ZVOL_STATUS_HEALTHY;
+		rargs->zrepl_rebuild_status = ZVOL_REBUILDING_DONE;
+		rargs->rebuild_status_enquiry = 0;
+	}
+
+	if (rargs->zrepl_rebuild_status == ZVOL_REBUILDING_IN_PROGRESS)
+		rargs->rebuild_status_enquiry++;
+	zrepl_status->state = rargs->zrepl_status;
+	zrepl_status->rebuild_status = rargs->zrepl_rebuild_status;
 
 	if (zio_cmd->buf)
 		free(zio_cmd->buf);
@@ -174,12 +218,14 @@ static void handle_replica_status(zvol_io_cmd_t *zio_cmd)
 /*
  * Handles ZVOL_OPCODE_HANDSHAKE mgmt command
  */
-static void handle_handshake(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
+static void
+handle_handshake(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 {
 	zvol_io_hdr_t *hdr = &(zio_cmd->hdr);
 
 	if (strcmp(zio_cmd->buf, rargs->volname) != 0)
-		REPLICA_ERRLOG("volname not matching %s %s\n", (char *)zio_cmd->buf, rargs->volname);
+		REPLICA_ERRLOG("volname not matching %s %s\n",
+		    (char *)zio_cmd->buf, rargs->volname);
 
 	mgmt_ack_t *mgmt_ack = malloc(sizeof (mgmt_ack_t));
 	memset(mgmt_ack, 0, sizeof (mgmt_ack_t));
@@ -221,7 +267,8 @@ uzfs_zvol_socket_write(int fd, char *buf, uint64_t nbytes)
 /*
  * This thread takes mgmt commands from mgmt_send_list and writes to mgmtfd
  */
-static void *mock_repl_mgmt_sender(void *args)
+static void *
+mock_repl_mgmt_sender(void *args)
 {
 	rargs_t *rargs = (rargs_t *)args;
 	zvol_io_cmd_t *zio_cmd;
@@ -232,8 +279,13 @@ static void *mock_repl_mgmt_sender(void *args)
 
 	while (1) {
 		MTX_LOCK(&rargs->mgmt_send_mtx);
-		while (TAILQ_EMPTY(&rargs->mgmt_send_list))
+		while (TAILQ_EMPTY(&rargs->mgmt_send_list)) {
 			pthread_cond_wait(&rargs->mgmt_send_cv, &rargs->mgmt_send_mtx);
+			if (rargs->kill_replica == true) {
+				MTX_UNLOCK(&rargs->mgmt_send_mtx);
+				goto end;
+			}
+		}
 		zio_cmd = TAILQ_FIRST(&rargs->mgmt_send_list);
 		TAILQ_REMOVE(&rargs->mgmt_send_list, zio_cmd, next);
 		MTX_UNLOCK(&rargs->mgmt_send_mtx);
@@ -249,13 +301,15 @@ static void *mock_repl_mgmt_sender(void *args)
 		zio_cmd_free(&zio_cmd);
 	}
 end:
+	REPLICA_LOG("mock_repl_mgmt_sender exiting....\n");
 	return NULL;
 }
 
 /*
  * This thread takes IOs from io_send_list and writes to iofd
  */
-static void *mock_repl_io_sender(void *args)
+static void *
+mock_repl_io_sender(void *args)
 {
 	rargs_t *rargs = (rargs_t *)args;
 	zvol_io_cmd_t *zio_cmd;
@@ -267,8 +321,13 @@ static void *mock_repl_io_sender(void *args)
 
 	while (1) {
 		MTX_LOCK(&rargs->io_send_mtx);
-		while (TAILQ_EMPTY(&rargs->io_send_list))
+		while (TAILQ_EMPTY(&rargs->io_send_list)) {
 			pthread_cond_wait(&rargs->io_send_cv, &rargs->io_send_mtx);
+			if (rargs->kill_replica == true) {
+				MTX_UNLOCK(&rargs->io_send_mtx);
+				goto end;
+			}
+		}
 		zio_cmd = TAILQ_FIRST(&rargs->io_send_list);
 		TAILQ_REMOVE(&rargs->io_send_list, zio_cmd, next);
 		MTX_UNLOCK(&rargs->io_send_mtx);
@@ -284,10 +343,12 @@ static void *mock_repl_io_sender(void *args)
 		zio_cmd_free(&zio_cmd);
 	}
 end:
+	REPLICA_LOG("mock_repl_io_sender exiting....\n");
 	return NULL;
 }
 
-static void handle_read(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
+static void
+handle_read(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 {
 	zvol_io_hdr_t *hdr = &(zio_cmd->hdr);
 	uint64_t offset = hdr->offset;
@@ -321,7 +382,8 @@ static void handle_read(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 	zio_cmd->buf = orig_data;
 }
 
-static void handle_write(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
+static void
+handle_write(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 {
 	int rc;
 	uint64_t nbytes = 0;
@@ -353,7 +415,8 @@ static void handle_write(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
  * This thread takes IOs from io_recv_list, executes them, and,
  * adds responses to io_send_list
  */
-static void *mock_repl_io_worker(void *args)
+static void *
+mock_repl_io_worker(void *args)
 {
 	rargs_t *rargs = (rargs_t *)args;
 	zvol_io_cmd_t *zio_cmd;
@@ -367,8 +430,13 @@ static void *mock_repl_io_worker(void *args)
 	clock_gettime(CLOCK_MONOTONIC, &prev);
 	while (1) {
 		MTX_LOCK(&rargs->io_recv_mtx);
-		while (TAILQ_EMPTY(&(rargs->io_recv_list)))
+		while (TAILQ_EMPTY(&(rargs->io_recv_list))) {
 			pthread_cond_wait(&rargs->io_recv_cv, &rargs->io_recv_mtx);
+			if (rargs->kill_replica == true) {
+				MTX_UNLOCK(&rargs->io_recv_mtx);
+				goto end;
+			}
+		}
 		zio_cmd = TAILQ_FIRST(&rargs->io_recv_list);
 		TAILQ_REMOVE(&rargs->io_recv_list, zio_cmd, next);
 		MTX_UNLOCK(&rargs->io_recv_mtx);
@@ -400,6 +468,8 @@ static void *mock_repl_io_worker(void *args)
 		pthread_cond_signal(&rargs->io_send_cv);
 		MTX_UNLOCK(&rargs->io_send_mtx);
 	}
+end:
+	REPLICA_LOG("mock_repl_io_worker exiting....\n");
 	return NULL;
 }
 
@@ -407,7 +477,8 @@ static void *mock_repl_io_worker(void *args)
  * This thread takes mgmt commands from mgmt_recv_list
  * executes them and adds to mgmt_send_list
  */
-static void *mock_repl_mgmt_worker(void *args)
+static void *
+mock_repl_mgmt_worker(void *args)
 {
 	rargs_t *rargs = (rargs_t *)args;
 	zvol_io_cmd_t *zio_cmd;
@@ -419,8 +490,13 @@ static void *mock_repl_mgmt_worker(void *args)
 
 	while (1) {
 		MTX_LOCK(&rargs->mgmt_recv_mtx);
-		while (TAILQ_EMPTY(&(rargs->mgmt_recv_list)))
+		while (TAILQ_EMPTY(&(rargs->mgmt_recv_list))) {
 			pthread_cond_wait(&rargs->mgmt_recv_cv, &rargs->mgmt_recv_mtx);
+			if (rargs->kill_replica == true) {
+				MTX_UNLOCK(&rargs->mgmt_recv_mtx);
+				goto end;
+			}
+		}
 		zio_cmd = TAILQ_FIRST(&rargs->mgmt_recv_list);
 		TAILQ_REMOVE(&rargs->mgmt_recv_list, zio_cmd, next);
 		MTX_UNLOCK(&rargs->mgmt_recv_mtx);
@@ -428,10 +504,14 @@ static void *mock_repl_mgmt_worker(void *args)
 		switch(hdr->opcode)
 		{
 			case ZVOL_OPCODE_HANDSHAKE:
+			case ZVOL_OPCODE_PREPARE_FOR_REBUILD:
 				handle_handshake(rargs, zio_cmd);
 				break;
 			case ZVOL_OPCODE_REPLICA_STATUS:
-				handle_replica_status(zio_cmd);
+				handle_replica_status(rargs, zio_cmd);
+				break;
+			case ZVOL_OPCODE_START_REBUILD:
+				handle_replica_start_rebuild(rargs, zio_cmd);
 				break;
 			default:
 				goto end;
@@ -443,13 +523,15 @@ static void *mock_repl_mgmt_worker(void *args)
 		MTX_UNLOCK(&rargs->mgmt_send_mtx);
 	}
 end:
+	REPLICA_LOG("mock_repl_mgmt_worker exiting....\n");
 	return NULL;
 }
 
 /*
  * This thread reads mgmt commands from mgmtfd and adds to mgmt_recv_list
  */
-static void *mock_repl_mgmt_receiver(void *args)
+static void *
+mock_repl_mgmt_receiver(void *args)
 {
 	rargs_t *rargs = (rargs_t *)args;
 	int rc;
@@ -470,7 +552,7 @@ static void *mock_repl_mgmt_receiver(void *args)
 
 		zio_cmd = zio_cmd_alloc(hdr);
 		/* Read payload for commands which have it */
-		if (zio_cmd->buf != NULL) {
+		if (hdr->len != 0) {
 			rc = uzfs_zvol_socket_read(rargs->mgmtfd, zio_cmd->buf, hdr->len);
 			if (rc != 0) {
 				zio_cmd_free(&zio_cmd);
@@ -491,13 +573,16 @@ static void *mock_repl_mgmt_receiver(void *args)
 		MTX_UNLOCK(&rargs->mgmt_recv_mtx);
 	}
 end:
+	free(hdr);
+	REPLICA_LOG("mock_repl_mgmt_receiver exiting....\n");
 	return NULL;
 }
 
 /*
  * This thread reads IOs from iofd and adds to io_recv_list
  */
-static void *mock_repl_io_receiver(void *args)
+static void *
+mock_repl_io_receiver(void *args)
 {
 	rargs_t *rargs = (rargs_t *)args;
 	int rc;
@@ -534,6 +619,8 @@ static void *mock_repl_io_receiver(void *args)
 		MTX_UNLOCK(&rargs->io_recv_mtx);
 	}
 end:
+	free(hdr);
+	REPLICA_LOG("mock_repl_io_receiver exiting....\n");
 	return NULL;
 }
 
@@ -586,6 +673,7 @@ mock_repl(void *args)
 	pthread_t io_receiver, io_sender, io_worker1, io_worker2, io_worker3;
 	struct sockaddr saddr;
 	socklen_t slen;
+	zvol_io_cmd_t *zio_cmd;
 
 	snprintf(tinfo, 50, "mock%d", rargs->replica_port);
 	prctl(PR_SET_NAME, tinfo, 0, 0, 0);
@@ -622,19 +710,81 @@ mock_repl(void *args)
 	TAILQ_INIT(&rargs->io_recv_list);
 	TAILQ_INIT(&rargs->io_send_list);
 
+	rargs->zrepl_status = ZVOL_STATUS_DEGRADED; 
+	rargs->zrepl_rebuild_status = ZVOL_REBUILDING_INIT;
+	rargs->rebuild_status_enquiry = 0;
+
 	pthread_create(&mgmt_receiver, NULL, &mock_repl_mgmt_receiver, args);
 	pthread_create(&mgmt_sender, NULL, &mock_repl_mgmt_sender, args);
 	pthread_create(&mgmt_worker, NULL, &mock_repl_mgmt_worker, args);
 
-	while (1) {
-		rargs->iofd = accept(sfd, &saddr, &slen);
-		pthread_create(&io_receiver, NULL, &mock_repl_io_receiver, args);
-		pthread_create(&io_sender, NULL, &mock_repl_io_sender, args);
-		pthread_create(&io_worker1, NULL, &mock_repl_io_worker, args);
-		pthread_create(&io_worker2, NULL, &mock_repl_io_worker, args);
-		pthread_create(&io_worker3, NULL, &mock_repl_io_worker, args);
-	}
 
+	rargs->iofd = accept(sfd, &saddr, &slen);
+	pthread_create(&io_receiver, NULL, &mock_repl_io_receiver, args);
+	pthread_create(&io_sender, NULL, &mock_repl_io_sender, args);
+	pthread_create(&io_worker1, NULL, &mock_repl_io_worker, args);
+	pthread_create(&io_worker2, NULL, &mock_repl_io_worker, args);
+	pthread_create(&io_worker3, NULL, &mock_repl_io_worker, args);
+	while(1) {
+		sleep(5);
+		if (rargs->kill_replica == true) {
+			REPLICA_ERRLOG("Killing replica:%s port:%d\n",
+			    rargs->replica_ip, rargs->replica_port);
+			pthread_cond_broadcast(&rargs->mgmt_recv_cv);
+			pthread_cond_broadcast(&rargs->mgmt_send_cv);
+			pthread_cond_broadcast(&rargs->io_recv_cv);
+			pthread_cond_broadcast(&rargs->io_send_cv);
+			sleep(5);
+			shutdown(rargs->mgmtfd, SHUT_RDWR);
+			shutdown(rargs->iofd, SHUT_RDWR);
+			close(rargs->mgmtfd);
+			close(rargs->iofd);
+			close(rargs->file_fd);
+			sleep(5);
+
+			while (!TAILQ_EMPTY(&(rargs->mgmt_recv_list))) {
+				zio_cmd = TAILQ_FIRST(&rargs->mgmt_recv_list);
+				TAILQ_REMOVE(&rargs->mgmt_recv_list, zio_cmd, next);
+				free(zio_cmd);
+			}
+
+			while (!TAILQ_EMPTY(&rargs->mgmt_send_list)) {
+				zio_cmd = TAILQ_FIRST(&rargs->mgmt_send_list);
+				TAILQ_REMOVE(&rargs->mgmt_send_list, zio_cmd, next);
+				free(zio_cmd);
+			}
+
+			while (!TAILQ_EMPTY(&(rargs->io_recv_list))) {
+				zio_cmd = TAILQ_FIRST(&rargs->io_recv_list);
+				TAILQ_REMOVE(&rargs->io_recv_list, zio_cmd, next);
+				free(zio_cmd);
+			}
+
+			while (!TAILQ_EMPTY(&rargs->io_send_list)) {
+				zio_cmd = TAILQ_FIRST(&rargs->io_send_list);
+				TAILQ_REMOVE(&rargs->io_send_list, zio_cmd, next);
+				free(zio_cmd);
+			}
+			rargs->mgmtfd = rargs->iofd = rargs->file_fd = -1;
+			pthread_mutex_destroy(&rargs->mgmt_recv_mtx);
+			pthread_mutex_destroy(&rargs->mgmt_send_mtx);
+
+			pthread_cond_destroy(&rargs->mgmt_recv_cv);
+			pthread_cond_destroy(&rargs->mgmt_send_cv);
+
+			pthread_mutex_destroy(&rargs->io_recv_mtx);
+			pthread_mutex_destroy(&rargs->io_send_mtx);
+
+			pthread_cond_destroy(&rargs->io_recv_cv);
+			pthread_cond_destroy(&rargs->io_send_cv);
+			rargs->kill_is_over = true;
+			REPLICA_ERRLOG("Killing of replica:%s port:%d"
+			    " completed\n", rargs->replica_ip, rargs->replica_port);
+			goto exit;
+		}
+	}
+exit:
+	REPLICA_LOG("mock_repl exiting....\n");
 	return NULL;
 }
 
@@ -665,6 +815,8 @@ create_mock_replicas(int replication_factor, char *volname)
 		rargs = &(all_rargs[i]);
 		strncpy(rargs->replica_ip, "127.0.0.1", MAX_IP_LEN);
 		rargs->replica_port = 6161 + i;
+		rargs->kill_replica = false;
+		rargs->kill_is_over = false;	
 
 		strncpy(rargs->ctrl_ip, "127.0.0.1", MAX_IP_LEN);
 		rargs->ctrl_port = 6060;
@@ -738,7 +890,8 @@ nicenumtoull(const char *buf)
 	return (val);
 }
 
-static void process_options(int argc, char **argv)
+static void
+process_options(int argc, char **argv)
 {
 	int opt;
 	uint64_t val = 0;
@@ -784,6 +937,63 @@ static void process_options(int argc, char **argv)
 	    total_time_in_sec, test_id);
 }
 
+static void *
+rebuild_test(void *arg)
+{
+	rebuild_test_t *test_args = (rebuild_test_t *)arg;
+	spec_t *spec = test_args->spec;
+	rargs_t *rargs = &(all_rargs[0]);
+	pthread_t replica_thread;
+	char filepath[50];
+
+	while (1) {
+		sleep(5);
+
+		if ((test_args->replica_killing == false) &&
+		    (spec->degraded_rcount == 0)) {
+			rargs = &(all_rargs[0]);
+			rargs->kill_replica = true;
+			test_args->replica_killing = true;
+			continue;
+		}
+		
+		if (rargs->kill_is_over == true) {
+			sleep(60);
+
+			strncpy(rargs->replica_ip, "127.0.0.1", MAX_IP_LEN);
+			rargs->replica_port = 6161 + spec->replication_factor + 1;
+			rargs->kill_replica = false;
+			rargs->kill_is_over = false;	
+
+			strncpy(rargs->ctrl_ip, "127.0.0.1", MAX_IP_LEN);
+			rargs->ctrl_port = 6060;
+
+			strncpy(rargs->volname, spec->volname, MAX_NAME_LEN);
+
+			snprintf(filepath, 45, "/tmp/test_vol%d", 1);
+			strncpy(rargs->file_path, filepath, MAX_NAME_LEN);
+
+			REPLICA_ERRLOG("Reconnecting new replica:%s port:%d\n",
+			    rargs->replica_ip, rargs->replica_port);
+			pthread_create(&replica_thread, NULL, &mock_repl, rargs);
+			test_args->reregister_replica_test = true;
+			continue;
+		}
+
+		if ((test_args->replica_killing == true) &&
+		    (test_args->reregister_replica_test == true) &&
+		    (spec->degraded_rcount == 0)) {
+			MTX_LOCK(&test_args->test_mtx);
+			pthread_cond_signal(&test_args->test_state_cv);
+			MTX_UNLOCK(&test_args->test_mtx);
+			goto exit;
+		}
+	}
+exit:
+	return NULL;
+}
+
+
 int
 main(int argc, char **argv)
 {
@@ -792,6 +1002,20 @@ main(int argc, char **argv)
 	int replication_factor = 3, consistency_factor = 2;
 	pthread_t replica_thread;
 	struct stat sbuf;
+	pthread_t rebuild_test_thread;
+	rebuild_test_t *test_args;
+
+	test_args = (rebuild_test_t *)malloc(sizeof (rebuild_test_t));
+	rc = pthread_cond_init(&test_args->test_state_cv, NULL);
+	if (rc != 0) {
+		REPLICA_ERRLOG("cond_init() failed errno:%d\n", errno);
+		return -1;
+	}
+
+	pthread_mutex_init(&test_args->test_mtx, NULL);
+	test_args->spec = spec;
+	test_args->replica_killing = false;
+	test_args->reregister_replica_test = false;
 
 	process_options(argc, argv);
 	rc = pthread_mutexattr_init(&mutex_attr);
@@ -838,6 +1062,12 @@ main(int argc, char **argv)
 	spec->ready = false;
 
 	create_mock_replicas(spec->replication_factor, spec->volname);
+	pthread_create(&rebuild_test_thread, NULL, &rebuild_test, (void *)test_args);
+
+	MTX_LOCK(&test_args->test_mtx);
+	pthread_cond_wait(&test_args->test_state_cv, &test_args->test_mtx);
+	MTX_UNLOCK(&test_args->test_mtx);
+
 	create_mock_client(spec);
 
 	return 0;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -820,12 +820,18 @@ typedef struct istgt_lu_disk_t {
 	rte_smempool_t rcommon_deadlist;	// Contains completed IOs
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
 	TAILQ_HEAD(, replica_s) rwaitq; //Queue of replicas completed handshake, and yet to have data connection to this spec(volume)
-	int replica_count;
+	int replica_io_timeout;
 	int replication_factor;
 	int consistency_factor;
 	int healthy_rcount;
 	int degraded_rcount;
 	bool ready;
+	bool rebuild_in_progress;
+	int rebuild_replica_count;
+	int rebuild_info_ack_recvd;
+	struct replica_s *master_replica;
+	mgmt_ack_t *rebuild_info;
+
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/
 	pthread_mutex_t rq_mtx; 

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -820,17 +820,13 @@ typedef struct istgt_lu_disk_t {
 	rte_smempool_t rcommon_deadlist;	// Contains completed IOs
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
 	TAILQ_HEAD(, replica_s) rwaitq; //Queue of replicas completed handshake, and yet to have data connection to this spec(volume)
-	int replica_io_timeout;
 	int replication_factor;
 	int consistency_factor;
 	int healthy_rcount;
 	int degraded_rcount;
 	bool ready;
 	bool rebuild_in_progress;
-	int rebuild_replica_count;
-	int rebuild_info_ack_recvd;
-	struct replica_s *master_replica;
-	mgmt_ack_t *rebuild_info;
+	struct replica_s *target_replica;
 
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/

--- a/src/replication.h
+++ b/src/replication.h
@@ -114,6 +114,13 @@ typedef struct io_data_chunk {
 } io_data_chunk_t;
 
 TAILQ_HEAD(io_data_chunk_list_t, io_data_chunk);
+/*
+ * struct can be used in multithreaded scope and in single thread scope.
+ * Multithreaded scope - snapshot create
+ * Single threade scope - prepare_for_rebuild
+ * So if you are using it in multithreaded scope, use mutex for
+ * thread safe access.
+ */
 typedef struct rcommon_mgmt_cmd {
 	int cmds_sent; // total cmds sent
 	int cmds_succeeded; // success responses received
@@ -168,7 +175,7 @@ int64_t perform_read_write_on_fd(int fd, uint8_t *data, uint64_t len,
 int initialize_volume(spec_t *spec, int, int);
 
 /* Replica default timeout is 200 seconds */
-#define	REPLICA_DEFAULT_TIMEOUT	1
+#define	REPLICA_DEFAULT_TIMEOUT	200
 
 #define REPLICA_LOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_NOTICELOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)

--- a/src/replication.h
+++ b/src/replication.h
@@ -119,7 +119,9 @@ typedef struct rcommon_mgmt_cmd {
 	int cmds_succeeded; // success responses received
 	int cmds_failed; // failure responses received
 	int caller_gone; // thread that is waiting for responses is gone?
+	uint64_t buf_size;
 	pthread_mutex_t mtx;
+	void *buf;
 } rcommon_mgmt_cmd_t;
 
 typedef struct mgmt_cmd_s {
@@ -166,7 +168,7 @@ int64_t perform_read_write_on_fd(int fd, uint8_t *data, uint64_t len,
 int initialize_volume(spec_t *spec, int, int);
 
 /* Replica default timeout is 200 seconds */
-#define	REPLICA_DEFAULT_TIMEOUT	200
+#define	REPLICA_DEFAULT_TIMEOUT	1
 
 #define REPLICA_LOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_NOTICELOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -22,7 +22,7 @@ __thread char  tinfo[50] =  {0};
 	mgmt_ack_hdr = (zvol_io_hdr_t *)malloc(sizeof(zvol_io_hdr_t));\
 	mgmt_ack_hdr->opcode = opcode;\
 	mgmt_ack_hdr->version = REPLICA_VERSION;\
-	mgmt_ack_hdr->len = sizeof(mgmt_ack_data_t);\
+	mgmt_ack_hdr->len = sizeof (mgmt_ack_data_t);\
 	mgmt_ack_hdr->status = ZVOL_OP_STATUS_OK;\
 	mgmt_ack_hdr->checkpointed_io_seq = 1000;\
 }
@@ -210,19 +210,21 @@ test_read_data(int fd, uint8_t *data, uint64_t len)
 	return nbytes;
 }
 
-int
-send_mgmtack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip, int replica_port)
+static int
+send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
+    int replica_port, zrepl_status_ack_t *zrepl_status,
+    int *zrepl_status_msg_cnt)
 {
-	zvol_io_hdr_t *mgmt_ack_hdr = NULL;
 	int i, nbytes = 0;
 	int rc = 0, start;
 	struct iovec iovec[6];
-	build_mgmt_ack_hdr;
 	int iovec_count;
-	zrepl_status_ack_t repl_status;
+	zvol_io_hdr_t *mgmt_ack_hdr = NULL;
 	mgmt_ack_t *mgmt_ack_data = NULL;
 	int ret = -1;
 
+	/* Init mgmt_ack_hdr */
+	build_mgmt_ack_hdr;
 	iovec[0].iov_base = mgmt_ack_hdr;
 	iovec[0].iov_len = 16;
 
@@ -248,14 +250,25 @@ send_mgmtack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip, int rep
 		mgmt_ack_hdr->status = (random() % 5 == 0) ? ZVOL_OP_STATUS_FAILED : ZVOL_OP_STATUS_OK;
 		mgmt_ack_hdr->len = 0;
 	} else if (opcode == ZVOL_OPCODE_REPLICA_STATUS) {
-		if (degraded_mode)
-			repl_status.state = ZVOL_STATUS_DEGRADED;
-		else
-			repl_status.state = ZVOL_STATUS_HEALTHY;
-		mgmt_ack_hdr->len = sizeof(zrepl_status_ack_t);
+		if (((*zrepl_status_msg_cnt) >= 2) &&
+		    (zrepl_status->state != ZVOL_STATUS_HEALTHY)) {
+			zrepl_status->state = ZVOL_STATUS_HEALTHY;
+			zrepl_status->rebuild_status = ZVOL_REBUILDING_DONE;
+			(*zrepl_status_msg_cnt) = 0;
+		}
+
+		if (zrepl_status->rebuild_status == ZVOL_REBUILDING_IN_PROGRESS) {
+			(*zrepl_status_msg_cnt) += 1;
+		}
+
+		mgmt_ack_hdr->len = sizeof (zrepl_status_ack_t);
 		iovec_count = 4;
-		iovec[3].iov_base = &repl_status;
-		iovec[3].iov_len = sizeof(zrepl_status_ack_t);
+		iovec[3].iov_base = zrepl_status;
+		iovec[3].iov_len = sizeof (zrepl_status_ack_t);
+	} else if (opcode == ZVOL_OPCODE_START_REBUILD) {
+		zrepl_status->rebuild_status = ZVOL_REBUILDING_IN_PROGRESS;
+		mgmt_ack_hdr->len = 0;
+		iovec_count = 3;
 	} else {
 		build_mgmt_ack_data;
 
@@ -270,10 +283,10 @@ send_mgmtack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip, int rep
 		iovec_count = 6;
 	}
 
-	for (start = 0; start < iovec_count; start += 2) {
-		nbytes = iovec[start].iov_len + iovec[start + 1].iov_len;
+	for (start = 0; start < iovec_count; start += 1) {
+		nbytes = iovec[start].iov_len;
 		while (nbytes) {
-			rc = writev(fd, &iovec[start], 2);//Review iovec in this line
+			rc = writev(fd, &iovec[start], 1);//Review iovec in this line
 			if (rc < 0) {
 				goto out;
 			}
@@ -281,7 +294,7 @@ send_mgmtack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip, int rep
 			if (nbytes == 0)
 				break;
 			/* adjust iovec length */
-			for (i = start; i < start + 2; i++) {
+			for (i = start; i < start + 1; i++) {
 				if (iovec[i].iov_len != 0 && iovec[i].iov_len > (size_t)rc) {
 					iovec[i].iov_base
 						= (void *) (((uintptr_t)iovec[i].iov_base) + rc);
@@ -380,6 +393,8 @@ int
 main(int argc, char **argv)
 {
 	char ctrl_ip[MAX_IP_LEN];
+	zrepl_status_ack_t *zrepl_status;
+	int zrepl_status_msg_cnt = 0;
 	int ctrl_port = 0;
 	char replica_ip[MAX_IP_LEN];
 	int replica_port = 0;
@@ -454,7 +469,9 @@ main(int argc, char **argv)
 	vol_fd = open(test_vol, O_RDWR, 0666);
 	io_hdr = malloc(sizeof(zvol_io_hdr_t));
 	mgmtio = malloc(sizeof(zvol_io_hdr_t));
-
+	zrepl_status = (zrepl_status_ack_t *)malloc(sizeof (zrepl_status_ack_t));
+	zrepl_status->state = ZVOL_STATUS_DEGRADED; 
+	zrepl_status->rebuild_status = ZVOL_REBUILDING_INIT; 
 	if (init_mdlist(test_vol)) {
 		REPLICA_ERRLOG("Failed to initialize mdlist\n");
 		close(vol_fd);
@@ -525,7 +542,7 @@ main(int argc, char **argv)
 					count = test_read_data(events[i].data.fd, (uint8_t *)data, mgmtio->len);
 				}
 				opcode = mgmtio->opcode;
-				send_mgmtack(mgmtfd, opcode, data, replica_ip, replica_port);
+				send_mgmt_ack(mgmtfd, opcode, data, replica_ip, replica_port, zrepl_status, &zrepl_status_msg_cnt);
 			} else if (events[i].data.fd == sfd) {
 				struct sockaddr saddr;
 				socklen_t slen;

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -330,10 +330,10 @@ run_read_consistency_test ()
 		echo "read consistency test passed"
 	fi
 
-	kill -9 $replica1_pid $replica2_pid $replica3_pid
-	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
 	logout_of_volume
+	kill -9 $replica1_pid $replica2_pid $replica3_pid
 	stop_istgt
+	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
 }
 
 run_data_integrity_test


### PR DESCRIPTION
Rebuild functionality has been added in iSCSI controller. This code suppose to handle
1. Mesh rebuild i.e. iSCSI controller failure.
2. Normal rebuild i.e. rebuild from healthy replica.

What can be expected from this PR ?
1. Code should be able to handle iSCSI controller crash i.e. electing on replica for rebuild and rebuild this replica with the help of all other replicas. Mark this replica healthy and pick next replica for rebuild.
2. Rebuild was going on a replica, rebuild failed because of different reasons. It should able to handle failure case and kick-start rebuild again.
3. New replica got added, code should be able to kick-start rebuild on this replica.
4. Replica got disconnected, code should be able to see if replication_factor and consistency factor requirement is matching or not. Based on that it mark volume healthy or degraded. That way read request on target will decide if they need to read it from all online replicas or from just one.

What is missing from this PR ?
This code is not handling the case where we have consistency factor == 1 and replication factor == 1. So in that case if there is just one replica, it should be marked healthy at uZFS side. I am creating task for this.

 

Signed-off-by: satbir <satbir.chhikara@gmail.com>