### PR TITLE
[TA1646] Fixing memory leak in replication module

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -33,6 +33,7 @@ CFLAGS  += -Wcast-qual -Wchar-subscripts -Winline
 CFLAGS  += -Wmissing-prototypes -Wnested-externs -Wpointer-arith
 CFLAGS  += -Wredundant-decls -Wshadow -Wstrict-prototypes -Wwrite-strings
 CFLAGS  += -Wno-error=cast-align
+CFLAGS  += --param max-inline-insns-single=1000
 
 istgt_source = istgt.c istgt_iscsi.c istgt_iscsi_param.c istgt_lu.c 	\
 		istgt_cmd_table.c istgt_ser_table.c istgt_lu_disk.c 	\

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -320,13 +320,14 @@ istgt_pg_match_all(PORTAL_GROUP *pgp, CF_SECTION *sp)
 	char *label = NULL, *portal = NULL, *host = NULL, *port = NULL;
 	int que;
 	int rc;
+	int ret = 0;
 	int i;
 
 	for (i = 0; i < pgp->nportals; i++) {
 		label = istgt_get_nmval(sp, "Portal", i, 0);
 		portal = istgt_get_nmval(sp, "Portal", i, 1);
 		if (label == NULL || portal == NULL)
-			return 0;
+			goto no_match;
 		rc = istgt_parse_portal(portal, &host, &port, &que);
 		if (rc < 0)
 			goto no_match;
@@ -339,18 +340,19 @@ istgt_pg_match_all(PORTAL_GROUP *pgp, CF_SECTION *sp)
 		if (pgp->portals[i]->que != que)
 			goto no_match;
 	}
+
 	label = istgt_get_nmval(sp, "Portal", i, 0);
 	portal = istgt_get_nmval(sp, "Portal", i, 1);
 	if (label != NULL || portal != NULL)
-		return 0;
-	return 1;
+		goto no_match;
+	ret = 1;
 
 no_match:
 	if (port)
 		xfree(port);
 	if (host)
 		xfree(host);
-	return 0;
+	return ret;
 }
 
 static int

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -317,7 +317,7 @@ istgt_add_portal_group(ISTGT_Ptr istgt, CF_SECTION *sp, int *pgp_idx)
 static int
 istgt_pg_match_all(PORTAL_GROUP *pgp, CF_SECTION *sp)
 {
-	char *label, *portal, *host, *port;
+	char *label = NULL, *portal = NULL, *host = NULL, *port = NULL;
 	int que;
 	int rc;
 	int i;
@@ -329,21 +329,28 @@ istgt_pg_match_all(PORTAL_GROUP *pgp, CF_SECTION *sp)
 			return 0;
 		rc = istgt_parse_portal(portal, &host, &port, &que);
 		if (rc < 0)
-			return 0;
+			goto no_match;
 		if (strcmp(pgp->portals[i]->label, label) != 0)
-			return 0;
+			goto no_match;
 		if (strcmp(pgp->portals[i]->host, host) != 0)
-			return 0;
+			goto no_match;
 		if (strcmp(pgp->portals[i]->port, port) != 0)
-			return 0;
+			goto no_match;
 		if (pgp->portals[i]->que != que)
-			return 0;
+			goto no_match;
 	}
 	label = istgt_get_nmval(sp, "Portal", i, 0);
 	portal = istgt_get_nmval(sp, "Portal", i, 1);
 	if (label != NULL || portal != NULL)
 		return 0;
 	return 1;
+
+no_match:
+	if (port)
+		xfree(port);
+	if (host)
+		xfree(host);
+	return 0;
 }
 
 static int
@@ -1637,27 +1644,6 @@ istgt_init(ISTGT_Ptr istgt)
 		    istgt->discovery_auth_group);
 	}
 
