### PR TITLE
[TA1304] unit tests for negative cases in target for network connections 

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -60,7 +60,7 @@ ctl_header = istgt_ver.h istgt_conf.h istgt_log.h istgt_sock.h istgt_misc.h \
 	istgt_md5.h
 
 istgt_integration_source  = istgt_integration_test.c mock_client.c replication.c replication_misc.c rte_ring.c \
-	ring_mempool.c data_conn.c istgt_misc.c
+	ring_mempool.c data_conn.c istgt_misc.c mock_errored_replica.c
 
 replication_test_source   = replication_test.c replication_misc.c
 replication_test_header   = replication.h istgt_integration.h

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -308,12 +308,16 @@ handle_data_conn_error(replica_t *r)
 	r->data_eventfd = -1;
 	close_fd(epollfd, data_eventfd);
 
-	MTX_UNLOCK(&r->r_mtx);
-
-	if (r->io_resp_hdr)
+	if (r->io_resp_hdr) {
 		free(r->io_resp_hdr);
-	if (r->ongoing_io_buf)
+		r->io_resp_hdr = NULL;
+	}
+	if (r->ongoing_io_buf) {
 		free(r->ongoing_io_buf);
+		r->ongoing_io_buf = NULL;
+	}
+
+	MTX_UNLOCK(&r->r_mtx);
 
 	respond_with_error_for_all_outstanding_ios(r);
 

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -34,31 +34,31 @@ typedef struct replica_s {
 	TAILQ_ENTRY(replica_s) r_waitnext;
 	rte_smempool_t cmdq;	/* list of IOs queued from spec to replica */
 	TAILQ_HEAD(, rcmd_s) readyq;	/* list of IOs (non-blocking IOs) ready to sent to replica */
-	TAILQ_HEAD(, rcmd_s) waitq;
-	TAILQ_HEAD(, rcmd_s) blockedq;
-	pthread_cond_t r_cond;
-	pthread_mutex_t r_mtx;
+	TAILQ_HEAD(, rcmd_s) waitq;	/* list of IOs waiting for the response from replica */
+	TAILQ_HEAD(, rcmd_s) blockedq;	/* list of blocked IOs */
+	pthread_cond_t r_cond;		/* replica level cond. variable */
+	pthread_mutex_t r_mtx;		/* replica level mutex lock */
 	replica_state_t state;
 	spec_t *spec;
 	int iofd;
-	int mgmt_fd;
-	int port;
-	char *ip;
+	int mgmt_fd;			/* management connection descriptor */
+	int port;			/* replica's IOs server port */
+	char *ip;			/* replica's IP */
 	uint64_t pool_guid;
 	uint64_t zvol_guid;
 
-	void *ongoing_io_buf;	// data received from replica
-	uint64_t ongoing_io_len;	// number of bytes received from replica
-	rcmd_t *ongoing_io;		// cmd for which we are receiving response
-	void *m_event1;
-	int mgmt_eventfd1;
-	void *m_event2;
-	int mgmt_eventfd2;
-	int disconnect_conn;
-	int conn_closed;
-	int epollfd;
-	int data_eventfd;
-	int epfd;
+	void *ongoing_io_buf;		/* payload for current IO response for a replica */
+	uint64_t ongoing_io_len;	/* payload size for IO response for a replica */
+	rcmd_t *ongoing_io;		/* IO for which we are receiving response from replica */
+	void *m_event1;			/* data ptr for epoll */
+	int mgmt_eventfd1;		/* eventfd to notify for a command in replica's mgmt cmd queue */
+	void *m_event2;			/* data ptr for epoll */
+	int mgmt_eventfd2;		/* to inform mgmt interface for an error in data interface */
+	int disconnect_conn;		/* to inform data interface for an error in mgmt interface */
+	int conn_closed;		/* To track tear down of replica's interfaces(mgmt and data) */
+	int epollfd;			/* Epoll descriptor for data interface */
+	int data_eventfd;		/* eventfd to notify data interface for IOs in replica's cmdq */
+	int epfd;			/* Epoll descriptor for mgmt interface */
 	int dont_free;
 
 	struct timespec create_time;
@@ -68,15 +68,15 @@ typedef struct replica_s {
 	 */
 	uint64_t replica_inflight_write_io_cnt;
 
-	zvol_io_hdr_t *io_resp_hdr;	// header recieved on data connection
-	int io_state;			// state of command on data connection
-	int io_read;			// amount of IO data read in current IO state for data connection
-	zvol_io_hdr_t *mgmt_io_resp_hdr;// header recieved on management connection
-	void *mgmt_io_resp_data;	// data recieved on management connection
-	TAILQ_HEAD(, mgmt_cmd_s) mgmt_cmd_queue;	// command queue for management connection
+	zvol_io_hdr_t *io_resp_hdr;	/* header recieved on data connection */
+	int io_state;			/* state of command on data connection */
+	int io_read;			/* amount of IO data read in current IO state for data connection */
+	zvol_io_hdr_t *mgmt_io_resp_hdr;/* header recieved on management connection */
+	void *mgmt_io_resp_data;	/* data recieved on management connection */
+	TAILQ_HEAD(, mgmt_cmd_s) mgmt_cmd_queue;	/* mgmt command queue for management connection */
 	uint64_t initial_checkpointed_io_seq;
 #ifdef	DEBUG
-	int replica_mgmt_dport;		// port from which replica has made mgmt conn.
+	int replica_mgmt_dport;		/* port from which replica has made mgmt conn. */
 #endif
 } replica_t;
 

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -75,6 +75,9 @@ typedef struct replica_s {
 	void *mgmt_io_resp_data;	// data recieved on management connection
 	TAILQ_HEAD(, mgmt_cmd_s) mgmt_cmd_queue;	// command queue for management connection
 	uint64_t initial_checkpointed_io_seq;
+#ifdef	DEBUG
+	int replica_mgmt_dport;		// port from which replica has made mgmt conn.
+#endif
 } replica_t;
 
 typedef struct cstor_conn_ops {

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -3170,7 +3170,7 @@ istgt_uctl_cmd_execute(UCTL_Ptr uctl)
 		if (rc != UCTL_CMD_OK) {
 			return UCTL_CMD_DISCON;
 		}
-		return UCTL_CMD_ERR;
+		return UCTL_CMD_QUIT;
 	}
 #endif
 

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -6918,6 +6918,8 @@ istgt_lu_disk_status(ISTGT_LU_Ptr lu, int lun)
 	if (spec->state == ISTGT_LUN_BUSY) {
 #endif
 		status = ISTGT_LUN_BUSY;
+	} else {
+		status = ISTGT_LUN_ONLINE;
 	}
 #ifdef	REPLICATION
 	MTX_UNLOCK(&spec->rq_mtx);

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -1,0 +1,972 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <sys/epoll.h>
+#include <sys/prctl.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <replication.h>
+#include <replication_misc.h>
+#include <istgt_integration.h>
+#include <zrepl_prot.h>
+#include <assert.h>
+
+#define	REPL_TEST_ERROR		-1
+#define	REPL_TEST_RESTART	-2
+
+#define	ERROR_TYPE_MGMT	(1)
+#define	ERROR_TYPE_DATA	(1 << 1)
+
+int start_errored_replica(int replica_count);
+void trigger_data_conn_error(void);
+void shutdown_errored_replica(void);
+void wait_for_spec_ready(void);
+
+extern int replication_initialized;
+extern int replication_factor;
+extern int consistency_factor;
+
+static int *replica_port_list;
+static pthread_t *errored_rthread;
+static pthread_key_t err_repl_key;
+static int total_replica;
+static int active_replica;
+
+static int error_type;
+static pthread_mutex_t err_replica_mtx;
+
+volatile int ignore_io_error = 0;
+
+typedef struct {
+	int replica_port;
+	int mgmtfd;
+	int datafd;
+	int mgmt_err_cnt;
+	int data_err_cnt;
+	int replica_status;
+} errored_replica_data_t;
+
+#define	CONNECTION_CLOSE_ERROR_EPOLL(_fd, _epoll_fd, rc, _label, _err_freq, _err_type)				\
+do {														\
+	errored_replica_data_t *_repl_data;									\
+	if (_fd == -1)												\
+		break;												\
+														\
+	if (!check_for_error(_err_type))									\
+		break;												\
+														\
+	_repl_data = (errored_replica_data_t *)pthread_getspecific(err_repl_key);				\
+	(void) epoll_ctl(_epoll_fd, EPOLL_CTL_DEL, _fd, NULL);							\
+	close(_fd);												\
+	(_repl_data->mgmtfd == _fd) && (_repl_data->mgmtfd = _fd = -1);						\
+	(_repl_data->datafd == _fd) && (_repl_data->datafd = _fd = -1);						\
+														\
+	if (_err_type & ERROR_TYPE_MGMT)									\
+		_repl_data->mgmt_err_cnt++;									\
+	if (_err_type & ERROR_TYPE_DATA)									\
+		_repl_data->data_err_cnt++;									\
+														\
+	REPLICA_ERRLOG("Injecting error at %s:%d.. error count.. mgmt(%d) data(%d) replica(%d)\n",		\
+	    __FUNCTION__, __LINE__, _repl_data->mgmt_err_cnt, _repl_data->data_err_cnt,				\
+	    _repl_data->replica_port);										\
+	rc = REPL_TEST_RESTART;											\
+	goto _label;												\
+} while (0);
+
+#define	HEADER_BUF_ERROR(iohdr, _err_freq, _err_type)								\
+do {														\
+	errored_replica_data_t *_repl_data;									\
+														\
+	if (!check_for_error(_err_type))									\
+		break;												\
+														\
+	iohdr->version = REPLICA_VERSION;									\
+/*	iohdr->opcode = -1;										*/	\
+/*	iohdr->status = ZVOL_OP_STATUS_VERSION_MISMATCH; ZVOL_OP_STATUS_FAILED;				*/	\
+/*	iohdr->io_seq = -1 or NONE									*/	\
+/*	iohdr->offset = ULONG_MAX;									*/	\
+/*	iohdr->len = ULONG_MAX;										*/	\
+	_repl_data = (errored_replica_data_t *)pthread_getspecific(err_repl_key);				\
+														\
+	if (_err_type & ERROR_TYPE_MGMT)									\
+		_repl_data->mgmt_err_cnt++;									\
+	if (_err_type & ERROR_TYPE_DATA)									\
+		_repl_data->data_err_cnt++;									\
+														\
+	REPLICA_ERRLOG("Injecting error at %s:%d.. error count.. mgmt(%d) data(%d) replica(%d)\n",		\
+	    __FUNCTION__, __LINE__, _repl_data->mgmt_err_cnt, _repl_data->data_err_cnt,				\
+	    _repl_data->replica_port);										\
+} while (0);
+
+#define	CONNECTION_CLOSE_ERROR(_fd, _rc, _label, _err_freq, _err_type)						\
+do {														\
+	errored_replica_data_t *_repl_data;									\
+	if (_fd == -1)												\
+		break;												\
+														\
+	if (!check_for_error(_err_type))									\
+		break;												\
+														\
+	_repl_data = (errored_replica_data_t *)pthread_getspecific(err_repl_key);				\
+	close(_fd);												\
+	(_repl_data->mgmtfd == _fd) && (_repl_data->mgmtfd = _fd = -1);						\
+	(_repl_data->datafd == _fd) && (_repl_data->datafd = _fd = -1);						\
+														\
+	_rc = REPL_TEST_RESTART;										\
+	if (_err_type & ERROR_TYPE_MGMT)									\
+		_repl_data->mgmt_err_cnt++;									\
+	if (_err_type & ERROR_TYPE_DATA)									\
+		_repl_data->data_err_cnt++;									\
+														\
+	REPLICA_ERRLOG("Injecting error at %s:%d.. error count.. mgmt(%d) data(%d) replica(%d)\n",		\
+	    __FUNCTION__, __LINE__, _repl_data->mgmt_err_cnt, _repl_data->data_err_cnt,				\
+	    _repl_data->replica_port);										\
+	goto _label;												\
+} while (0);
+
+static void
+exit_errored_replica(void *arg)
+{
+	errored_replica_data_t *rdata = (errored_replica_data_t *)arg;
+
+	if (rdata->mgmtfd != -1)
+		close(rdata->mgmtfd);
+
+	if (rdata->datafd != -1)
+		close(rdata->datafd);
+
+	REPLICA_LOG("Errored Replica(%d) destroyed.. "
+	    "total injected errors mgmt(%d) data(%d)", rdata->replica_port,
+	    rdata->mgmt_err_cnt, rdata->data_err_cnt);
+	free(rdata);
+}
+
+static uint64_t
+fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
+    uint8_t **resp_data)
+{
+	uint32_t count = 0;
+	uint64_t len = io_hdr->len;
+	uint64_t offset = io_hdr->offset;
+	uint64_t start = offset;
+	uint64_t end = offset + len;
+	uint64_t resp_index, data_index;
+	uint64_t total_payload_len;
+	uint64_t md_io_num = 0, last_md_io_num = 0;
+	struct zvol_io_rw_hdr *last_io_rw_hdr;
+	uint8_t *resp;
+
+	while (start < end) {
+		count++;
+		start += 512;
+	}
+
+	if (!count)
+		count = 1;
+
+	if (!(io_hdr->flags & ZVOL_OP_FLAG_READ_METADATA))
+		count = 1;
+
+	total_payload_len = len + count * sizeof(struct zvol_io_rw_hdr);
+	*resp_data = malloc(total_payload_len);
+	memset(*resp_data, 0, total_payload_len);
+	start = offset;
+
+	last_md_io_num = md_io_num = random();
+	last_io_rw_hdr = (struct zvol_io_rw_hdr *)*resp_data;
+	last_io_rw_hdr->io_num = (io_hdr->flags & ZVOL_OP_FLAG_READ_METADATA) ?
+	    last_md_io_num : 0;
+	resp_index = sizeof (struct zvol_io_rw_hdr);
+	resp = *resp_data;
+	data_index = 0;
+	count = 0;
+	while ((io_hdr->flags & ZVOL_OP_FLAG_READ_METADATA) && (start < end)) {
+		if (md_io_num != last_md_io_num) {
+			last_io_rw_hdr->len = count * 512;
+			memcpy(resp + resp_index, user_data + data_index,
+			    last_io_rw_hdr->len);
+			data_index += last_io_rw_hdr->len;
+			resp_index += last_io_rw_hdr->len;
+			last_io_rw_hdr = (struct zvol_io_rw_hdr *)(resp + resp_index);
+			last_io_rw_hdr->io_num = md_io_num;
+			resp_index += sizeof (struct zvol_io_rw_hdr);
+			last_io_rw_hdr->io_num = last_md_io_num;
+			last_md_io_num = md_io_num;
+			count = 0;
+		}
+		count++;
+		start += 512;
+		md_io_num = random();
+	}
+	last_io_rw_hdr->len = (io_hdr->flags & ZVOL_OP_FLAG_READ_METADATA) ?
+	    (count * 512) : len;
+	memcpy(resp + resp_index, user_data + data_index, last_io_rw_hdr->len);
+	return total_payload_len;
+}
+
+static int
+verify_replica_removal(int replica_mgmt_sport)
+{
+	int rc = 0;
+#ifdef	DEBUG
+	replica_t *r;
+	spec_t *spec = NULL;
+	int retry_count = 10;
+#endif
+
+	if (!replica_mgmt_sport)
+		goto error;
+
+#ifdef	DEBUG
+	MTX_LOCK(&specq_mtx);
+		TAILQ_FOREACH(spec, &spec_q, spec_next) {
+			// Since we are supporting single spec per controller
+			// we will continue using first spec only       
+			break;
+		}
+	MTX_UNLOCK(&specq_mtx);
+
+	/*
+	 * Check if the replica is in spec's list (both normal and waitlist) or not.
+	 * There are chances that replica won't be removed immediately, so we will
+	 * try to check `retry_count` times if the replica is in spec's list.
+	 */
+	while (retry_count) {
+		rc = 0;
+
+		MTX_LOCK(&spec->rq_mtx);
+		TAILQ_FOREACH(r, &(spec->rq), r_next) {
+			if (r->replica_mgmt_dport == replica_mgmt_sport) {
+				rc = 1;
+				goto retry;
+			}
+		}
+
+		TAILQ_FOREACH(r, &(spec->rwaitq), r_next) {
+			if (r->replica_mgmt_dport == replica_mgmt_sport) {
+				rc = 1;
+				goto retry;
+			}
+		}
+
+retry:
+		MTX_UNLOCK(&spec->rq_mtx);
+		retry_count--;
+
+		/* Sleep for 10 us to avoid lock starvation */
+		usleep(10000);
+	}
+#else
+#error	Debug mode is disabled
+#endif
+
+error:
+	return rc;
+}
+
+static inline int
+get_socket_info(int socket)
+{
+	int rc = -1;
+	struct sockaddr_in addr;
+	socklen_t len = sizeof (struct sockaddr);
+
+	rc = getsockname(socket, (struct sockaddr *)&addr, &len);
+	if (rc == -1) {
+		REPLICA_ERRLOG("Failed to get sockinfo for socket(%d)\n", socket);
+		goto error;
+	}
+
+	REPLICA_DEBUGLOG("socket(%d) bound to %s:%d\n",
+	    socket, inet_ntoa(addr.sin_addr), (int) ntohs(addr.sin_port));
+	rc = (int) ntohs(addr.sin_port);
+
+error:
+	return rc;
+}
+
+static inline int
+check_for_error(int err_type)
+{
+	
+	int rc = 0;
+	static int num = 1;
+
+	MTX_LOCK(&err_replica_mtx);
+	if (!(err_type & error_type)) {
+		MTX_UNLOCK(&err_replica_mtx);
+		goto out;
+	}
+	MTX_UNLOCK(&err_replica_mtx);
+
+	num--;
+
+	if (num <= 0) {
+		if (err_type == ERROR_TYPE_DATA) {
+			MTX_LOCK(&err_replica_mtx);
+			if (active_replica <= consistency_factor) {
+				MTX_UNLOCK(&err_replica_mtx);
+				goto out;
+			} else {
+				active_replica--;
+			}
+			MTX_UNLOCK(&err_replica_mtx);
+		}
+		rc = 1;
+		num = (int) random() % 9;
+	}
+
+out:
+	return rc;
+}
+
+static int
+send_mgmt_ack(int fd, zvol_io_hdr_t *mgmt_ack_hdr, void *buf, int *zrepl_status_msg_cnt,
+    const char *replica_ip, int replica_port)
+{
+	int i, nbytes = 0;
+	int rc = 0, start;
+	struct iovec iovec[6];
+	int iovec_count;
+	zrepl_status_ack_t zrepl_status;
+	mgmt_ack_t mgmt_ack_data;
+	int ret = -1;
+	zvol_op_stat_t stats;
+
+	iovec[0].iov_base = mgmt_ack_hdr;
+	iovec[0].iov_len = 16;
+
+	iovec[1].iov_base = ((uint8_t *)mgmt_ack_hdr) + 16;
+	iovec[1].iov_len = 16;
+
+	iovec[2].iov_base = ((uint8_t *)mgmt_ack_hdr) + 32;
+	iovec[2].iov_len = sizeof (zvol_io_hdr_t) - 32;
+
+	switch (mgmt_ack_hdr->opcode) {
+		case ZVOL_OPCODE_SNAP_DESTROY:
+			iovec[2].iov_base = ((uint8_t *)mgmt_ack_hdr) + 32;
+			iovec[2].iov_len = 2;
+
+			iovec[3].iov_base = ((uint8_t *)mgmt_ack_hdr) + 34;
+			iovec[3].iov_len = sizeof (zvol_io_hdr_t) - 34;
+
+			iovec_count = 4;
+			mgmt_ack_hdr->status = (random() % 2) ? ZVOL_OP_STATUS_FAILED : ZVOL_OP_STATUS_OK;
+			mgmt_ack_hdr->len = 0;
+			break;
+
+		case ZVOL_OPCODE_SNAP_CREATE:
+			iovec_count = 3;
+			sleep(random()%3 + 1);
+			mgmt_ack_hdr->status = (random() % 5 == 0) ? ZVOL_OP_STATUS_FAILED : ZVOL_OP_STATUS_OK;
+			mgmt_ack_hdr->len = 0;
+			break;
+
+		case ZVOL_OPCODE_REPLICA_STATUS:
+			zrepl_status.state = ZVOL_STATUS_DEGRADED;
+//			zrepl_status.state = ZVOL_STATUS_HEALTHY;
+
+			if (((*zrepl_status_msg_cnt) >= 3)) {
+//			    (zrepl_status.state != ZVOL_STATUS_HEALTHY)) {
+				zrepl_status.state = ZVOL_STATUS_HEALTHY;
+				zrepl_status.rebuild_status = ZVOL_REBUILDING_DONE;
+				(*zrepl_status_msg_cnt) = 0;
+			} else if ((*zrepl_status_msg_cnt) >= 1) {
+				zrepl_status.rebuild_status = ZVOL_REBUILDING_IN_PROGRESS;
+			}
+
+			if (zrepl_status.rebuild_status == ZVOL_REBUILDING_IN_PROGRESS) {
+				(*zrepl_status_msg_cnt) += 1;
+			}
+
+			mgmt_ack_hdr->len = sizeof (zrepl_status_ack_t);
+			iovec_count = 4;
+			iovec[3].iov_base = &zrepl_status;
+			iovec[3].iov_len = sizeof (zrepl_status_ack_t);
+			mgmt_ack_hdr->len = sizeof (zrepl_status_ack_t);
+			break;
+
+		case ZVOL_OPCODE_START_REBUILD:
+			*zrepl_status_msg_cnt = 1;
+			zrepl_status.rebuild_status = ZVOL_REBUILDING_IN_PROGRESS;
+			iovec_count = 3;
+			mgmt_ack_hdr->len = 0;
+			break;
+
+		case ZVOL_OPCODE_STATS:
+			strcpy(stats.label, "used");
+			stats.value = 10000;
+
+			iovec[3].iov_base = &stats;
+			iovec[3].iov_len = sizeof (zvol_op_stat_t);
+			iovec_count = 4;
+			mgmt_ack_hdr->len = sizeof (zvol_op_stat_t);
+			break;
+
+		case ZVOL_OPCODE_PREPARE_FOR_REBUILD:
+		case ZVOL_OPCODE_HANDSHAKE:
+			strcpy(mgmt_ack_data.ip, replica_ip);
+			strcpy(mgmt_ack_data.volname, buf);
+			mgmt_ack_data.port = replica_port;
+			mgmt_ack_data.pool_guid = replica_port;
+			mgmt_ack_data.zvol_guid = replica_port;
+
+			iovec[3].iov_base = &mgmt_ack_data;
+			iovec[3].iov_len = 50;
+
+			iovec[4].iov_base = ((uint8_t *)&mgmt_ack_data) + 50;
+			iovec[4].iov_len = 50;
+
+			iovec[5].iov_base = ((uint8_t *)&mgmt_ack_data) + 100;
+			iovec[5].iov_len = sizeof (mgmt_ack_t) - 100;
+			iovec_count = 6;
+			mgmt_ack_hdr->len = sizeof (mgmt_ack_data);
+			break;
+
+		default:
+			REPLICA_ERRLOG("opcode(%d) is not handled.. program is aborting now..",
+			    mgmt_ack_hdr->opcode);
+			abort();
+			break;
+	}
+
+	for (start = 0; start < iovec_count; start += 1) {
+		nbytes = iovec[start].iov_len;
+		while (nbytes) {
+			rc = writev(fd, &iovec[start], 1);//Review iovec in this line
+			if (rc < 0) {
+				goto out;
+			}
+			nbytes -= rc;
+			if (nbytes == 0)
+				break;
+			/* adjust iovec length */
+			for (i = start; i < start + 1; i++) {
+				if (iovec[i].iov_len != 0 && iovec[i].iov_len > (size_t)rc) {
+					iovec[i].iov_base
+						= (void *) (((uintptr_t)iovec[i].iov_base) + rc);
+					iovec[i].iov_len -= rc;
+					break;
+				} else {
+					rc -= iovec[i].iov_len;
+					iovec[i].iov_len = 0;
+				}
+			}
+		}
+	}
+	ret = 0;
+out:
+	return ret;
+}
+
+static int
+send_io_resp(int fd, zvol_io_hdr_t *io_hdr, void *buf)
+{
+	struct iovec iovec[2];
+	int iovcnt, i, nbytes = 0;
+	int rc = 0;
+
+	if (fd < 0) {
+		REPLICA_ERRLOG("fd is %d!!!\n", fd);
+		return REPL_TEST_ERROR;
+	}
+
+	HEADER_BUF_ERROR(io_hdr, err_freq, ERROR_TYPE_DATA);
+
+	if(io_hdr->opcode == ZVOL_OPCODE_READ) {
+		iovcnt = 2;
+		iovec[0].iov_base = io_hdr;
+		nbytes = iovec[0].iov_len = sizeof(zvol_io_hdr_t);
+		iovec[1].iov_base = buf;
+		iovec[1].iov_len = io_hdr->len;
+		nbytes += io_hdr->len;
+	} else if(io_hdr->opcode == ZVOL_OPCODE_WRITE) {
+		iovcnt = 1;
+		iovec[0].iov_base = io_hdr;
+		nbytes = iovec[0].iov_len = sizeof(zvol_io_hdr_t);
+	} else {
+		iovcnt = 1;
+		iovec[0].iov_base = io_hdr;
+		nbytes = iovec[0].iov_len = sizeof(zvol_io_hdr_t);
+		io_hdr->len = 0;
+	}
+	while (nbytes) {
+		rc = writev(fd, iovec, iovcnt);//Review iovec in this line
+		if (rc < 0) {
+			REPLICA_ERRLOG("failed to write on fd errno(%d)\n", errno);
+			return REPL_TEST_ERROR;
+		}
+
+		nbytes -= rc;
+		if (nbytes == 0)
+			break;
+		/* adjust iovec length */
+		for (i = 0; i < iovcnt; i++) {
+			if (iovec[i].iov_len != 0 && iovec[i].iov_len > (size_t)rc) {
+				iovec[i].iov_base
+					= (void *) (((uintptr_t)iovec[i].iov_base) + rc);
+				iovec[i].iov_len -= rc;
+				break;
+			} else {
+				rc -= iovec[i].iov_len;
+				iovec[i].iov_len = 0;
+			}
+		}
+	}
+	return 0;
+}
+
+static void *
+errored_replica(void *arg)
+{
+	int zrepl_status_msg_cnt = 0;
+	int ctrl_port = 6060;
+	int replica_port = *(int *)arg;
+	int replica_mgmt_sport = 0;
+	zvol_op_open_data_t *open_ptr;
+	int sfd, rc, epfd, event_count, i;
+	int mgmtfd = -1, iofd = -1;
+	int64_t count;
+	struct epoll_event event, *events;
+	uint8_t *data;
+	zvol_io_hdr_t *io_hdr;
+	zvol_io_hdr_t *mgmtio;
+	bool read_rem_data = false, read_rem_hdr = false;
+	uint64_t recv_len = 0, total_len = 0;
+	struct timespec now;
+	errored_replica_data_t *rdata;
+
+	ASSERT(replica_port);
+	REPLICA_ERRLOG("starting replica(%d)\n", replica_port);
+
+	rdata = malloc(sizeof (errored_replica_data_t));
+	memset(rdata, 0, sizeof (errored_replica_data_t));
+	rdata->replica_port = replica_port;
+	rdata->replica_status = ZVOL_STATUS_DEGRADED;
+	pthread_setspecific(err_repl_key, rdata);
+
+	pthread_cleanup_push(exit_errored_replica, rdata);
+	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+
+	io_hdr = malloc(sizeof(zvol_io_hdr_t));
+	mgmtio = malloc(sizeof(zvol_io_hdr_t));
+
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	srandom(now.tv_sec);
+
+	snprintf(tinfo, 50, "mock_nwrepl%d", replica_port);
+        prctl(PR_SET_NAME, tinfo, 0, 0, 0);
+
+	data = NULL;
+	epfd = epoll_create1(0);
+	
+	//Create non-blocking listener for io connections from controller and add to epoll
+	if((sfd = replication_listen("127.0.0.1", replica_port, 32, 1)) < 0) {
+               	rc = REPL_TEST_ERROR;
+		goto error;
+        }
+
+	event.data.fd = sfd;
+	event.events = EPOLLIN | EPOLLET;
+	rc = epoll_ctl(epfd, EPOLL_CTL_ADD, sfd, &event);
+	if (rc == -1) {
+	       	rc = REPL_TEST_ERROR;
+		goto error;
+	}
+
+	events = calloc(MAXEVENTS, sizeof(event));
+
+try_again:
+	mgmtfd = rdata->mgmtfd = -1;
+	iofd = rdata->datafd = -1;
+	read_rem_data = false;
+	read_rem_hdr = false;
+	zrepl_status_msg_cnt = 0;
+	replica_mgmt_sport = 0;
+
+	//Connect to controller to start handshake and connect to epoll
+	if((mgmtfd = replication_connect("127.0.0.1", ctrl_port)) < 0) {
+		REPLICA_ERRLOG("conn_connect() failed errno:%d\n", errno);
+		rc = REPL_TEST_ERROR;
+		goto error;
+	}
+
+	rdata->mgmtfd = mgmtfd;
+
+	replica_mgmt_sport = get_socket_info(mgmtfd);
+	if (replica_mgmt_sport < 0) {
+		REPLICA_ERRLOG("failed to get socket info\n");
+		goto error;
+	}
+
+	CONNECTION_CLOSE_ERROR(mgmtfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+
+	event.data.fd = mgmtfd;
+	event.events = EPOLLIN | EPOLLET;
+	rc = epoll_ctl(epfd, EPOLL_CTL_ADD, mgmtfd, &event);
+	if (rc == -1) {
+		REPLICA_ERRLOG("epoll_ctl() failed.. err(%d) replica(%d)", errno, replica_port);
+		rc = REPL_TEST_ERROR;
+		goto error;
+	}
+
+	CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+
+	while (1) {
+		event_count = epoll_wait(epfd, events, MAXEVENTS, -1);
+		for(i=0; i< event_count; i++) {
+			if ((events[i].events & EPOLLERR) ||
+					(events[i].events & EPOLLHUP) ||
+					(!(events[i].events & EPOLLIN))) {
+				REPLICA_ERRLOG("epoll error for replica(%d) event(%d) fd(%d)\n",
+				    replica_port, events[i].events, events[i].data.fd);
+				if (events[i].data.fd == mgmtfd || events[i].data.fd == iofd) {
+					rc = REPL_TEST_RESTART;
+					goto error;
+				} else {
+					REPLICA_ERRLOG("something messy\n");
+					abort();
+				}
+			} else if (events[i].data.fd == mgmtfd) {
+				count = perform_read_write_on_fd(events[i].data.fd, (uint8_t *)mgmtio, sizeof(zvol_io_hdr_t), READ_IO_RESP_HDR);
+				if (count < 0) {
+					REPLICA_ERRLOG("Failed to read from fd(%d)\n", events[i].data.fd);
+					rc = REPL_TEST_RESTART;
+					goto error;
+				}
+
+				ASSERT(count == sizeof (zvol_io_hdr_t));
+
+				CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+				CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+
+				if(mgmtio->len) {
+					data = malloc(mgmtio->len);
+					count = perform_read_write_on_fd(events[i].data.fd, (uint8_t *)data, mgmtio->len, READ_IO_RESP_DATA);
+					if (count < 0) {
+						rc = REPL_TEST_ERROR;
+						goto error;
+					}
+					ASSERT(count == mgmtio->len);
+
+					CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+					CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+				}
+
+				rc = send_mgmt_ack(mgmtfd, mgmtio, data, &zrepl_status_msg_cnt, "127.0.0.1", replica_port);
+				if (rc == REPL_TEST_ERROR || rc == REPL_TEST_RESTART) {
+					REPLICA_ERRLOG("failed to send ack for opcode:%d replica(%d)\n", mgmtio->opcode, replica_port);
+					goto error;
+				}
+				if (zrepl_status_msg_cnt == 0)
+					rdata->replica_status = ZVOL_STATUS_HEALTHY;
+			} else if (events[i].data.fd == sfd) {
+				iofd = accept(sfd, NULL, 0);
+				if (iofd == -1) {
+					if((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+						break;
+					} else {
+						REPLICA_ERRLOG("accept() failed, err(%d) replica(%d)", errno, replica_port);
+						break;
+					}
+				}
+
+				rdata->datafd = iofd;
+
+				CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+
+				rc = make_socket_non_blocking(iofd);
+				if (rc == -1) {
+					REPLICA_ERRLOG("make_socket_non_blocking() failed, err(%d)"
+					    " replica(%d)", errno, replica_port);
+					rc = REPL_TEST_ERROR;
+					goto error;
+				}
+
+				CONNECTION_CLOSE_ERROR(iofd, rc, error, err_freq, ERROR_TYPE_DATA);
+
+				event.data.fd = iofd;
+				event.events = EPOLLIN | EPOLLET;
+				rc = epoll_ctl(epfd, EPOLL_CTL_ADD, iofd, &event);
+				if(rc == -1) {
+					REPLICA_ERRLOG("epoll_ctl() failed, errno:%d replica(%d)", errno, replica_port);
+					rc = REPL_TEST_ERROR;
+					goto error;
+				}
+			} else if(events[i].data.fd == iofd) {
+				while(1) {
+					if (read_rem_data) {
+						count = perform_read_write_on_fd(events[i].data.fd, (uint8_t *)data + recv_len,
+						    total_len - recv_len, READ_IO_RESP_DATA);
+						CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+						CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+						if (count < 0) {
+							rc = REPL_TEST_ERROR;
+							goto error;
+						} else if ((uint64_t)count < (total_len - recv_len)) {
+							read_rem_data = true;
+							recv_len += count;
+							break;
+						} else {
+							recv_len = 0;
+							total_len = 0;
+							read_rem_data = false;
+							goto execute_io;
+						}
+
+					} else if (read_rem_hdr) {
+						CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+						CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+						count = perform_read_write_on_fd(events[i].data.fd, (uint8_t *)io_hdr + recv_len,
+						    total_len - recv_len, READ_IO_RESP_HDR);
+						if (count < 0) {
+							rc = REPL_TEST_ERROR;
+							goto error;
+						} else if ((uint64_t)count < (total_len - recv_len)) {
+							read_rem_hdr = true;
+							recv_len += count;
+							break;
+						} else {
+							read_rem_hdr = false;
+							recv_len = 0;
+							total_len = 0;
+						}
+					} else {
+						count = perform_read_write_on_fd(events[i].data.fd, (uint8_t *)io_hdr,
+						    sizeof (zvol_io_hdr_t), READ_IO_RESP_HDR);
+						CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+						CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+						if (count < 0) {
+							rc = REPL_TEST_ERROR;
+							goto error;
+						} else if ((uint64_t)count < sizeof (zvol_io_hdr_t)) {
+							read_rem_hdr = true;
+							recv_len = count;
+							total_len = sizeof (zvol_io_hdr_t);
+							break;
+						} else {
+							read_rem_hdr = false;
+						}
+					}
+
+					CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+					CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+
+					if (io_hdr->opcode == ZVOL_OPCODE_WRITE ||
+					    io_hdr->opcode == ZVOL_OPCODE_HANDSHAKE ||
+					    io_hdr->opcode == ZVOL_OPCODE_OPEN) {
+						if (io_hdr->len) {
+							io_hdr->status = ZVOL_OP_STATUS_OK;
+							data = malloc(io_hdr->len);
+
+							CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+							CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+
+							count = perform_read_write_on_fd(events[i].data.fd, (uint8_t *)data,
+							    io_hdr->len, READ_IO_RESP_DATA);
+							if (count < 0) {
+								rc = REPL_TEST_ERROR;
+								goto error;
+							} else if ((uint64_t)count < io_hdr->len) {
+								read_rem_data = true;
+								recv_len = count;
+								total_len = io_hdr->len;
+								break;
+							}
+							read_rem_data = false;
+						}
+					}
+
+					if (io_hdr->opcode == ZVOL_OPCODE_OPEN) {
+						open_ptr = (zvol_op_open_data_t *)data;
+						io_hdr->status = ZVOL_OP_STATUS_OK;
+
+						MTX_LOCK(&err_replica_mtx);
+						active_replica++;
+						MTX_UNLOCK(&err_replica_mtx);
+
+						REPLICA_LOG("Got volname(%s) blocksize(%d) timeout(%d) for replica(%d)\n",
+						    open_ptr->volname, open_ptr->tgt_block_size, open_ptr->timeout, replica_port);
+					}
+execute_io:
+					if(io_hdr->opcode == ZVOL_OPCODE_WRITE) {
+						CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+						CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+
+						io_hdr->status = ZVOL_OP_STATUS_OK;
+					} else if(io_hdr->opcode == ZVOL_OPCODE_READ) {
+						uint8_t *user_data = NULL;
+						CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+						CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+
+						if(io_hdr->len)
+							user_data = malloc(io_hdr->len);
+
+						io_hdr->status = ZVOL_OP_STATUS_OK;
+						io_hdr->len = fetch_update_io_buf(io_hdr, user_data, &data);
+
+						if (user_data)
+							free(user_data);
+					}
+
+					CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
+					CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);
+
+					rc = send_io_resp(iofd, io_hdr, data);
+					if (rc == REPL_TEST_ERROR || rc == REPL_TEST_RESTART) {
+						REPLICA_ERRLOG("Failed to send response from replica(%d)\n", replica_port);
+						goto error;
+					}
+
+					if (data) {
+						free(data);
+						data = NULL;
+					}
+				}
+			}
+		}
+	}
+
+error:
+	MTX_LOCK(&err_replica_mtx);
+	if ((rdata->replica_status == ZVOL_STATUS_HEALTHY) &&
+	    (error_type == ERROR_TYPE_DATA))
+		ignore_io_error = 1;
+	MTX_UNLOCK(&err_replica_mtx);
+
+	if (mgmtfd != -1) {
+		(void) epoll_ctl(epfd, EPOLL_CTL_DEL, mgmtfd, NULL);
+		close(mgmtfd);
+	}
+
+	if (iofd != -1) {
+		(void) epoll_ctl(epfd, EPOLL_CTL_DEL, iofd, NULL);
+		close(iofd);
+	}
+
+	if (data) {
+		free(data);
+		data = NULL;
+	}
+
+	if (rc == REPL_TEST_RESTART) {
+		rc = verify_replica_removal(replica_mgmt_sport);
+		if (rc) {
+			REPLICA_ERRLOG("Replica(%d) is not removed\n", replica_port);
+			abort();
+		}
+		goto try_again;
+	}
+
+	free(events);
+	REPLICA_ERRLOG("shutting down replica(%d)... \n", replica_port);
+	pthread_cleanup_pop(0);
+	return NULL;
+}
+
+static void
+wait_for_replication_initialization(void)
+{
+	int count = 10;
+
+	while (count) {
+		__sync_synchronize();
+		usleep(100000);
+		if (replication_initialized)
+			return;
+		count--;
+	}
+
+	REPLICA_ERRLOG("replication module is not initialized yet!\n");
+	abort();
+}
+
+int
+start_errored_replica(int replica_count)
+{
+	int i, rc = 0;
+	int replica_port;
+
+	ASSERT(replica_count > 0);
+
+	wait_for_replication_initialization();
+
+	/*
+	 * By default, error will be injected in mgmt connection only.
+	 * error_type is proected with `err_replica_mtx`.
+	 */
+	error_type = ERROR_TYPE_DATA | ERROR_TYPE_MGMT;
+	pthread_mutex_init(&err_replica_mtx, NULL);
+
+	errored_rthread = malloc(replica_count * sizeof (pthread_t));
+	replica_port_list = malloc(replica_count * sizeof (int));
+	total_replica = replica_count;
+	pthread_key_create(&err_repl_key, NULL);
+
+	for (i = 0; i < replica_count; i++) {
+		replica_port_list[i] = 6061 + i;
+		rc = pthread_create(&errored_rthread[i], NULL, &errored_replica, (void *)&replica_port_list[i]);
+		if (rc != 0) {
+			REPLICA_ERRLOG("Failed to create errored replica(%d) err(%d)\n", replica_port, rc);
+			goto error;
+		}
+        }
+
+	REPLICA_NOTICELOG("Total %d errored replica started\n", replica_count);
+
+error:
+	return rc;
+}
+
+void
+trigger_data_conn_error(void)
+{
+	MTX_LOCK(&err_replica_mtx);
+	error_type = ERROR_TYPE_DATA;
+	MTX_UNLOCK(&err_replica_mtx);
+}
+
+void
+shutdown_errored_replica(void)
+{
+	int i;
+
+	for (i = 0; i < total_replica; i++) {
+		pthread_cancel(errored_rthread[i]);
+	}
+
+	free(errored_rthread);
+	free(replica_port_list);
+}
+
+void
+wait_for_spec_ready(void)
+{
+	int count = 10;
+	spec_t *spec = NULL;
+	
+	MTX_LOCK(&specq_mtx);
+		TAILQ_FOREACH(spec, &spec_q, spec_next) {
+			// Since we are supporting single spec per controller
+			// we will continue using first spec only       
+			break;
+		}
+	MTX_UNLOCK(&specq_mtx);
+
+	while (count && spec) {
+		usleep(100000);
+		MTX_LOCK(&spec->rq_mtx);
+		if (spec->ready) {
+			MTX_UNLOCK(&spec->rq_mtx);
+			return;
+		}
+		MTX_UNLOCK(&spec->rq_mtx);
+
+		count--;
+	}
+	REPLICA_ERRLOG("spec is not ready yet.. \n");
+	abort();
+}

--- a/src/replication.c
+++ b/src/replication.c
@@ -415,16 +415,16 @@ trigger_rebuild(spec_t *spec)
 	replica_t *target_replica = NULL;
 	replica_t *healthy_replica = NULL;
 
+	if (spec->ready != true) {
+		REPLICA_NOTICELOG("Volume(%s) is not ready to accept IOs\n",
+		    spec->volname);
+		return;
+	}
+
 	if (spec->rebuild_in_progress == true) {
 		assert(spec->ready == true);
 		REPLICA_NOTICELOG("Rebuild is already in progress "
 		    "on volume(%s)\n", spec->volname);
-		return;
-	}
-
-	if (spec->ready != true) {
-		REPLICA_NOTICELOG("Volume(%s) is not ready to accept IOs\n",
-		    spec->volname);
 		return;
 	}
 
@@ -875,6 +875,7 @@ replica_error:
 	free(rio_hdr);
 	free(rio_payload);
 
+	MTX_LOCK(&spec->rq_mtx);
 	MTX_LOCK(&replica->r_mtx);
 	for (i = 0; (i < 10) && (replica->mgmt_eventfd2 == -1); i++) {
 		MTX_UNLOCK(&replica->r_mtx);
@@ -893,8 +894,6 @@ replica_error:
 		return -1;
 	}
 	MTX_UNLOCK(&replica->r_mtx);
-
-	MTX_LOCK(&spec->rq_mtx);
 
 	spec->degraded_rcount++;
 	TAILQ_REMOVE(&spec->rwaitq, replica, r_waitnext);
@@ -1335,25 +1334,25 @@ handle_prepare_for_rebuild_resp(spec_t *spec, zvol_io_hdr_t *hdr,
 			    "state:%d\n", spec->target_replica->zvol_guid,
 			    spec->target_replica->state);
 		} else {
+			REPLICA_LOG("Unable to trigger rebuild on Replica(%lu)"
+			    " state:%d\n", spec->target_replica->zvol_guid,
+			    spec->target_replica->state);
 			MTX_LOCK(&spec->rq_mtx);
 			spec->target_replica = NULL;
 			spec->rebuild_in_progress = false;
 			MTX_UNLOCK(&spec->rq_mtx);
-			REPLICA_LOG("Unable to trigger rebuild on Replica(%lu)"
-			    " state:%d\n", spec->target_replica->zvol_guid,
-			    spec->target_replica->state);
 		}	
 		free_rcommon_mgmt_cmd(rcomm_mgmt);
 	} else if (rcomm_mgmt->cmds_sent ==
 	    (rcomm_mgmt->cmds_failed + rcomm_mgmt->cmds_succeeded)) {
 		free_rcommon_mgmt_cmd(rcomm_mgmt);
+		REPLICA_LOG("Unable to trigger rebuild on Replica(%lu) "
+		    "state:%d\n", spec->target_replica->zvol_guid,
+		    spec->target_replica->state);
 		MTX_LOCK(&spec->rq_mtx);
 		spec->target_replica = NULL;
 		spec->rebuild_in_progress = false;
 		MTX_UNLOCK(&spec->rq_mtx);
-		REPLICA_LOG("Unable to trigger rebuild on Replica(%lu) "
-		    "state:%d\n", spec->target_replica->zvol_guid,
-		    spec->target_replica->state);
 	}
 }
 
