### PR TITLE
[TA2100] Add capacity stats

### DIFF
--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -2927,9 +2927,9 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 {
 	ISTGT_LU_Ptr lu;
 	int rc, length;
-    uint64_t usedlogicalblock;
+	uint64_t usedlogicalblocks;
 	/* instantiate json_object from json-c library. */
-        struct json_object *jobj;
+	struct json_object *jobj;
 	/* these are utility variables that will be freed at the end of the function. */
 	char *writes, *reads, *totalreadbytes, *totalwritebytes, *size, *usedblocks, *sectorsize;
 	ISTGT_LU_DISK *spec;
@@ -2959,14 +2959,13 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 		length = snprintf(NULL, 0, "%"PRIu64, spec->size);
 		size = malloc(length + 1);
 		snprintf(size, length + 1, "%"PRIu64, spec->size);
+		usedlogicalblocks = ( spec->stats.used / spec->blocklen ) ;
 
-        usedlogicalblock = ( spec->stats.used / spec->blocklen ) ;
-
-        length = snprintf(NULL, 0, "%"PRIu64, usedlogicalblock);
+		length = snprintf(NULL, 0, "%"PRIu64, usedlogicalblocks);
 		usedblocks = malloc(length + 1);
-		snprintf(usedblocks, length + 1, "%"PRIu64, usedlogicalblock);
+		snprintf(usedblocks, length + 1, "%"PRIu64, usedlogicalblocks);
 
-        length = snprintf(NULL, 0, "%"PRIu64, spec->blocklen);
+		length = snprintf(NULL, 0, "%"PRIu64, spec->blocklen);
 		sectorsize = malloc(length + 1);
 		snprintf(sectorsize, length + 1, "%"PRIu64, spec->blocklen);
 
@@ -2983,8 +2982,8 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 		json_object_object_add(jobj, "TotalWriteBytes", jtotalwritebytes);
 		json_object_object_add(jobj, "TotalReadBytes", jtotalreadbytes);
 		json_object_object_add(jobj, "Size", jsize);
-     	json_object_object_add(jobj, "UsedLogicalBlocks", jusedlogicalblocks);
-     	json_object_object_add(jobj, "SectorSize", jsectorsize);
+		json_object_object_add(jobj, "UsedLogicalBlocks", jusedlogicalblocks);
+		json_object_object_add(jobj, "SectorSize", jsectorsize);
 
 		istgt_uctl_snprintf(uctl, "%s  %s\n", uctl->cmd, json_object_to_json_string(jobj));
 		rc = istgt_uctl_writeline(uctl);
@@ -2995,9 +2994,9 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 			free(totalreadbytes);
 			free(totalwritebytes);
 			free(size);
-            free(usedblocks);
-	        free(sectorsize);
-            /* freeing root json_object will free all the allocated memory
+			free(usedblocks);
+			free(sectorsize);
+			/* freeing root json_object will free all the allocated memory
 			** associated with the json_object.
 			*/
 			json_object_put(jobj);
@@ -3009,9 +3008,9 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 		free(totalreadbytes);
 		free(totalwritebytes);
 		free(size);
-	    free(usedblocks);
-	    free(sectorsize);
-        json_object_put(jobj);
+		free(usedblocks);
+		free(sectorsize);
+		json_object_put(jobj);
 	}
 	MTX_UNLOCK(&specq_mtx);
 	istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);


### PR DESCRIPTION
On branch used-size-implementation
Changes to be committed:
  modified:   src/istgt_lu_ctl.c

1. Why is this change necessary?
-  As per the earlier commit capacity stats such as used size and sectorsize
   details were not there in the metrics.

2. How does it address the issue?
-  This commit adds such details.

3. What side effects does this change have?
-  None

4. How to verify this change?
-  Run `sudo istgtcontrol iostats` and you will be able to get the following:
   ```
   { "iqn": "iqn.2016-09.com.openebs.cstor:vol1", "WriteIOPS": "0",
   "ReadIOPS": "0", "TotalWriteBytes": "0", "TotalReadBytes": "0",
   "Size": "10737418240", "UsedLogicalBlocks": "0", "SectorSize": "512" }
   ```

5. Any specific message for reviewer ?
-  None

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>