-	rc = istgt_uctl_init(istgt);
-	if (rc < 0) {
-		ISTGT_ERRLOG("istgt_uctl_init() failed\n");
-		return -1;
-	}
-	rc = istgt_build_uctl_portal(istgt);
-	if (rc < 0) {
-		ISTGT_ERRLOG("istgt_build_uctl_portal() failed\n");
-		return -1;
-	}
-	rc = istgt_build_portal_group_array(istgt);
-	if (rc < 0) {
-		ISTGT_ERRLOG("istgt_build_portal_array() failed\n");
-		return -1;
-	}
-	rc = istgt_build_initiator_group_array(istgt);
-	if (rc < 0) {
-		ISTGT_ERRLOG("build_initiator_group_array() failed\n");
-		return -1;
-	}
-
 	rc = pthread_attr_init(&istgt->attr);
 	if (rc != 0) {
 		ISTGT_ERRLOG("pthread_attr_init() failed\n");
@@ -1711,6 +1697,27 @@ istgt_init(ISTGT_Ptr istgt)
 	rc = pthread_cond_init(&istgt->reload_cond, NULL);
 	if (rc != 0) {
 		ISTGT_ERRLOG("cond_init() failed\n");
+		return -1;
+	}
+
+	rc = istgt_uctl_init(istgt);
+	if (rc < 0) {
+		ISTGT_ERRLOG("istgt_uctl_init() failed\n");
+		return -1;
+	}
+	rc = istgt_build_uctl_portal(istgt);
+	if (rc < 0) {
+		ISTGT_ERRLOG("istgt_build_uctl_portal() failed\n");
+		return -1;
+	}
+	rc = istgt_build_portal_group_array(istgt);
+	if (rc < 0) {
+		ISTGT_ERRLOG("istgt_build_portal_array() failed\n");
+		return -1;
+	}
+	rc = istgt_build_initiator_group_array(istgt);
+	if (rc < 0) {
+		ISTGT_ERRLOG("build_initiator_group_array() failed\n");
 		return -1;
 	}
 
@@ -2034,9 +2041,11 @@ istgt_reload(ISTGT_Ptr istgt)
 	config_new = istgt_allocate_config();
 	config_old = istgt->config;
 	config_file = config_old->file;
+
 	rc = istgt_read_config(config_new, config_file);
 	if (rc < 0) {
 		ISTGT_ERRLOG("config error\n");
+		istgt_free_config(config_new);
 		return -1;
 	}
 	if (config_new->section == NULL) {
@@ -2334,7 +2343,6 @@ reload:
 	event.events = EPOLLIN;
 	rc = epoll_ctl(epfd, EPOLL_CTL_ADD, istgt->sig_pipe[0], &event);
 	if (rc == -1) {
-		MTX_UNLOCK(&istgt->mutex);
 		ISTGT_ERRLOG("epoll_ctl() failed, errno:%d\n", errno);
 		close(epfd);
 		return -1;
@@ -2725,6 +2733,7 @@ main(int argc, char **argv)
 	pthread_t replication_thread;
 #endif
 
+	(void) detach;
 	send_abrt_resp = 0;
 	abort_result_queue = 0;
 	wait_inflights = 1;
@@ -2927,6 +2936,11 @@ main(int argc, char **argv)
 	if (rc < 0) {
 		ISTGT_ERRLOG("istgt_init() failed\n");
 	initialize_error:
+#ifdef	REPLICATION
+		destroy_replication_mempool();
+#endif
+		istgt_iscsi_shutdown(istgt);
+		istgt_lu_shutdown(istgt);
 		istgt_close_log();
 		istgt_free_config(config);
 		poolfini();
@@ -2986,7 +3000,8 @@ main(int argc, char **argv)
 */
 	/* setup signal handler thread */
 	signal(SIGPIPE, SIG_IGN);
-	#if 0
+
+#if 0
 	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "setup signal handler\n");
 	memset(&sigact, 0, sizeof sigact);
 	memset(&sigoldact_pipe, 0, sizeof sigoldact_pipe);
@@ -3089,7 +3104,8 @@ main(int argc, char **argv)
 		goto initialize_error;
 	}
 #endif
-	#endif
+
+#endif
 
 	/* create LUN threads for command queuing */
 	istgt_queue_init(&closedconns);

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -1137,6 +1137,9 @@ istgt_iscsi_negotiate_params(CONN_Ptr conn, ISCSI_PARAM *params, uint8_t *data, 
 			if (alloc_len - total < 1) {
 				ISTGT_ERRLOG("data space small %d\n",
 				    alloc_len);
+				xfree(valid_list);
+				xfree(in_val);
+				xfree(cur_val);
 				return total;
 			}
 			ISTGT_TRACELOG(ISTGT_TRACE_ISCSI, "negotiated %s=%s\n",
@@ -1257,6 +1260,11 @@ istgt_chap_get_authinfo(ISTGT_CHAP_AUTH *auth, const char *authfile, const char 
 				secret = istgt_get_nmval(sp, "Auth", i, 1);
 				muser = istgt_get_nmval(sp, "Auth", i, 2);
 				msecret = istgt_get_nmval(sp, "Auth", i, 3);
+				if (!user || !secret || !muser || !msecret) {
+					ISTGT_ERRLOG("Invalid argument\n");
+					istgt_free_config(config);
+					return -1;
+				}
 				if (strcasecmp(authuser, user) == 0) {
 					/* match user */
 					auth->user = xstrdup(user);
@@ -1715,6 +1723,7 @@ istgt_iscsi_check_values(CONN_Ptr conn)
 	if (conn->TargetMaxRecvDataSegmentLength < 512) {
 		ISTGT_ERRLOG("MaxRecvDataSegmentLength(%d) < 512\n",
 		    conn->TargetMaxRecvDataSegmentLength);
+		SESS_MTX_UNLOCK(conn);
 		return -1;
 	}
 	if (conn->TargetMaxRecvDataSegmentLength > 0x00ffffff) {
@@ -1726,6 +1735,7 @@ istgt_iscsi_check_values(CONN_Ptr conn)
 	if (conn->MaxRecvDataSegmentLength < 512) {
 		ISTGT_ERRLOG("MaxRecvDataSegmentLength(%d) < 512\n",
 		    conn->MaxRecvDataSegmentLength);
+		SESS_MTX_UNLOCK(conn);
 		return -1;
 	}
 	if (conn->MaxRecvDataSegmentLength > 0x00ffffff) {
@@ -2520,15 +2530,17 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 		    || SN32_GT(CmdSN, conn->sess->MaxCmdSN)) {
 			SESS_MTX_UNLOCK(conn);
 			ISTGT_ERRLOG("op_text CSN=%x ignore expCSN:%x-%x.  I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eSSN=%x, StatSN=%x\n",
-					CmdSN, sExpCmdSN, sMaxCmdSN,
-					I_bit, F_bit, C_bit, task_tag, transfer_tag, ExpStatSN, cStatSN);
+			    CmdSN, sExpCmdSN, sMaxCmdSN,
+			    I_bit, F_bit, C_bit, task_tag, transfer_tag, ExpStatSN, cStatSN);
+			xfree(data);
 			return -1;
 		}
 	} else if (CmdSN != conn->sess->ExpCmdSN) {
 		SESS_MTX_UNLOCK(conn);
 		ISTGT_ERRLOG("op_text CSN=%x not expCSN:%x-%x.  I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eSSN=%x, StatSN=%x\n",
-					CmdSN, sExpCmdSN, sMaxCmdSN,
-					I_bit, F_bit, C_bit, task_tag, transfer_tag, ExpStatSN, cStatSN);
+		    CmdSN, sExpCmdSN, sMaxCmdSN,
+		    I_bit, F_bit, C_bit, task_tag, transfer_tag, ExpStatSN, cStatSN);
+		xfree(data);
 		return -1;
 	}
 	if (SN32_GT(ExpStatSN, conn->StatSN)) {
@@ -2544,31 +2556,32 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 
 	if (step == 1) {
 		ISTGT_TRACELOG(ISTGT_TRACE_ISCSI,
-				"op_text CSN=%x SSN:%x-advancedto-eSSN:%x.  I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eCSN:%x-%x\n",
-					CmdSN, cStatSN, ExpStatSN,
-					I_bit, F_bit, C_bit, task_tag, transfer_tag, sExpCmdSN, sMaxCmdSN);
+		    "op_text CSN=%x SSN:%x-advancedto-eSSN:%x.  I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eCSN:%x-%x\n",
+		    CmdSN, cStatSN, ExpStatSN,
+		    I_bit, F_bit, C_bit, task_tag, transfer_tag, sExpCmdSN, sMaxCmdSN);
 	} else if (step == 2) {
 		ISTGT_WARNLOG("op_text CSN=%x SSN:%x-rewoundto-eSSN:%x.  I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eCSN:%x-%x\n",
-					CmdSN, cStatSN, ExpStatSN,
-					I_bit, F_bit, C_bit, task_tag, transfer_tag, sExpCmdSN, sMaxCmdSN);
+		    CmdSN, cStatSN, ExpStatSN,
+		    I_bit, F_bit, C_bit, task_tag, transfer_tag, sExpCmdSN, sMaxCmdSN);
 	}
 
 	if (F_bit && C_bit) {
 		if (step != 2) { //we didn't log
 			ISTGT_ERRLOG("op_text CSN=%x final_and_continue. I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eSSN=%x, StatSN=%x, eCSN=%x-%x\n",
-					CmdSN, I_bit, F_bit, C_bit, task_tag, transfer_tag,
-					ExpStatSN, cStatSN, sExpCmdSN, sMaxCmdSN);
+			    CmdSN, I_bit, F_bit, C_bit, task_tag, transfer_tag,
+			    ExpStatSN, cStatSN, sExpCmdSN, sMaxCmdSN);
 		} else {
 			ISTGT_ERRLOG("CSN=%x final and continue\n", CmdSN);
 		}
+		xfree(data);
 		return -1;
 	}
 
 	if (step == 0) {
 		ISTGT_TRACELOG(ISTGT_TRACE_ISCSI,
-				"op_text CSN=%x final_and_continue. I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eSSN=%x, StatSN=%x, eCSN=%x-%x\n",
-				CmdSN, I_bit, F_bit, C_bit, task_tag, transfer_tag,
-				ExpStatSN, cStatSN, sExpCmdSN, sMaxCmdSN);
+		    "op_text CSN=%x final_and_continue. I=%d, F=%d, C=%d, ITT=%x, TTT=%x, eSSN=%x, StatSN=%x, eCSN=%x-%x\n",
+		    CmdSN, I_bit, F_bit, C_bit, task_tag, transfer_tag,
+		    ExpStatSN, cStatSN, sExpCmdSN, sMaxCmdSN);
 	}
 
 
@@ -2578,6 +2591,7 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	if (rc < 0) {
 		ISTGT_ERRLOG("iscsi_parse_params() failed\n");
 		istgt_iscsi_param_free(params);
+		xfree(data);
 		return -1;
 	}
 
@@ -2839,7 +2853,7 @@ istgt_iscsi_transfer_in(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 static int
 istgt_iscsi_transfer_in_internal(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 {
-	ISCSI_PDU rsp_pdu;
+	ISCSI_PDU rsp_pdu = { 0 };
 	uint8_t *rsp;
 	uint8_t *data;
 	uint32_t task_tag;
@@ -3010,6 +3024,7 @@ parse_scsi_cdb(ISTGT_LU_CMD_Ptr lu_cmd)
 	SCSIstat_rest[sidx].opcode = cdb[0];
 	++SCSIstat_rest[sidx].req_start;
 
+	(void)inv;
 	lu_cmd->infdx = 0;
 	lu_cmd->cdbflags = 0;
 	lu_cmd->cdb0  = cdb[0];
@@ -6890,6 +6905,13 @@ istgt_remove_conn(CONN_Ptr conn)
 	SESS_Ptr sess;
 	int clear = 0;
 	ISTGT_LU_DISK *spec = NULL;
+	int idx;
+	int i, j;
+	int delayedFree = 0;
+	int sessConns = 0, ioPending = 0;
+	int rc = 0;
+	int lun;
+	uint16_t tsih;
 
 	if(conn->sess != NULL){
 		if(conn->sess->lu != NULL) {
@@ -6900,11 +6922,6 @@ istgt_remove_conn(CONN_Ptr conn)
 			spec = (ISTGT_LU_DISK *)conn->sess->lu->lun[0].spec;
 		}
 	}
-	int idx;
-	int i, j;
-	int delayedFree = 0;
-	int sessConns = 0, ioPending = 0;
-	int rc = 0;
 
 	idx = -1;
 	sess = conn->sess;
@@ -6938,6 +6955,10 @@ istgt_remove_conn(CONN_Ptr conn)
 	}
 	sessConns = sess->connections;
 	MTX_UNLOCK(&sess->mutex);
+
+	lun = (sess->lu == NULL)? 0 : sess->lu->num;
+	tsih = sess->tsih;
+
 	if (sessConns == 0) {
 		if(clear == 1) {
 			MTX_LOCK(&spec->pr_rsv_mutex);
@@ -6969,6 +6990,7 @@ istgt_remove_conn(CONN_Ptr conn)
 			/* Ignore Error */
 			ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "Failed to remove the Nexus\n");
 		}
+
 		istgt_free_sess(sess);
 	}
 	MTX_LOCK(&conn->diskioflag_mutex);
@@ -6982,9 +7004,9 @@ istgt_remove_conn(CONN_Ptr conn)
 	MTX_UNLOCK(&conn->diskioflag_mutex);
 
 	ISTGT_NOTICELOG("remove_conn->initiator:%s(%s) Target: %s(%s LU%d) conn:%p:%d tsih:%d connections:%d %s IOPending=%d",
-			conn->initiator_addr, conn->initiator_name, conn->target_addr, conn->target_name,
-			(sess->lu==NULL)?0:sess->lu->num, conn, conn->cid, sess->tsih, sessConns,
-			(delayedFree == 1) ? "delay_free" : "", ioPending);
+	    conn->initiator_addr, conn->initiator_name, conn->target_addr, conn->target_name,
+	    lun, conn, conn->cid, tsih, sessConns,
+	    (delayedFree == 1) ? "delay_free" : "", ioPending);
 	if (strcmp(conn->target_name, "dummy") && conn->exec_logout == 0)
 		ioctl_call(conn, TYPE_CONNBRK);
 /*
@@ -7009,6 +7031,7 @@ istgt_iscsi_drop_all_conns(CONN_Ptr conn)
 	MTX_UNLOCK(&conn->istgt->mutex);
 	num = 0;
 	MTX_LOCK(&g_conns_mutex);
+
 	for (i = 0; i <= g_max_connidx; i++) {
 		xconn = g_conns[i];
 		if (xconn == NULL)
@@ -7018,12 +7041,12 @@ istgt_iscsi_drop_all_conns(CONN_Ptr conn)
 		}
 		if (strcasecmp(conn->target_name, xconn->target_name) == 0) {
 			if (xconn->sess != NULL) {
-				printf("exiting conn by %s(%s), TSIH=%u, CID=%u\n",
+				ISTGT_NOTICELOG("exiting conn by %s(%s), TSIH=%u, CID=%u\n",
 				    xconn->initiator_name,
 				    xconn->initiator_addr,
 				    xconn->sess->tsih, xconn->cid);
 			} else {
-				printf("exiting conn by %s(%s), TSIH=xx, CID=%u\n",
+				ISTGT_NOTICELOG("exiting conn by %s(%s), TSIH=xx, CID=%u\n",
 				    xconn->initiator_name,
 				    xconn->initiator_addr,
 				    xconn->cid);
@@ -7032,12 +7055,16 @@ istgt_iscsi_drop_all_conns(CONN_Ptr conn)
 			num++;
 		}
 	}
-	if(num!=0){
+
+	MTX_UNLOCK(&g_conns_mutex);
+	if (num != 0){
 		istgt_yield();
 		sleep(1);
 		ISTGT_NOTICELOG("drop all %d connections %d %s by %s\n",
 	    			num, conn->id, conn->target_name, conn->initiator_name);
 	}
+
+	MTX_LOCK(&g_conns_mutex);
 	if (num > max_conns + 1) {
 		for (i = 0; i <= g_max_connidx; i++) {
 			xconn = g_conns[i];
@@ -7050,12 +7077,12 @@ istgt_iscsi_drop_all_conns(CONN_Ptr conn)
 			}
 			if (strcasecmp(conn->target_name, xconn->target_name) == 0) {
 				if (xconn->sess != NULL) {
-					printf("exiting conn by %s(%s), TSIH=%u, CID=%u\n",
+					ISTGT_NOTICELOG("exiting conn by %s(%s), TSIH=%u, CID=%u\n",
 					    xconn->initiator_port,
 					    xconn->initiator_addr,
 					    xconn->sess->tsih, xconn->cid);
 				} else {
-					printf("exiting conn by %s(%s), TSIH=xx, CID=%u\n",
+					ISTGT_NOTICELOG("exiting conn by %s(%s), TSIH=xx, CID=%u\n",
 					    xconn->initiator_port,
 					    xconn->initiator_addr,
 					    xconn->cid);
@@ -7084,6 +7111,7 @@ istgt_iscsi_drop_old_conns(CONN_Ptr conn)
 	max_conns = conn->istgt->MaxConnections;
 	MTX_UNLOCK(&conn->istgt->mutex);
 	num = 0;
+
 	MTX_LOCK(&g_conns_mutex);
 	for (i = 0; i <= g_max_connidx; i++) {
 		xconn = g_conns[i];
@@ -7110,12 +7138,16 @@ istgt_iscsi_drop_old_conns(CONN_Ptr conn)
 			num++;
 		}
 	}
-	if(num!=0){
+	MTX_UNLOCK(&g_conns_mutex);
+
+	if(num != 0){
 		istgt_yield();
 		sleep(1);
 		ISTGT_NOTICELOG("drop all %d old connections %d %s by %s\n",
 	    				num, conn->id, conn->target_name, conn->initiator_port);
 	}
+
+	MTX_LOCK(&g_conns_mutex);
 	if (num > max_conns + 1) {
 		for (i = 0; i <= g_max_connidx; i++) {
 			xconn = g_conns[i];

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -653,15 +653,15 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->max_unmap_sectors = setval;
 			}
 			ISTGT_LOG("ALL->max_unmap_sectors ->%d\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->max_unmap_sectors %d->%d\n", iqn, spec->max_unmap_sectors, setval);
 		spec->max_unmap_sectors = setval;
 		break;
@@ -681,15 +681,15 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->ats = setval;
 			}
 			ISTGT_LOG("ALL->ats ->%d\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->ats %d->%d\n", iqn, spec->ats, setval);
 		spec->ats = setval;
 		break;
@@ -701,23 +701,19 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->xcopy = setval;
 			}
 			ISTGT_LOG("ALL->xcopy ->%d\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->xcopy %d->%d\n", iqn, spec->xcopy, setval);
 		spec->xcopy = setval;
 		break;
 	case 8:
-		if(setval < 0) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter value %d\n", setval);
-			goto error_return;
-		}	
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				istgt->logical_unit[i]->limit_q_size = setval;
@@ -730,42 +726,34 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		}
 		break;
 	case 9:
-		if(setval < 0) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter value %d for 9\n", setval);
-			goto error_return;
-		}
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->delay_reserve = setval;
 			}
 			ISTGT_LOG("ALL->delay_reserve ->%d\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->delay_reserve %d->%d\n", iqn, spec->delay_reserve, setval);
 		spec->delay_reserve = setval;
 		break;
 	case 10:
-		if(setval < 0) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter value %d for 9\n", setval);
-			goto error_return;
-		}
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->delay_release = setval;
 			}
 			ISTGT_LOG("ALL->delay_release ->%d\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->delay_release %d->%d\n", iqn, spec->delay_release, setval);
 		spec->delay_release = setval;
 		break;
@@ -781,15 +769,15 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->error_inject = setval;
 			}
 			ISTGT_LOG("ALL->error_inject->0x%x\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->error_inject 0x%x->0x%x\n", iqn, spec->error_inject, setval);
 		spec->error_inject = setval;
 		break;
@@ -797,15 +785,15 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->inject_cnt = setval;
 			}
 			ISTGT_LOG("ALL->inject_cnt->%d\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->inject_cnt %d->%d\n", iqn, spec->inject_cnt, setval);
 		spec->inject_cnt = setval;
 		break;
@@ -818,15 +806,15 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		if(!strcmp(iqn, "ALL")) {
 			for (i = 1; i <= istgt->nlogical_unit; i++) {
 				spec = (ISTGT_LU_DISK *)istgt->logical_unit[i]->lun[0].spec;
+				if (!spec)
+					goto spec_error;
 				spec->exit_lu_worker = setval;
 			}
 			ISTGT_LOG("ALL->exit_lu_worker->%d\n", setval);
 			break;
 		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
-		}
+		if (!spec)
+			goto spec_error;
 		ISTGT_LOG("%s->exit_lu_worker %d->%d\n", iqn, spec->exit_lu_worker, setval);
 		spec->exit_lu_worker = setval;
 		break;
@@ -836,11 +824,14 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 			istgt_uctl_snprintf(uctl, "ERR invalid parameter value %d\n", setval);
 			goto error_return;
 		}
+		if (!spec)
+			goto spec_error;
 		spec->percent_count = 0;
 		sleep(1);
 		if(!strcmp(iqn, "ALL")) {
 			spec = (ISTGT_LU_DISK *)istgt->logical_unit[1]->lun[0].spec;
-
+			if (!spec)
+				goto spec_error;
 			tot = 0;
 			for(j=0;j<setval;j+=2) {
 				val1 = atoi(strsepq(&arg, delim));
@@ -867,10 +858,6 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 				spec1->percent_count = (j>>1);
 			}
 			break;
-		}
-		if(spec==NULL) {
-			istgt_uctl_snprintf(uctl, "ERR invalid parameter ALL\n");
-			goto error_return;
 		}
 		tot = 0;
 		for(j=0;j<setval;j+=2) {
@@ -901,6 +888,10 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 		return rc;
 	}
 	return UCTL_CMD_OK;
+
+spec_error:
+	istgt_uctl_snprintf(uctl, "ERR spec is NULL\n");
+
 error_return:
 	rc = istgt_uctl_writeline(uctl);
 	if (rc != UCTL_CMD_OK) {
@@ -2487,16 +2478,19 @@ istgt_uctl_cmd_dump(UCTL_Ptr uctl)
 
 		istgt_lock_gconns();
 		MTX_LOCK(&lu->mutex);
-		for (j = 0; j < lu->maxmap; j++) {
+		/* limit host string to 2048 characters */
+		for (j = 0; j < lu->maxmap && rem > 256; j++) {
 			pgp = istgt_lu_find_portalgroup(uctl->istgt, lu->map[j].pg_tag);
 			if(pgp != NULL) {
-				for( x = 0; x < pgp->nportals; x++) {
+				for( x = 0; x < pgp->nportals && rem > 256; x++) {
 					ln = snprintf(bp, 256, " IP%d:%s  ", x+1, pgp->portals[x]->host);
-					if(ln <0)
+					if(ln < 0)
 						ln = 0;
-					else if(ln > rem)
-						ln = rem;
-					rem -= ln;
+					else if(ln > 0) {
+						if (ln > 256)
+							ln = 256;
+						rem -= ln;
+					}
 					bp += ln;
 					*bp = '\0';
 				}

--- a/src/istgt_misc.c
+++ b/src/istgt_misc.c
@@ -243,8 +243,9 @@ poolfini(void)
 		mpools[i].endmem = NULL;
 
 	}
-	//if (gstart != NULL)
-	//	free(gstart);
+
+	if (gstart != NULL)
+		free(gstart);
 	gstart = NULL;
 	gend = NULL;
 }

--- a/src/mock_client.c
+++ b/src/mock_client.c
@@ -136,7 +136,9 @@ writer(void *args)
 
 		if (rc != len && !ignore_io_error)
 			goto end;
+
 		count++;
+
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		if (now.tv_sec - start.tv_sec > 120)
 			break;
@@ -147,6 +149,8 @@ writer(void *args)
 	}
 end:
 	REPLICA_ERRLOG("exiting wrote %d from %s\n", count, tinfo);
+
+	free(lu_cmd);
 
 	MTX_LOCK(mtx);
 	*cnt = *cnt + 1;
@@ -205,7 +209,7 @@ reader(void *args)
 		if (rc != len && !ignore_io_error)
 			goto end;
 
-		if (rc == len)
+		if (lu_cmd->data)
 			xfree(lu_cmd->data);
 
 		lu_cmd->data = NULL;
@@ -221,6 +225,10 @@ reader(void *args)
 	}
 end:
 	REPLICA_ERRLOG("exiting read %d from %s\n", count, tinfo);
