### PR TITLE
Fixing NodeBase in istgt.conf

### DIFF
--- a/src/istgt.conf
+++ b/src/istgt.conf
@@ -1,6 +1,6 @@
 # Global section
 [Global]
-  NodeBase "iqn.2017-08.OpenEBS.cstor"
+  NodeBase "iqn.2016-09.com.openebs.cstor"
   PidFile "/var/run/istgt.pid"
   AuthFile "/usr/local/etc/istgt/auth.conf"
   LogFile "/usr/local/etc/istgt/logfile"


### PR DESCRIPTION
This PR is to change NodeBase in sample conf file from iqn.2017-08.OpenEBS.cstor to iqn.2016-09.com.openebs.cstor

Signed-off-by: Vishnu Itta <vitta@mayadata.io>