### PR TITLE
debug build support for ISTGT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 #
 # Normal rules
 #
-*.[oa]
+*.[oais]
 *.lo
 *.la
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
 install:
-    - ./configure --with-replication
+    - ./configure --enable-debug --enable-replication
     - sudo make
 script:
     # run ztest and test supported zio backends

--- a/configure
+++ b/configure
@@ -622,7 +622,9 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 ALLOW_SYMLINK_DEVICE
+REPLICATION
 DEBUG
+TRACEDUMP
 mediadir
 configdir
 MKDEP
@@ -699,11 +701,12 @@ enable_largefile
 with_configdir
 with_mediadir
 with_rcdir
+enable_tracedump
 enable_debug
+enable_replication
 enable_symlink_device
 with_logfacility
 with_logpriority
-with_replication
 with_vbox
 with_vboxlib
 '
@@ -1333,7 +1336,9 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --disable-largefile     omit support for large files
-  --enable-debug          enable debug(logging)
+  --enable-tracedump      enable tracedump(logging)
+  --enable-debug          enable debug
+  --enable-replication    enable replication feature
   --enable-symlink-device allow symlink device
 
 Optional Packages:
@@ -3390,14 +3395,6 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 case "$host_os" in
 *linux*)
-# Check whether --with-replication was given.
-if test "${with_replication+set}" = set; then :
- cat >>confdefs.h <<_ACEOF
-#define REPLICATION
-_ACEOF
-LIBS="-lm $LIBS"
-fi
-
 	tmp="/usr/src/virtualbox/*/include"
 	if test -d "`echo $tmp`"; then
 	    vboxinc=$tmp
@@ -4751,14 +4748,46 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 CFLAGS="$saved_CFLAGS"
 
 # check enable features
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to use debug mode" >&5
-$as_echo_n "checking whether to use debug mode... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to dump packet data (tracedump mode)" >&5
+$as_echo_n "checking whether to dump packet data (tracedump mode)... " >&6; }
+# Check whether --enable-tracedump was given.
+if test "${enable_tracedump+set}" = set; then :
+  enableval=$enable_tracedump; { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; };
+$as_echo "#define TRACEDUMP 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable debug mode" >&5
+$as_echo_n "checking whether to enable debug mode... " >&6; }
 # Check whether --enable-debug was given.
 if test "${enable_debug+set}" = set; then :
   enableval=$enable_debug; { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; };
 $as_echo "#define DEBUG 1" >>confdefs.h
 
+  CFLAGS="-DDEBUG -Werror -ggdb3 -fstack-check"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable replication mode" >&5
+$as_echo_n "checking whether to enable replication mode... " >&6; }
+# Check whether --enable-replication was given.
+if test "${enable_replication+set}" = set; then :
+  enableval=$enable_replication; { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; };
+$as_echo "#define REPLICATION 1" >>confdefs.h
+
+  LIBS="$LIBS -lm"
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/configure
+++ b/configure
@@ -3312,7 +3312,7 @@ $as_echo "$MKDIR_P" >&6; }
 
 # clagn with -O3
 if test "$CC" = "clang" && test "$ac_test_CFLAGS" != "set"; then
-  CFLAGS="-g -O3"
+  CFLAGS="-g -O3 -DNDEBUG"
 fi
 
 # host OS related

--- a/configure.in
+++ b/configure.in
@@ -15,7 +15,7 @@ AC_PROG_MKDIR_P
 
 # clagn with -O3
 if test "$CC" = "clang" && test "$ac_test_CFLAGS" != "set"; then
-  CFLAGS="-g -O3"
+  CFLAGS="-g -O3 -DNDEBUG"
 fi
 
 # host OS related