+
+	if (lu_cmd->data)
+		xfree(lu_cmd->data);
+	free(lu_cmd);
 
 	MTX_LOCK(mtx);
 	*cnt = *cnt + 1;

--- a/src/replication.h
+++ b/src/replication.h
@@ -173,6 +173,8 @@ int64_t perform_read_write_on_fd(int fd, uint8_t *data, uint64_t len,
     int state);
 int initialize_volume(spec_t *spec, int, int);
 void destroy_volume(spec_t *spec);
+void free_replica(replica_t *replica);
+void respond_with_error_for_all_outstanding_ios(replica_t *r);
 
 /* Replica default timeout is 200 seconds */
 #define	REPLICA_DEFAULT_TIMEOUT	200

--- a/src/replication.h
+++ b/src/replication.h
@@ -172,6 +172,7 @@ void close_fd(int epollfd, int fd);
 int64_t perform_read_write_on_fd(int fd, uint8_t *data, uint64_t len,
     int state);
 int initialize_volume(spec_t *spec, int, int);
+void destroy_volume(spec_t *spec);
 
 /* Replica default timeout is 200 seconds */
 #define	REPLICA_DEFAULT_TIMEOUT	200

--- a/src/ring_mempool.c
+++ b/src/ring_mempool.c
@@ -76,6 +76,9 @@ destroy_mempool(rte_smempool_t *obj)
 	void *entry;
 	int rc;
 
