### PR TITLE
Added timestamp for logs

### DIFF
--- a/src/istgt.c
+++ b/src/istgt.c
@@ -73,6 +73,7 @@
 #include "istgt_lu.h"
 #include "istgt_proto.h"
 #ifdef	REPLICATION
+#include "replication.h"
 #include "istgt_integration.h"
 #endif
 #include "istgt_misc.h"

--- a/src/istgt.conf
+++ b/src/istgt.conf
@@ -4,7 +4,7 @@
   PidFile "/var/run/istgt.pid"
   AuthFile "/usr/local/etc/istgt/auth.conf"
   LogFile "/usr/local/etc/istgt/logfile"
-  Luworkers 1 
+  Luworkers 6
   MediaDirectory "/mnt"
   Timeout 60
   NopInInterval 20
@@ -52,8 +52,8 @@
   ConsistencyFactor 2
   UnitType Disk
   UnitOnline Yes
-  BlockLength 512
-  QueueDepth 32
+  BlockLength 4096
+  QueueDepth 128
   Luworkers 6
   UnitInquiry "CloudByte" "iscsi" "0" "4059aab98f093c5d95207f7af09d1413"
   PhysRecordLength 4096

--- a/src/replication.h
+++ b/src/replication.h
@@ -15,8 +15,8 @@
 #include <sys/uio.h>
 #include <syslog.h>
 #include <stdbool.h>
-#include "zrepl_prot.h"
 #include "replication_log.h"
+#include "zrepl_prot.h"
 
 #define MAXREPLICA 5
 #define MAXEVENTS 64

--- a/src/replication_log.h
+++ b/src/replication_log.h
@@ -1,6 +1,9 @@
 #ifndef	REPLICATION_LOG_H
 #define	REPLICATION_LOG_H
 
+#include <sys/time.h>
+#include <time.h>
+
 enum replication_log_level {
 	LOG_LEVEL_ERR,
 	LOG_LEVEL_INFO,
@@ -10,38 +13,57 @@ enum replication_log_level {
 
 int replication_log_level;
 
+#define	repl_log(lvl, fmt, ...)						\
+do {									\
+	struct timeval _tv;						\
+	struct tm *_tinfo;						\
+	unsigned int _ms;						\
+	char _l[512];							\
+	int _off = 0;							\
+									\
+	if (replication_log_level < lvl)				\
+		break;							\
+									\
+	/* Create timestamp prefix */					\
+	gettimeofday(&_tv, NULL);					\
+	_tinfo = localtime(&_tv.tv_sec);				\
+	_ms = _tv.tv_usec / 1000;					\
+	strftime(_l, sizeof (_l), "%Y-%m-%d/%H:%M:%S.", _tinfo);	\
+	_off += 20;							\
+	snprintf(_l+ _off, sizeof (_l) - _off, "%03u ", _ms);		\
+	_off += 4;							\
+									\
+	snprintf(_l + _off, sizeof (_l) - _off, fmt, ##__VA_ARGS__);	\
+	fprintf(stderr, "%s\n", _l);					\
+}while(0);
+
 #define REPLICA_LOG(fmt, ...)						\
 {									\
-	if (replication_log_level >= LOG_LEVEL_INFO)			\
-		fprintf(stderr, "%-18.18s:%4d: %-20.20s: " fmt,		\
+	repl_log(LOG_LEVEL_INFO, "%-18.18s:%4d: %-20.20s: " fmt,	\
 		    __func__, __LINE__, tinfo, ##__VA_ARGS__);		\
 }
 
 #define REPLICA_NOTICELOG(fmt, ...)					\
 {									\
-	if (replication_log_level >= LOG_LEVEL_INFO)			\
-		fprintf(stderr, "%-18.18s:%4d: %-20.20s: " fmt,		\
+	repl_log(LOG_LEVEL_INFO, "%-18.18s:%4d: %-20.20s: " fmt,	\
 		    __func__, __LINE__, tinfo, ##__VA_ARGS__);		\
 }
 
 #define REPLICA_ERRLOG(fmt, ...)					\
 {									\
-	if (replication_log_level >= LOG_LEVEL_ERR)			\
-		fprintf(stderr, "%-18.18s:%4d: %-20.20s: " fmt,		\
+	repl_log(LOG_LEVEL_ERR, "%-18.18s:%4d: %-20.20s: " fmt,		\
 		    __func__, __LINE__, tinfo, ##__VA_ARGS__);		\
 }
 #define REPLICA_WARNLOG(fmt, ...)					\
 {									\
-	if (replication_log_level >= LOG_LEVEL_ERR)			\
-		fprintf(stderr, "%-18.18s:%4d: %-20.20s: " fmt,		\
+	repl_log(LOG_LEVEL_ERR, "%-18.18s:%4d: %-20.20s: " fmt,		\
 		    __func__, __LINE__, tinfo, ##__VA_ARGS__);		\
 }
 
 #ifdef	DEBUG
 #define REPLICA_DEBUGLOG(fmt, ...)					\
 {									\
-	if (replication_log_level >= LOG_LEVEL_DEBUG)			\
-		fprintf(stderr, "%-18.18s:%4d: %-20.20s: " fmt,		\
+	repl_log(LOG_LEVEL_DEBUG, "%-18.18s:%4d: %-20.20s: " fmt,	\
 		    __func__, __LINE__, tinfo, ##__VA_ARGS__);		\
 }
 #else


### PR DESCRIPTION
Currently, istgt doesn't have timestamp in its logs. This PR is to add timestamp in the istgt logs.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>