### PR TITLE
[US2082] Enabling SPC2 and setting default IO timeout in handshake

### DIFF
--- a/src/istgt.conf
+++ b/src/istgt.conf
@@ -16,7 +16,7 @@
   FirstBurstLength 262144
   MaxBurstLength 1048576
   MaxRecvDataSegmentLength 262144
-  MaxOutstandingR2T 16
+  MaxOutstandingR2T 1
   DefaultTime2Wait 2
   DefaultTime2Retain 20
   OperationalMode 0

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -2504,11 +2504,7 @@ istgt_lu_disk_scsi_inquiry(ISTGT_LU_DISK *spec, CONN_Ptr conn, uint8_t *cdb, uin
 		BDSET8W(&data[1], rmb, 7, 1);
 		/* VERSION */
 		/* See SPC3/SBC2/MMC4/SAM2 for more details */
-#ifndef	REPLICATION
 		data[2] = SPC_VERSION_SPC3;
-#else
-		data[2] = SPC_VERSION_SPC2;
-#endif
 		/* NORMACA(5) HISUP(4) RESPONSE DATA FORMAT(3-0) */
 		BDSET8W(&data[3], 2, 3, 4);		/* format 2 */
 		BDADD8(&data[1], 1, 4);         /* hierarchical support */
@@ -2548,11 +2544,7 @@ istgt_lu_disk_scsi_inquiry(ISTGT_LU_DISK *spec, CONN_Ptr conn, uint8_t *cdb, uin
 		data[57] = 0;
 		/* VERSION DESCRIPTOR 1-8 */
 		DSET16(&data[58], 0x0960); /* iSCSI (no version claimed) */
-#ifndef	REPLICATION
 		DSET16(&data[60], 0x0300); /* SPC-3 (no version claimed) */
-#else
-		DSET16(&data[60], 0x0260); /* SPC-2 (no version claimed) */
-#endif
 		DSET16(&data[62], 0x0320); /* SBC-2 (no version claimed) */
 		DSET16(&data[64], 0x0040); /* SAM-2 (no version claimed) */
 		DSET16(&data[66], 0x0000);

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -10587,6 +10587,12 @@ istgt_lu_disk_execute(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 
 	case SPC_PERSISTENT_RESERVE_IN:
 		{
+#ifdef	REPLICATION
+			ISTGT_TRACELOG(ISTGT_TRACE_SCSI, "c#%d RESERVE_IN not handled\n", conn->id);
+			/* INVALID COMMAND OPERATION CODE */
+			BUILD_SENSE(ILLEGAL_REQUEST, 0x24, 0x00);
+			lu_cmd->status = ISTGT_SCSI_STATUS_CHECK_CONDITION;
+#else
 			sa = BGET8W(&cdb[1], 4, 5);
 			if (lu_cmd->R_bit == 0) {
 				ISTGT_ERRLOG("c#%d PERSISTENT_RESERVE_IN: sa:0x%2.2x R_bit == 0\n", conn->id, sa);
@@ -10622,11 +10628,18 @@ istgt_lu_disk_execute(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 			lu_cmd->data_len = DMIN32((size_t)data_len, lu_cmd->transfer_len);
 			lu_cmd->status = ISTGT_SCSI_STATUS_GOOD;
 			ISTGT_TRACELOG(ISTGT_TRACE_SCSI, "c#%d PERSISTENT_RESERVE_IN sa:0x%2.2x data:%u/%u/%u\n", conn->id, sa, data_len, lu_cmd->transfer_len, allocation_len);
+#endif
 		}
 		break;
 
 	case SPC_PERSISTENT_RESERVE_OUT:
 		{
+#ifdef	REPLICATION
+			ISTGT_TRACELOG(ISTGT_TRACE_SCSI, "c#%d RESERVE_OUT not handled\n", conn->id);
+			/* INVALID COMMAND OPERATION CODE */
+			BUILD_SENSE(ILLEGAL_REQUEST, 0x24, 0x00);
+			lu_cmd->status = ISTGT_SCSI_STATUS_CHECK_CONDITION;
+#else
 			int scope, type;
 			sa = BGET8W(&cdb[1], 4, 5);
 
@@ -10674,6 +10687,7 @@ istgt_lu_disk_execute(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 			lu_cmd->status = ISTGT_SCSI_STATUS_GOOD;
 			ISTGT_ERRLOG("c#%d PERSISTENT_RESERVE_OUT sa:0x%2.2x scope:%x type:%x plen:%d success (%d)",
 						conn->id, sa, scope, type, parameter_len, data_len);
+#endif
 		}
 		break;
 

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -2504,7 +2504,11 @@ istgt_lu_disk_scsi_inquiry(ISTGT_LU_DISK *spec, CONN_Ptr conn, uint8_t *cdb, uin
 		BDSET8W(&data[1], rmb, 7, 1);
 		/* VERSION */
 		/* See SPC3/SBC2/MMC4/SAM2 for more details */
+#ifndef	REPLICATION
 		data[2] = SPC_VERSION_SPC3;
+#else
+		data[2] = SPC_VERSION_SPC2;
+#endif
 		/* NORMACA(5) HISUP(4) RESPONSE DATA FORMAT(3-0) */
 		BDSET8W(&data[3], 2, 3, 4);		/* format 2 */
 		BDADD8(&data[1], 1, 4);         /* hierarchical support */
@@ -2544,7 +2548,11 @@ istgt_lu_disk_scsi_inquiry(ISTGT_LU_DISK *spec, CONN_Ptr conn, uint8_t *cdb, uin
 		data[57] = 0;
 		/* VERSION DESCRIPTOR 1-8 */
 		DSET16(&data[58], 0x0960); /* iSCSI (no version claimed) */
+#ifndef	REPLICATION
 		DSET16(&data[60], 0x0300); /* SPC-3 (no version claimed) */
+#else
+		DSET16(&data[60], 0x0260); /* SPC-2 (no version claimed) */
+#endif
 		DSET16(&data[62], 0x0320); /* SBC-2 (no version claimed) */
 		DSET16(&data[64], 0x0040); /* SAM-2 (no version claimed) */
 		DSET16(&data[66], 0x0000);
@@ -9056,6 +9064,8 @@ istgt_lu_disk_busy_excused(int opcode)
 }
 #define checklength \
 	if(transfer_len*spec->blocklen > (uint64_t)lu->MaxBurstLength) { \
+		ISTGT_WARNLOG("c#%d checklength error: transferlen %lu should be < maxburstlen %lu\n", \
+			conn->id, transfer_len*spec->blocklen, (uint64_t)(lu->MaxBurstLength)); \
 		lu_cmd->status = ISTGT_SCSI_STATUS_CHECK_CONDITION; \
 		BUILD_SENSE(ILLEGAL_REQUEST, 0x24, 0x00);\
 		break;\

--- a/src/replication.c
+++ b/src/replication.c
@@ -902,7 +902,7 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 
 	rio_payload = (zvol_op_open_data_t *) malloc(
 	    sizeof (zvol_op_open_data_t));
-	rio_payload->timeout = (10 * 60);
+	rio_payload->timeout = (3 * replica_timeout);
 	rio_payload->tgt_block_size = spec->blocklen;
 	strncpy(rio_payload->volname, spec->volname,
 	    sizeof (rio_payload->volname));

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -187,6 +187,8 @@ setup_test_env() {
 	mkdir -p /mnt/store
 	truncate -s 5G /tmp/test_vol1 /tmp/test_vol2 /tmp/test_vol3
 	logout_of_volume
+	sudo killall -9 istgt
+	sudo killall -9 replication_test
 
 	start_istgt 5G
 }
@@ -369,6 +371,11 @@ run_read_consistency_test ()
 		echo "error happened while running read consistency test"
 		kill -9 $replica1_pid $replica2_pid $replica3_pid
 		return
+	fi
+	var1="$(sudo sg_inq /dev/$device_name | grep SPC-2 | wc -l)"
+	if [ $var1 -ne 1 ]; then
+		sudo sg_inq /dev/$device_name
+		echo "sg_inq command failed" && exit 1
 	fi
 
 	write_data 0 41943040 512 "/dev/$device_name" $file_name

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -372,11 +372,6 @@ run_read_consistency_test ()
 		kill -9 $replica1_pid $replica2_pid $replica3_pid
 		return
 	fi
-	var1="$(sudo sg_inq /dev/$device_name | grep SPC-2 | wc -l)"
-	if [ $var1 -ne 1 ]; then
-		sudo sg_inq /dev/$device_name
-		echo "sg_inq command failed" && exit 1
-	fi
 
 	write_data 0 41943040 512 "/dev/$device_name" $file_name
 	sync


### PR DESCRIPTION
Currently, istgt code advertises that it supports SPC3 reservations. But, in cStor volumes, replicas doesn't support SPC3.

This PR is to disable SPC3 and enable SPC2 reservations while advertising to client.
Update:
Setting Standard Inquiry parameters to SPC2 is limiting initiator not to read BLOCK_LIMITS vpd page.
This is making initiator to send write IOs that are more than 1MB, where as, istgt is configured to throw error if write IO size is more than 1MB.
Had set the standard inquiry parameters to SPC3 (as usual), and started returning error for RESERVE_IN and RESERVE_OUT CDBs.

Also, currently, istgt sends 10*60 seconds as IO time out in its handshake message. This PR changes hardcoded value to 3 times of configured replica_timeout value.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>