+	if (!obj->ring)
+		return 0;
+
 	if (rte_ring_count(obj->ring) != obj->length) {
 		REPLICA_ERRLOG("there are still orphan entries(%d) for "
 		    "mempool(%s)\n",

--- a/src/ring_mempool.c
+++ b/src/ring_mempool.c
@@ -29,7 +29,7 @@ init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size,
 
 	if (!initialize) {
 		ASSERT0(mem_size);
-		obj->length = count;
+		obj->length = 0;
 	} else {
 		for (i = 0; i < count; i++, mem_entry = NULL) {
 			mem_entry = malloc(mem_size);
@@ -95,6 +95,7 @@ destroy_mempool(rte_smempool_t *obj)
 
 	ASSERT0(rte_ring_count(obj->ring));
 	rte_ring_free(obj->ring);
+	obj->ring = NULL;
 	return 0;
 }
 


### PR DESCRIPTION
Changes : 
Memory leak fix for replication module reported by Valgrind. Test was performed on `istgt_integration_test`.

Details of memory leak before this changes:
https://rally1.rallydev.com/slm/attachment/238766730428/valgrind_output_before_changes
Details of memory leak with this changes:
https://rally1.rallydev.com/slm/attachment/238767578200/valgrind_output_after_memory_leak_fix
