### PR TITLE
[TA2090] Sync command from iSCSI controller should not pass length.

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -91,6 +91,7 @@ static int handle_mgmt_event_fd(replica_t *replica);
 			case SBC_SYNCHRONIZE_CACHE_16:			\
 				rcomm_cmd->opcode = ZVOL_OPCODE_SYNC;	\
 				rcomm_cmd->iovcnt = 0;			\
+				rcomm_cmd->data_len = 0;		\
 				break;					\
 			default:					\
 				break;					\

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -81,7 +81,7 @@ run_and_verify_iostats() {
 	login_to_volume "$CONTROLLER_IP:3260"
 	get_scsi_disk
 	if [ "$device_name"!="" ]; then
-		sudo mkfs.ext2 -F /dev/$device_name
+		sudo mkfs.ext4 -F /dev/$device_name
 		[[ $? -ne 0 ]] && echo "mkfs failed for $device_name" && exit 1
 
 		sudo mount /dev/$device_name /mnt/store
@@ -119,7 +119,7 @@ write_and_verify_data(){
 	sleep 5
 	get_scsi_disk
 	if [ "$device_name"!="" ]; then
-		mkfs.ext2 -F /dev/$device_name
+		mkfs.ext4 -F /dev/$device_name
 		[[ $? -ne 0 ]] && echo "mkfs failed for $device_name" && tail -20 /var/log/syslog && exit 1
 
 		mount /dev/$device_name /mnt/store


### PR DESCRIPTION
uZFS not expecting any length with SYNC command. Fixing same. Found as part of GKE integration testing.
Also, modified CI to use ext4 instead of ext2 during testing.