--- a/configure.in
+++ b/configure.in
@@ -160,12 +160,28 @@ AC_TRY_COMPILE(,,
 CFLAGS="$saved_CFLAGS"
 
 # check enable features
-AC_MSG_CHECKING([whether to use debug mode])
+AC_MSG_CHECKING([whether to dump packet data (tracedump mode)])
+AC_ARG_ENABLE([tracedump],
+  AS_HELP_STRING([--enable-tracedump], [enable tracedump(logging)]),
+  AC_MSG_RESULT(yes); AC_DEFINE([TRACEDUMP], 1, [Define if enable tracedump]),
+  AC_MSG_RESULT(no))
+AC_SUBST([TRACEDUMP])
+
+AC_MSG_CHECKING([whether to enable debug mode])
 AC_ARG_ENABLE([debug],
-  AS_HELP_STRING([--enable-debug], [enable debug(logging)]),
-  AC_MSG_RESULT(yes); AC_DEFINE([DEBUG], 1, [Define if enable debug]),
+  AS_HELP_STRING([--enable-debug], [enable debug]),
+  AC_MSG_RESULT(yes); AC_DEFINE([DEBUG], 1, [Define if enable debug])
+  CFLAGS="-DDEBUG -Werror -ggdb3 -fstack-check",
   AC_MSG_RESULT(no))
 AC_SUBST([DEBUG])
+
+AC_MSG_CHECKING([whether to enable replication mode])
+AC_ARG_ENABLE([replication],
+  AS_HELP_STRING([--enable-replication], [enable replication feature]),
+  AC_MSG_RESULT(yes); AC_DEFINE([REPLICATION], 1, [Define if enable replication])
+  LIBS="$LIBS -lm",
+  AC_MSG_RESULT(no))
+AC_SUBST([REPLICATION])
 
 AC_MSG_CHECKING([whether to use symlink device])
 AC_ARG_ENABLE([symlink-device],

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -26,7 +26,6 @@ MKDIR_P  = @MKDIR_P@
 RANLIB   = @RANLIB@
 MKDEP	 = @MKDEP@
 
-CFLAGS  += -DDEBUG -ggdb3
 CFLAGS  += -fno-strict-aliasing -Wstrict-aliasing
 CFLAGS  += -Wformat=2 -Wreturn-type
 CFLAGS  += -Wbad-function-cast

--- a/src/assert.h
+++ b/src/assert.h
@@ -1,0 +1,115 @@
+#ifndef	_REPLICATION_ASSERT_H
+#define	_REPLICATION_ASSERT_H
+
+#include <replication.h>
+#include <assert.h>
+
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#ifdef verify
+#undef verify
+#endif
+
+#define	VERIFY(cond)							\
+do {									\
+	if (!(cond)) {							\
+		fprintf(stderr, "%s(%s:%d): assertion occurred for %s",	\
+		    __FILE__, __FUNCTION__, __LINE__, #cond);		\
+	    abort();							\
+	}								\
+} while (0)
+
+#define	verify(cond)							\
+do {									\
+	if (!(cond)) {							\
+		fprintf(stderr, "%s(%s:%d): assertion occurred for %s",\
+		    __FILE__, __FUNCTION__, __LINE__, #cond);		\
+	    abort();							\
+	}								\
+} while (0)
+
+#define	VERIFY3_IMPL(LEFT, OP, RIGHT, TYPE)				\
+do {									\
+	const TYPE __left = (TYPE)(LEFT);				\
+	const TYPE __right = (TYPE)(RIGHT);				\
+	if (!(__left OP __right)) {					\
+		fprintf(stderr, "%s(%s:%d): assrtion occurred .. "	\
+		    "%s %s %s (0x%llx %s 0x%llx)", __FILE__, 		\
+		    __FUNCTION__, __LINE__, #LEFT, #OP, #RIGHT, 	\
+		    (unsigned long long int)__left, #OP, 		\
+		    (unsigned long long int)__right);			\
+		abort();						\
+	}								\
+} while (0)
+
+#define	VERIFY3S(x, y, z)	VERIFY3_IMPL(x, y, z, int64_t)
+#define	VERIFY3U(x, y, z)	VERIFY3_IMPL(x, y, z, uint64_t)
+#define	VERIFY3P(x, y, z)	VERIFY3_IMPL(x, y, z, uintptr_t)
+#define	VERIFY0(x)		VERIFY3_IMPL(x, ==, 0, uint64_t)
+
+#ifdef assert
+#undef assert
+#endif
+
+/* Compile time assert */
+#define	CTASSERT_GLOBAL(x)		_CTASSERT(x, __LINE__)
+#define	CTASSERT(x)			{ _CTASSERT(x, __LINE__); }
+#define	_CTASSERT(x, y)			__CTASSERT(x, y)
+#define	__CTASSERT(x, y)						\
+	typedef char __attribute__((unused))				\
+	__compile_time_assertion__ ## y[(x) ? 1 : -1]
+
+#ifndef DEBUG
+#define	ASSERT3S(x, y, z)	((void)0)
+#define	ASSERT3U(x, y, z)	((void)0)
+#define	ASSERT3P(x, y, z)	((void)0)
+#define	ASSERT0(x)		((void)0)
+#define	ASSERT(x)		((void)0)
+#define	assert(x)		((void)0)
+#define	ASSERTV(x)
+#define	IMPLY(A, B)		((void)0)
+#define	EQUIV(A, B)		((void)0)
+#else
+#define	ASSERT3S(x, y, z)	VERIFY3S(x, y, z)
+#define	ASSERT3U(x, y, z)	VERIFY3U(x, y, z)
+#define	ASSERT3P(x, y, z)	VERIFY3P(x, y, z)
+#define	ASSERT0(x)		VERIFY0(x)
+#define	ASSERT(x)		VERIFY(x)
+#define	assert(x)		VERIFY(x)
+#define	ASSERTV(x)		x
+#define	IMPLY(A, B) \
+	((void)(((!(A)) || (B)) || \
+	    REPLICA_ERRLOG("(" %s ") implies (" %s ")", \
+	    #A, #B)))
+#define	EQUIV(A, B) \
+	((void)((!!(A) == !!(B)) || \
+	    REPLICA_ERRLOG("(" %s ") is equivalent to (" %s ")", \
+	    #A, #B)))
+
+#endif  /* DEBUG */
+
+#endif /* _REPLICATION_ASSERT_H */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -6,6 +6,9 @@
 /* Define if enable debug */
 #undef DEBUG
 
+/* Define if packet data dump or tracedump enable */
+#undef TRACEDUMP
+
 /* Define if enable replication */
 #undef REPLICATION
 

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -187,7 +187,7 @@ respond_with_error_for_all_outstanding_ios(replica_t *r)
 	rcommon_cmd_t *rcomm_cmd;
 	pthread_cond_t *cond_var;
 
-	VERIFY(r->data_eventfd == -1);
+	ASSERT(r->data_eventfd == -1);
 
 	while ((rcmd = dequeue_replica_cmdq(r)) != NULL)
 		move_to_blocked_or_ready_q(r, rcmd);
@@ -319,7 +319,7 @@ read_cmd(replica_t *r)
 
 	switch(state) {
 		case READ_IO_RESP_HDR:
-			VERIFY(r->io_read < sizeof(zvol_io_hdr_t));
+			ASSERT(r->io_read < sizeof(zvol_io_hdr_t));
 			reqlen = sizeof (zvol_io_hdr_t) - (r->io_read);
 			count = perform_read_write_on_fd(fd,
 			    ((uint8_t *)resp_hdr) + (r->io_read), reqlen, state);
@@ -364,6 +364,12 @@ read_cmd(replica_t *r)
 					return READ_PARTIAL;
 			}
 			return READ_COMPLETED;
+		default:
+			REPLICA_ERRLOG("got invalid read state(%d) for "
+			    "replica(%lu).. aborting..\n", state,
+			    r->zvol_guid);
+			abort();
+			break;
 	}
 	return -1;
 }
@@ -374,7 +380,7 @@ write_cmd(int fd, rcmd_t *cmd)
 	ssize_t rc;
 	int err, i;
 
-	VERIFY(cmd->iovcnt > 0);
+	ASSERT(cmd->iovcnt > 0);
 start:
 	rc = writev(fd, cmd->iov, cmd->iovcnt);
 	err = errno;

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -8,6 +8,7 @@
 #include "replication.h"
 #include "replication_misc.h"
 #include "ring_mempool.h"
+#include "assert.h"
 
 #define	READ_PARTIAL	1
 #define	READ_COMPLETED	2
@@ -42,7 +43,7 @@ int replica_timeout = REPLICA_DEFAULT_TIMEOUT;
 	}								\
 }
 
-#define SEND_ERROR_RESPONSES(head, _cond) {				\
+#define SEND_ERROR_RESPONSES(r, head, _cond) {				\
 	rcmd = TAILQ_FIRST(head);					\
 	while (rcmd != NULL) {						\
 		next_rcmd = TAILQ_NEXT(rcmd, next);			\
@@ -56,6 +57,9 @@ int replica_timeout = REPLICA_DEFAULT_TIMEOUT;
 		    ZVOL_OP_STATUS_FAILED;				\
 		rcomm_cmd->resp_list[idx].data_ptr = NULL;		\
 		rcomm_cmd->resp_list[idx].status |= RECEIVED_ERR;	\
+		REPLICA_DEBUGLOG("error set for command(%lu) for "	\
+		    "replica(%s:%d)\n", rcomm_cmd->io_seq, r->ip,	\
+		    r->port);						\
 		if (rcomm_cmd->state != CMD_EXECUTION_DONE)		\
 			pthread_cond_signal(_cond);			\
 		free(rcmd->iov_data);					\
@@ -183,12 +187,14 @@ respond_with_error_for_all_outstanding_ios(replica_t *r)
 	rcommon_cmd_t *rcomm_cmd;
 	pthread_cond_t *cond_var;
 
+	VERIFY(r->data_eventfd == -1);
+
 	while ((rcmd = dequeue_replica_cmdq(r)) != NULL)
 		move_to_blocked_or_ready_q(r, rcmd);
 
-	SEND_ERROR_RESPONSES((&(r->waitq)), cond_var);
-	SEND_ERROR_RESPONSES((&(r->readyq)), cond_var);
-	SEND_ERROR_RESPONSES((&(r->blockedq)), cond_var);
+	SEND_ERROR_RESPONSES(r, (&(r->waitq)), cond_var);
+	SEND_ERROR_RESPONSES(r, (&(r->readyq)), cond_var);
+	SEND_ERROR_RESPONSES(r, (&(r->blockedq)), cond_var);
 }
 
 /*
@@ -313,6 +319,7 @@ read_cmd(replica_t *r)
 
 	switch(state) {
 		case READ_IO_RESP_HDR:
+			VERIFY(r->io_read < sizeof(zvol_io_hdr_t));
 			reqlen = sizeof (zvol_io_hdr_t) - (r->io_read);
 			count = perform_read_write_on_fd(fd,
 			    ((uint8_t *)resp_hdr) + (r->io_read), reqlen, state);
@@ -367,6 +374,7 @@ write_cmd(int fd, rcmd_t *cmd)
 	ssize_t rc;
 	int err, i;
 
+	VERIFY(cmd->iovcnt > 0);
 start:
 	rc = writev(fd, cmd->iov, cmd->iovcnt);
 	err = errno;

--- a/src/init.sh
+++ b/src/init.sh
@@ -74,10 +74,6 @@ touch $path/$volname
 truncate -s $size $path/$volname
 export externalIP=$externalIP
 echo $external
-touch $path/sdisk.img
-truncate -s $size $path/sdisk.img
-touch /tmp/ztest1.0a
-truncate -s 1G /tmp/ztest1.0a
 service rsyslog start
 #setting replica timeout to 20 seconds
 /usr/local/bin/istgt -R 20 &

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -3107,7 +3107,7 @@ main(int argc, char **argv)
 	istgt_close_log();
 
 	/* Destroy mempool created for replication */
-	(void)destroy_relication_mempool();
+	(void)destroy_replication_mempool();
 
 	config = istgt->config;
 	istgt->config = NULL;

--- a/src/istgt.h
+++ b/src/istgt.h
@@ -50,6 +50,7 @@
 
 #include <pthread.h>
 #include <signal.h>
+#include <sys/syscall.h>
 #include "istgt_log.h"
 #include "istgt_conf.h"
 
@@ -180,6 +181,8 @@
 			pthread_exit(NULL);				\
 		}							\
 	} while (0)
+
+#define	MTX_LOCKED(MTX)	((MTX)->__data.__owner == syscall(SYS_gettid))
 
 typedef struct istgt_portal_t {
 	char *label;

--- a/src/istgt_log.h
+++ b/src/istgt_log.h
@@ -68,7 +68,7 @@ extern __thread char tinfo[50];
 		if (g_trace_flag & FLAG)		\
 			syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__); \
 	} while (0)
-#ifdef DEBUG
+#ifdef TRACEDUMP
 #define ISTGT_TRACEDUMP(FLAG, LABEL, BUF, LEN)				\
 	do {								\
 		if (g_trace_flag & (FLAG)) {				\
@@ -77,7 +77,7 @@ extern __thread char tinfo[50];
 	} while (0)
 #else
 #define ISTGT_TRACEDUMP(FLAG, LABEL, BUF, LEN)
-#endif /* DEBUG */
+#endif /* TRACEDUMP */
 
 int istgt_set_log_facility(const char *facility);
 int istgt_set_log_priority(const char *priority);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1952,8 +1952,6 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 				rc = cmd->data_len = rcomm_cmd->data_len;
 			}
 			rcomm_cmd->state = CMD_EXECUTION_DONE;
-			put_to_mempool(&spec->rcommon_deadlist, rcomm_cmd);
-			MTX_UNLOCK(rcomm_cmd->mutex);
 
 			/*
 			 * NOTE: This is for debugging purpose only
@@ -1966,6 +1964,8 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 			TAILQ_REMOVE(&spec->rcommon_waitq, rcomm_cmd, wait_cmd_next);
 			MTX_UNLOCK(&spec->rq_mtx);
 
+			put_to_mempool(&spec->rcommon_deadlist, rcomm_cmd);
+			MTX_UNLOCK(rcomm_cmd->mutex);
 			break;
 		}
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -155,7 +155,7 @@ int zvol_handshake(spec_t *, replica_t *);
 void accept_mgmt_conns(int, int);
 int send_io_resp(int fd, zvol_io_hdr_t *, void *);
 int initialize_replication_mempool(bool should_fail);
-int destroy_relication_mempool(void);
+int destroy_replication_mempool(void);
 void clear_rcomm_cmd(rcommon_cmd_t *);
 void ask_replica_status(spec_t *spec, replica_t *replica);
 extern void * replica_thread(void *);
@@ -172,6 +172,12 @@ int initialize_volume(spec_t *spec, int, int);
 #define REPLICA_NOTICELOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_ERRLOG(fmt, ...)	syslog(LOG_ERR, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
 #define REPLICA_WARNLOG(fmt, ...)	syslog(LOG_ERR, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
+
+#ifdef	DEBUG
+#define REPLICA_DEBUGLOG(fmt, ...)	syslog(LOG_NOTICE, "%-18.18s:%4d: %-20.20s: " fmt, __func__, __LINE__, tinfo, ##__VA_ARGS__)
+#else
+#define REPLICA_DEBUGLOG(fmt, ...)
+#endif
 
 #endif /* _REPLICATION_H */
 

--- a/src/ring_mempool.c
+++ b/src/ring_mempool.c
@@ -1,4 +1,5 @@
 #include "ring_mempool.h"
+#include "assert.h"
 
 int
 init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size,
@@ -9,6 +10,8 @@ init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size,
 	void *mem_entry = NULL;
 	int rc = 0;
 
+	ASSERT(count);
+
 	obj->entry_offset = offset;
 	obj->ring = rte_ring_create(ring_name, count, -1, RING_F_EXACT_SZ);
 	obj->create = mem_init;
@@ -16,6 +19,7 @@ init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size,
 	obj->reclaim = mem_reclaim;
 
 	if (!initialize) {
+		ASSERT0(mem_size);
 		obj->length = count;
 	} else {
 		for (i = 0; i < count; i++, mem_entry = NULL) {
@@ -74,11 +78,7 @@ destroy_mempool(rte_smempool_t *obj)
 		free(entry);
 	}
 
-	if (rte_ring_count(obj->ring) != 0) {
-		printf("allocation happened while destroying mempool\n");
-		return -1;
-	}
-
+	ASSERT0(rte_ring_count(obj->ring));
 	rte_ring_free(obj->ring);
 	return 0;
 }

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -332,10 +332,10 @@ run_read_consistency_test ()
 		echo "read consistency test passed"
 	fi
 
+	logout_of_volume
 	kill -9 $replica1_pid $replica2_pid $replica3_pid
 	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
 	rm -rf $file_name $device_file
-	logout_of_volume
 	stop_istgt
 }
 

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -93,10 +93,12 @@ write_and_verify_data(){
 		hash2=$(md5sum /mnt/store/file1 | awk '{print $1}')
 		if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
 		else
+			rm file1
 			echo "DI Test: FAILED";
 			tail -20 /var/log/syslog
 			exit 1
 		fi
+		rm file1
 
 		umount /mnt/store
 		logout_of_volume
@@ -332,6 +334,7 @@ run_read_consistency_test ()
 
 	kill -9 $replica1_pid $replica2_pid $replica3_pid
 	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
+	rm -rf $file_name $device_file
 	logout_of_volume
 	stop_istgt
 }


### PR DESCRIPTION
Changes : 

- Added debug build support
    - To enable debug build, configure with `--enable-debug` argument.
    - To enable replication support, configure with `--enable-replication` argument
    - To enable debug logging(tracedump) for ISTGT, configure with `--enable-tracedump`. (before this, it was `--enable-debug`. now changed to `--enable-tracedump`)

- Changes in travis file to use debug build in travis-build

Signed-off-by: mayank <mayank.patel@cloudbyte.com>