### PR TITLE
[TA1699] Error handling for mutiple responses for a mgmt command from a replica

### DIFF
--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -893,7 +893,7 @@ mock_repl(void *args)
 			while (!TAILQ_EMPTY(&(rargs->mgmt_recv_list))) {
 				zio_cmd = TAILQ_FIRST(&rargs->mgmt_recv_list);
 				TAILQ_REMOVE(&rargs->mgmt_recv_list, zio_cmd, next);
-				free(zio_cmd);
+				zio_cmd_free(&zio_cmd);
 			}
 
 			while (!TAILQ_EMPTY(&rargs->mgmt_send_list)) {

--- a/src/mock_client.c
+++ b/src/mock_client.c
@@ -146,6 +146,7 @@ writer(void *args)
 		}
 	}
 end:
+	free(lu_cmd);
 	REPLICA_ERRLOG("exiting wrote %d from %s\n", count, tinfo);
 
 	MTX_LOCK(mtx);
@@ -220,6 +221,7 @@ reader(void *args)
 		}
 	}
 end:
+	free(lu_cmd);
 	REPLICA_ERRLOG("exiting read %d from %s\n", count, tinfo);
 
 	MTX_LOCK(mtx);
@@ -273,6 +275,7 @@ mgmt_thrd(void *args)
 	}
 	REPLICA_ERRLOG("exiting mgmt_thrd %s sent %d\n", tinfo, count);
 
+	free(snapname);
 	MTX_LOCK(mtx);
 	*cnt = *cnt + 1;
 	pthread_cond_signal(cv);

--- a/src/replication.c
+++ b/src/replication.c
@@ -391,10 +391,8 @@ start_rebuild(void *buf, replica_t *replica, uint64_t data_len)
 	BUILD_REPLICA_MGMT_HDR(rmgmtio, mgmt_opcode, data_len);
 
 	mgmt_cmd->io_hdr = rmgmtio;
-	mgmt_cmd->io_bytes = 0;
 	mgmt_cmd->data = buf;
 	mgmt_cmd->mgmt_cmd_state = WRITE_IO_SEND_HDR;
-	mgmt_cmd->rcomm_mgmt = NULL;
 
 	MTX_LOCK(&replica->r_mtx);
 	TAILQ_INSERT_TAIL(&replica->mgmt_cmd_queue, mgmt_cmd, mgmt_cmd_next);