@@ -1479,6 +1478,10 @@ accept_mgmt_conns(int epfd, int sfd)
 	int mgmt_fd;
 	mgmt_event_t *mevent1, *mevent2;
 
+/*
+ * TODO :  Instead of while (1), there should be a limit on max connection
+ *	   to be accepted
+ */
 	while (1) {
 		struct sockaddr saddr;
 		socklen_t slen;
@@ -1571,6 +1574,9 @@ accept_mgmt_conns(int epfd, int sfd)
 		event.data.ptr = mevent2;
 		event.events = EPOLLIN | EPOLLHUP | EPOLLERR | EPOLLET | EPOLLOUT | EPOLLRDHUP;
 
+#ifdef	DEBUG
+		replica->replica_mgmt_dport = atoi(sbuf);
+#endif
 		rc = epoll_ctl(epfd, EPOLL_CTL_ADD, mgmt_fd, &event);
 		if(rc == -1) {
 			REPLICA_ERRLOG("epoll_ctl() failed on fd(%d), "
@@ -1578,7 +1584,7 @@ accept_mgmt_conns(int epfd, int sfd)
 			    mgmt_fd, errno, replica->ip, replica->port);
 cleanup:
 			if (replica->mgmt_eventfd1 != -1) {
-				epoll_ctl(epfd, EPOLL_CTL_DEL, replica->mgmt_eventfd1, NULL);
+				(void) epoll_ctl(epfd, EPOLL_CTL_DEL, replica->mgmt_eventfd1, NULL);
 				close(replica->mgmt_eventfd1);
 				free(mevent2);
 				free(mevent1);
@@ -2120,7 +2126,7 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 again:
 	MTX_LOCK(&spec->rq_mtx);
 	if(spec->ready == false) {
-		REPLICA_LOG("SPEC(%s) is not ready\n", spec->lu->name);
+		REPLICA_LOG("SPEC(%s) is not ready\n", spec->volname);
 		MTX_UNLOCK(&spec->rq_mtx);
 		return -1;
 	}
@@ -2253,6 +2259,8 @@ handle_mgmt_conn_error(replica_t *r, int sfd, struct epoll_event *events, int ev
 				if (r_ev == r) {
 					TAILQ_REMOVE(&r->spec->rwaitq, r, r_waitnext);
 					r->conn_closed++;
+					if (r->io_resp_hdr)
+						free(r->io_resp_hdr);
 				}
 			}
 		}
@@ -2403,7 +2411,7 @@ init_replication(void *arg __attribute__((__unused__)))
 {
 	struct epoll_event event, *events;
 	int rc, sfd, event_count, i;
-	int64_t epfd;
+	int epfd;
 	replica_t *r;
 	int timeout;
 	struct timespec last, now, diff;

--- a/src/replication.c
+++ b/src/replication.c
@@ -133,6 +133,17 @@ static int handle_mgmt_event_fd(replica_t *replica);
 		_donecount = -1;					\
 		break;							\
 	}								\
+	if (_donecount == 1 && _count) {				\
+		/*							\
+		 * Target or replica can only send one command/response.\
+		 * If _donecount is 1 then target/replica has already	\
+		 * processed one mgmt command.				\
+		 */							\
+		REPLICA_ERRLOG("protocol error occurred for "		\
+		    "replica(%lu)\n", replica->zvol_guid);		\
+		_donecount = -1;					\
+		break;							\
+	}								\
 	if ((uint64_t) _count != _reqlen) {				\
 		(_io_read) += _count;					\
 		break;							\
@@ -1478,10 +1489,6 @@ accept_mgmt_conns(int epfd, int sfd)
 	int mgmt_fd;
 	mgmt_event_t *mevent1, *mevent2;
 
-/*
- * TODO :  Instead of while (1), there should be a limit on max connection
- *	   to be accepted
- */
 	while (1) {
 		struct sockaddr saddr;
 		socklen_t slen;
@@ -2259,8 +2266,10 @@ handle_mgmt_conn_error(replica_t *r, int sfd, struct epoll_event *events, int ev
 				if (r_ev == r) {
 					TAILQ_REMOVE(&r->spec->rwaitq, r, r_waitnext);
 					r->conn_closed++;
-					if (r->io_resp_hdr)
+					if (r->io_resp_hdr) {
 						free(r->io_resp_hdr);
+						r->io_resp_hdr = NULL;
+					}
 				}
 			}
 		}

--- a/src/replication.h
+++ b/src/replication.h
@@ -162,7 +162,6 @@ int make_socket_non_blocking(int);
 int send_mgmtack(int, zvol_op_code_t, void *, char *, int);
 int zvol_handshake(spec_t *, replica_t *);
 void accept_mgmt_conns(int, int);
-int send_io_resp(int fd, zvol_io_hdr_t *, void *);
 int initialize_replication_mempool(bool should_fail);
 int destroy_replication_mempool(void);
 void clear_rcomm_cmd(rcommon_cmd_t *);

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -335,7 +335,7 @@ out:
 }
 
 
-int
+static int
 send_io_resp(int fd, zvol_io_hdr_t *io_hdr, void *buf)
 {
 	struct iovec iovec[2];


### PR DESCRIPTION
Changes : 
- Added error injection support in `istgt_integration` test utility. 
    As of now, error injection is added for below scenarios : 
       1. Closing management or data connection from replica
       2. Sending multiple responses for a single management command from replica
       3. Sending errored response for IOs from replica

- Code fix for the errors reported by error injection feature.
