### PR TITLE
[US2827] TCP keepalive for replica interface in istgt

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1544,6 +1544,13 @@ accept_mgmt_conns(int epfd, int sfd)
 			continue;
 		}
 
+		rc = set_socket_keepalive(mgmt_fd);
+		if (rc) {
+			REPLICA_ERRLOG("Failed to set keepalive for fd(%d)\n", mgmt_fd);
+			close(mgmt_fd);
+			continue;
+		}
+
                 MTX_LOCK(&specq_mtx);
                 TAILQ_FOREACH(spec, &spec_q, spec_next) {
 			// Since we are supporting single spec per controller

--- a/src/replication_misc.h
+++ b/src/replication_misc.h
@@ -5,5 +5,6 @@
 
 int replication_connect(const char *, int);
 int replication_listen(const char *, int, int, int);
+int set_socket_keepalive(int);
 
 #endif /* _REPLICATION_MISC_H */


### PR DESCRIPTION
Changes : 
Setting TCP keepalive for replica interface in ISTGT
**keepalive setting :**
**TCP_KEEPCNT = 5**
**TCP_KEEPIDLE = 5**
**TCP_KEEPINTVL = 5**