--- a/src/replication.c
+++ b/src/replication.c
@@ -250,6 +250,7 @@ enqueue_prepare_for_rebuild(spec_t *spec, replica_t *replica,
 	uint64_t data_len = strlen(spec->volname) + 1;
 
 	mgmt_cmd = malloc(sizeof (mgmt_cmd_t));
+	memset(mgmt_cmd, 0, sizeof (mgmt_cmd_t));
 	BUILD_REPLICA_MGMT_HDR(rmgmtio, opcode, data_len);
 
 	mgmt_cmd->io_hdr = rmgmtio;
@@ -298,6 +299,8 @@ send_prepare_for_rebuild_or_trigger_rebuild(spec_t *spec,
 	mgmt_ack_t *mgmt_data;
 	replica_t *replica;
 	struct rcommon_mgmt_cmd *rcomm_mgmt;
+
+	ASSERT(MTX_LOCKED(&spec->rq_mtx));
 
 	spec->target_replica = target_replica;
 	spec->rebuild_in_progress = true;
@@ -381,13 +384,17 @@ start_rebuild(void *buf, replica_t *replica, uint64_t data_len)
 	zvol_op_code_t mgmt_opcode = ZVOL_OPCODE_START_REBUILD;
 	mgmt_cmd_t *mgmt_cmd;
 
+	ASSERT(MTX_LOCKED(&replica->spec->rq_mtx));
+
 	mgmt_cmd = malloc(sizeof (mgmt_cmd_t));
+	memset(mgmt_cmd, 0, sizeof (mgmt_cmd_t));
 	BUILD_REPLICA_MGMT_HDR(rmgmtio, mgmt_opcode, data_len);
 
 	mgmt_cmd->io_hdr = rmgmtio;
 	mgmt_cmd->io_bytes = 0;
 	mgmt_cmd->data = buf;
 	mgmt_cmd->mgmt_cmd_state = WRITE_IO_SEND_HDR;
+	mgmt_cmd->rcomm_mgmt = NULL;
 
 	MTX_LOCK(&replica->r_mtx);
 	TAILQ_INSERT_TAIL(&replica->mgmt_cmd_queue, mgmt_cmd, mgmt_cmd_next);
@@ -425,6 +432,8 @@ trigger_rebuild(spec_t *spec)
 	replica_t *replica = NULL;
 	replica_t *target_replica = NULL;
 	replica_t *healthy_replica = NULL;
+
+	ASSERT(MTX_LOCKED(&spec->rq_mtx));
 
 	if (spec->ready != true) {
 		REPLICA_NOTICELOG("Volume(%s) is not ready to accept IOs\n",
@@ -933,6 +942,7 @@ send_replica_handshake_query(replica_t *replica, spec_t *spec)
 	int ret = 0;
 
 	mgmt_cmd = malloc(sizeof(mgmt_cmd_t));
+	memset(mgmt_cmd, 0, sizeof (mgmt_cmd_t));
 
 	data_len = strlen(spec->volname) + 1;
 
@@ -998,6 +1008,7 @@ send_replica_snapshot(spec_t *spec, replica_t *replica, uint64_t io_seq,
 	int ret = 0;
 
 	mgmt_cmd = malloc(sizeof(mgmt_cmd_t));
+	memset(mgmt_cmd, 0, sizeof (mgmt_cmd_t));
 	mgmt_cmd->rcomm_mgmt = rcomm_mgmt;
 	data_len = strlen(spec->volname) + strlen(snapname) + 2;
 
@@ -1230,6 +1241,7 @@ send_replica_query(replica_t *replica, spec_t *spec, zvol_op_code_t opcode)
 	mgmt_cmd_t *mgmt_cmd;
 
 	mgmt_cmd = malloc(sizeof(mgmt_cmd_t));
+	memset(mgmt_cmd, 0, sizeof (mgmt_cmd_t));
 	data_len = strlen(spec->volname) + 1;
 	BUILD_REPLICA_MGMT_HDR(rmgmtio, mgmt_opcode, data_len);
 
@@ -1338,29 +1350,36 @@ handle_prepare_for_rebuild_resp(spec_t *spec, zvol_io_hdr_t *hdr,
 	}
 
 	if (rcomm_mgmt->cmds_sent == rcomm_mgmt->cmds_succeeded) {
-		ret = start_rebuild(buf, spec->target_replica, rcomm_mgmt->buf_size);
-		rcomm_mgmt->buf = NULL;
-		if (ret == 0) {
-			REPLICA_LOG("Rebuild triggered on Replica(%lu) "
-			    "state:%d\n", spec->target_replica->zvol_guid,
-			    spec->target_replica->state);
+		MTX_LOCK(&spec->rq_mtx);
+		if (spec->target_replica) {
+			ret = start_rebuild(buf, spec->target_replica, rcomm_mgmt->buf_size);
+			rcomm_mgmt->buf = NULL;
+			if (ret == 0) {
+				REPLICA_LOG("Rebuild triggered on Replica(%lu) "
+				    "state:%d\n", spec->target_replica->zvol_guid,
+				    spec->target_replica->state);
+			} else {
+				REPLICA_LOG("Unable to trigger rebuild on Replica(%lu)"
+				    " state:%d\n", spec->target_replica->zvol_guid,
+				    spec->target_replica->state);
+				spec->target_replica = NULL;
+				spec->rebuild_in_progress = false;
+			}
 		} else {
-			REPLICA_LOG("Unable to trigger rebuild on Replica(%lu)"
-			    " state:%d\n", spec->target_replica->zvol_guid,
-			    spec->target_replica->state);
-			MTX_LOCK(&spec->rq_mtx);
-			spec->target_replica = NULL;
-			spec->rebuild_in_progress = false;
-			MTX_UNLOCK(&spec->rq_mtx);
-		}	
+			ASSERT(spec->rebuild_in_progress == false);
+		}
+		MTX_UNLOCK(&spec->rq_mtx);
 		free_rcommon_mgmt_cmd(rcomm_mgmt);
+		mgmt_cmd->rcomm_mgmt = NULL;
 	} else if (rcomm_mgmt->cmds_sent ==
 	    (rcomm_mgmt->cmds_failed + rcomm_mgmt->cmds_succeeded)) {
 		free_rcommon_mgmt_cmd(rcomm_mgmt);
-		REPLICA_LOG("Unable to trigger rebuild on Replica(%lu) "
-		    "state:%d\n", spec->target_replica->zvol_guid,
-		    spec->target_replica->state);
+		mgmt_cmd->rcomm_mgmt = NULL;
 		MTX_LOCK(&spec->rq_mtx);
+		if (spec->target_replica)
+			REPLICA_LOG("Unable to trigger rebuild on Replica(%lu) "
+			    "state:%d\n", spec->target_replica->zvol_guid,
+			    spec->target_replica->state);
 		spec->target_replica = NULL;
 		spec->rebuild_in_progress = false;
 		MTX_UNLOCK(&spec->rq_mtx);
@@ -1728,6 +1747,7 @@ read_io_resp_hdr:
 
 					memset(resp_hdr, 0, sizeof(zvol_io_hdr_t));
 					free(*resp_data);
+					mgmt_cmd->cmd_completed = 1;
 
 					if (rc == -1)
 						return (rc);
@@ -1744,6 +1764,7 @@ read_io_resp_hdr:
 
 				case ZVOL_OPCODE_STATS:
 					update_spec_stats(spec, resp_hdr, *resp_data);
+					free(*resp_data);
 					break;
 
 				case ZVOL_OPCODE_PREPARE_FOR_REBUILD:
@@ -1781,7 +1802,12 @@ read_io_resp_hdr:
 			*resp_data = NULL;
 			*read_count = 0;
 			donecount++;
+			mgmt_cmd->cmd_completed = 1;
 			*state = READ_IO_RESP_HDR;
+			/*
+			 * Try to read data from replica again if replica is
+			 * sending more or multiple reponses for the same command.
+			 */
 			goto read_io_resp_hdr;
 			break;
 		default:
@@ -1893,23 +1919,25 @@ empty_mgmt_q_of_replica(replica_t *r)
 	mgmt_cmd_t *mgmt_cmd;
 	while ((mgmt_cmd = TAILQ_FIRST(&r->mgmt_cmd_queue))) {
 		mgmt_cmd->io_hdr->status = ZVOL_OP_STATUS_FAILED;
-		switch (mgmt_cmd->io_hdr->opcode) {
-			case ZVOL_OPCODE_SNAP_CREATE:
-				handle_snap_create_resp(r, mgmt_cmd);
-				break;
-			case ZVOL_OPCODE_PREPARE_FOR_REBUILD:
-				handle_prepare_for_rebuild_resp(r->spec,
-				    mgmt_cmd->io_hdr, NULL, mgmt_cmd);
-				break;
-			case ZVOL_OPCODE_STATS:
-				update_spec_stats(r->spec, mgmt_cmd->io_hdr,
-				    NULL);
-				break;
-			default:
-				break;
+		if (!mgmt_cmd->cmd_completed) {
+			switch (mgmt_cmd->io_hdr->opcode) {
+				case ZVOL_OPCODE_SNAP_CREATE:
+					handle_snap_create_resp(r, mgmt_cmd);
+					break;
+				case ZVOL_OPCODE_PREPARE_FOR_REBUILD:
+					handle_prepare_for_rebuild_resp(r->spec,
+					    mgmt_cmd->io_hdr, NULL, mgmt_cmd);
+					break;
+				case ZVOL_OPCODE_STATS:
+					update_spec_stats(r->spec, mgmt_cmd->io_hdr,
+					    NULL);
+					break;
+				default:
+					break;
+			}
+			REPLICA_NOTICELOG("mgmt command(%d) failed for replica(%lu)\n",
+			    mgmt_cmd->io_hdr->opcode, r->zvol_guid);
 		}
-		REPLICA_NOTICELOG("mgmt command(%d) failed for replica(%lu)\n",
-		    mgmt_cmd->io_hdr->opcode, r->zvol_guid);
 		clear_mgmt_cmd(r, mgmt_cmd);
 	}
 }

--- a/src/replication.h
+++ b/src/replication.h
@@ -136,7 +136,7 @@ typedef struct mgmt_cmd_s {
 	zvol_io_hdr_t *io_hdr;			/* management command header */
 	void *data;				/* cmd data */
 	int mgmt_cmd_state;			/* current state of cmd */
-
+	int cmd_completed;			/* if command execution has completed */
 	/*
 	 * amount of IO data written/read in current command state
 	 */


### PR DESCRIPTION
Change : 
1. Since target doesn't allow parallel execution of mgmt command, If the target receives multiple responses for a mgmt command from the same replica then the target will disconnect that replica.

2. Fixes regarding memory leak in replica interface and integration test (only a few leaks are taken care, rest will be resolved in separate user story)

3. Few corner fixes in rebuild interface.