### PR TITLE
testcases for snapshot feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
     - sudo make
 script:
     # run ztest and test supported zio backends
+    - sudo bash ./print_debug_info.sh &
     - travis_wait 60 sudo bash ./test_istgt.sh || travis_terminate 1;

--- a/print_debug_info.sh
+++ b/print_debug_info.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while sleep 30; do
+    echo "=====[ $SECONDS seconds still running ]=====";
+    ps -auxwww;
+    netstat -nap;
+    echo "============================================";
+done

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -150,9 +150,6 @@ move_to_blocked_or_ready_q(replica_t *r, rcmd_t *cmd)
 	bool cmd_blocked = false;
 	rcmd_t *pending_rcmd;
 
-	if (cmd->opcode == ZVOL_OPCODE_WRITE)
-		r->replica_inflight_write_io_cnt += 1;
-
 	if (!TAILQ_EMPTY(&r->blockedq)) {
 		clock_gettime(CLOCK_MONOTONIC, &cmd->queued_time);
 		TAILQ_INSERT_TAIL(&r->blockedq, cmd, next);

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -96,9 +96,6 @@ typedef struct rargs_s {
 	int kill_is_over;
 } rargs_t;
 
-extern int replica_poll_time;
-extern int replica_timeout;
-
 typedef struct zvol_io_cmd_s {
 	TAILQ_ENTRY(zvol_io_cmd_s) next;
 	zvol_io_hdr_t 	hdr;

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -198,12 +198,12 @@ handle_snap_opcode(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 	uint64_t write_cnt1, write_cnt2;
 
 	if (strchr(zio_cmd->buf, '@') == NULL) {
-		REPLICA_ERRLOG("no @ in buf %s\n", zio_cmd->buf);
+		REPLICA_ERRLOG("no @ in buf %s\n", (char *)zio_cmd->buf);
 		exit(1);
 	}
 
 	if (strncmp(zio_cmd->buf, rargs->volname, strlen(rargs->volname)) != 0) {
-		REPLICA_ERRLOG("name mismatch %s %s\n", zio_cmd->buf, rargs->volname);
+		REPLICA_ERRLOG("name mismatch %s %s\n", (char *)zio_cmd->buf, rargs->volname);
 		exit(1);
 	}
 

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -207,6 +207,9 @@ handle_snap_opcode(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 		exit(1);
 	}
 
+	if (hdr->opcode == ZVOL_OPCODE_SNAP_DESTROY)
+		goto send_response;
+
 	if (rargs->zrepl_status != ZVOL_STATUS_HEALTHY) {
 		REPLICA_ERRLOG("replica not healthy %d\n", rargs->zrepl_status);
 		exit(1);
@@ -221,6 +224,7 @@ handle_snap_opcode(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 		exit(1);
 	}
 
+send_response:
 	if (zio_cmd->buf)
 		free(zio_cmd->buf);
 	zio_cmd->buf = NULL;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -760,6 +760,8 @@ typedef struct istgt_lu_disk_t {
 	uint32_t rsize;
 	uint32_t rshift;
 	uint32_t rshiftreal;
+
+	/* inflight write IOs in replication layer */
 	uint64_t inflight_write_io_cnt;
 	uint32_t max_unmap_sectors;
 	struct IO_types IO_size[10];	

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -5675,10 +5675,6 @@ freeiovcnt:
 			sleep(8);
 		}
 
-	MTX_LOCK(&spec->rq_mtx);
-	spec->inflight_write_io_cnt += 1;
-	MTX_UNLOCK(&spec->rq_mtx);
-
 	timediffw(lu_cmd, 'w');
 	if (spec->wzero && nthbitset == nbits) {
 		msg = "wzero";
@@ -5721,10 +5717,6 @@ freeiovcnt:
 		}
 #endif
 	}
-
-	MTX_LOCK(&spec->rq_mtx);
-	spec->inflight_write_io_cnt -= 1;
-	MTX_UNLOCK(&spec->rq_mtx);
 
 	lu_cmd->iobufsize = 0;
 	lu_cmd->iobufindx = -1;

--- a/src/mock_client.c
+++ b/src/mock_client.c
@@ -111,9 +111,6 @@ writer(void *args)
 
 		build_cmd(cargs, lu_cmd, 0, len);
 
-		while (spec->quiesce == 1)
-			sleep(1);
-
 		rc = replicate(spec, lu_cmd, offset, len);
 		if (rc != len)
 			goto end;
@@ -220,7 +217,7 @@ mgmt_thrd(void *args)
 	char *snapname;
 	int ret;
 
-	snprintf(tinfo, 50, "mgmt%d", cargs->workerid);
+	snprintf(tinfo, 50, "clientmgmt%d", cargs->workerid);
 	prctl(PR_SET_NAME, tinfo, 0, 0, 0);
 
 	snapname = malloc(50);
@@ -267,7 +264,7 @@ void
 create_mock_client(spec_t *spec)
 {
 	int num_threads = 6;
-	int mgmt_threads = 1;
+	int mgmt_threads = 2;
 	int i;
 	cargs_t *cargs;
 	struct timespec now;
@@ -300,8 +297,8 @@ create_mock_client(spec_t *spec)
 	}
 
 	for (i = 0; i < mgmt_threads; i++) {
+		cargs = &(all_cargs[num_threads + i]);
 		cargs->workerid = num_threads + i;
-		cargs = &(all_cargs[cargs->workerid]);
 		cargs->spec = spec;
 		cargs->mtx = &mtx;
 		cargs->cv = &cv;

--- a/src/replication.c
+++ b/src/replication.c
@@ -970,7 +970,9 @@ is_volume_healthy(spec_t *spec)
  * If volume is not healthy or timeout happens while waiting for ongoing IOs,
  * write IOs will be allowed, and false will be returned.
  * If there are no pending write IOs and volume is healthy, true will be returned.
- * rq_mtx is required to be held by caller
+ * rq_mtx is required to be held by caller.
+ * Returns true when IOs are paused and no ongoing IOs within a given time
+ * else returns false.
  */
 static bool
 pause_and_timed_wait_for_ongoing_ios(spec_t *spec, int sec)
@@ -1003,6 +1005,7 @@ pause_and_timed_wait_for_ongoing_ios(spec_t *spec, int sec)
 			break;
 		}
 		MTX_UNLOCK(&spec->rq_mtx);
+		/* inflight write IOs in spec, or in replica, so, wait for some time */
 		sleep (1);
 		MTX_LOCK(&spec->rq_mtx);
 		timesdiff(CLOCK_MONOTONIC, last, now, diff);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1112,8 +1112,9 @@ done:
 	if (r == false)
 		TAILQ_FOREACH(replica, &spec->rq, r_next)
 			send_replica_snapshot(spec, replica, io_seq, snapname, ZVOL_OPCODE_SNAP_DESTROY, NULL);
-	REPLICA_ERRLOG("snap create ioseq: %lu resp: %d\n", io_seq, r);
 	MTX_UNLOCK(&spec->rq_mtx);
+	if (r == false)
+		REPLICA_ERRLOG("snap create ioseq: %lu resp: %d\n", io_seq, r);
 	if (free_rcomm_mgmt == 1)
 		free(rcomm_mgmt);
 	return r;

--- a/src/replication.c
+++ b/src/replication.c
@@ -988,16 +988,14 @@ pause_and_timed_wait_for_ongoing_ios(spec_t *spec, int sec)
 
 	while ((diff.tv_sec < sec) && (is_volume_healthy(spec) == true)) {
 		write_io_found = false;
-		TAILQ_FOREACH(replica, &spec->rq, r_next) {
-			if (replica->replica_inflight_write_io_cnt != 0) {
-				write_io_found = true;
-				break;
-			}
-		}
-		if (write_io_found == false) {
-			if (spec->inflight_write_io_cnt != 0) {
-				write_io_found = true;
-				break;
+		if (spec->inflight_write_io_cnt != 0)
+			write_io_found = true;
+		else {
+			TAILQ_FOREACH(replica, &spec->rq, r_next) {
+				if (replica->replica_inflight_write_io_cnt != 0) {
+					write_io_found = true;
+					break;
+				}
 			}
 		}
 		if (write_io_found == false) {


### PR DESCRIPTION
This PR is to cover below testcases of snapshot feature:
- verify that no writes happen during snapshot request
- verify that replica is in healthy state
- added logs in snapshot failure case
- handling failure status of snapshot opcode
- random timings for io_wait_time and cmd_wait_time
- handling multiple snapshot commands at a time
- handling snap destroy in mock code
- quiescing write IOs in replication layer
- creating multiple threads to send snapshot commands
Signed-off-by: Vishnu Itta <vitta@mayadata.io>