### PR TITLE
Changing mempool allocation for `cmd` with `malloc`

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -28,7 +28,7 @@ MKDEP	 = @MKDEP@
 
 CFLAGS  += -fno-strict-aliasing -Wstrict-aliasing
 CFLAGS  += -Wformat=2 -Wreturn-type
-CFLAGS  += -Wbad-function-cast
+CFLAGS  += -Wbad-function-cast -Wuninitialized -Wunused-variable -Wunused-label -Wunused-function -Wsign-compare -Wno-missing-field-initializers -Wno-missing-braces
 CFLAGS  += -Wcast-qual -Wchar-subscripts -Winline
 CFLAGS  += -Wmissing-prototypes -Wnested-externs -Wpointer-arith
 CFLAGS  += -Wredundant-decls -Wshadow -Wstrict-prototypes -Wwrite-strings

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -17,7 +17,6 @@
 #define	WRITE_PARTIAL	1
 #define	WRITE_COMPLETED	2
 
-extern rte_smempool_t rcmd_mempool;
 /* default timeout is set to REPLICA_DEFAULT_TIMEOUT seconds */
 int replica_timeout = REPLICA_DEFAULT_TIMEOUT;
 
@@ -91,7 +90,7 @@ int replica_timeout = REPLICA_DEFAULT_TIMEOUT;
 			    RECEIVED_ERR;				\
 		}							\
 		free(rcmd->iov_data);					\
-		put_to_mempool(&rcmd_mempool, rcmd);			\
+		free(rcmd);						\
 		rcmd = next_rcmd;					\
 		_cnt++;							\
 	}								\
@@ -563,7 +562,7 @@ start:
 			rcomm_cmd->resp_list[idx].status |= RECEIVED_OK;
 
 		free(r->ongoing_io->iov_data);
-		put_to_mempool(&rcmd_mempool, r->ongoing_io);
+		free(r->ongoing_io);
 		r->ongoing_io = NULL;
 		r->io_read = 0;
 		r->ongoing_io_buf = NULL;

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -72,7 +72,7 @@ typedef struct replica_s {
 
 	zvol_io_hdr_t *io_resp_hdr;	/* header recieved on data connection */
 	int io_state;			/* state of command on data connection */
-	int io_read;			/* amount of IO data read in current IO state for data connection */
+	uint32_t io_read;			/* amount of IO data read in current IO state for data connection */
 	zvol_io_hdr_t *mgmt_io_resp_hdr;/* header recieved on management connection */
 	void *mgmt_io_resp_data;	/* data recieved on management connection */
 	TAILQ_HEAD(, mgmt_cmd_s) mgmt_cmd_queue;	/* mgmt command queue for management connection */

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -10,6 +10,7 @@
 #include <math.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "config.h"
 #include "istgt_misc.h"
 #include "istgt_proto.h"
 #include "replication.h"
@@ -1257,12 +1258,6 @@ main(int argc, char **argv)
 
 	volsize = sbuf.st_size;
 
-	/* Initialize mempool needed for replication*/
-	if (initialize_replication_mempool(false)) {
-		REPLICA_ERRLOG("Failed to initialize mempool\n");
-		return 1;
-	}
-
 	initialize_replication();
 
 	rc = initialize_spec(spec);
@@ -1326,8 +1321,6 @@ main(int argc, char **argv)
 	}
 	free(all_rargs);
 	free(all_rthrds);
-
-	destroy_replication_mempool();
 
 	return 0;
 }

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -582,7 +582,6 @@ error_return:
 static int
 istgt_uctl_cmd_mempoolstats(UCTL_Ptr uctl)
 {
-	ISTGT_LU_DISK *spec = NULL;
 	int rc = 0;
 	char *response = NULL;
 
@@ -610,7 +609,6 @@ istgt_uctl_cmd_mempoolstats(UCTL_Ptr uctl)
 static int
 istgt_uctl_cmd_replica_stats(UCTL_Ptr uctl)
 {
-	ISTGT_LU_Ptr lu = NULL;
 	const char *delim = ARGS_DELIM;
 	int rc = 0;
 	char *arg;
@@ -3539,10 +3537,6 @@ istgt_create_uctl(ISTGT_Ptr istgt, PORTAL_Ptr portal, int sock, struct sockaddr 
 			goto error_return;
 		}
 	}
-
-	printf("sock=%d, addr=%s, peer=%s\n",
-	    sock, uctl->saddr,
-	    uctl->caddr);
 
 	/* wildcard? */
 	if (uctl->family != AF_UNIX) {

--- a/src/istgt_misc.c
+++ b/src/istgt_misc.c
@@ -56,6 +56,7 @@
 #define __attribute__(x)
 #endif
 
+#ifndef	REPLICATION
 static void fatal(const char *format, ...) __attribute__((__noreturn__, __format__(__printf__, 1, 2)));
 
 static void
@@ -71,6 +72,7 @@ fatal(const char *format, ...)
 	va_end(ap);
 	exit(EXIT_FAILURE);
 }
+#endif
 
 typedef struct mem_hdr {
 	uint16_t pIdx;
@@ -324,6 +326,7 @@ poolprint(char *inbuf __attribute__((__unused__)), int len __attribute__((__unus
 
 int memdebug = 0;
 
+#ifndef	REPLICATION
 void *
 xmalloci(size_t size, uint16_t line)
 {
@@ -463,6 +466,7 @@ xstrdupi(const char *s, uint16_t line)
 	p[size - 1] = '\0';
 	return p;
 }
+#endif
 
 char *
 strlwr(char *s)

--- a/src/istgt_misc.h
+++ b/src/istgt_misc.h
@@ -143,12 +143,21 @@
 #define BUNSET32(B,N) ((B) &= ((uint32_t)(~((uint32_t)((1) << (N))))))
 
 /* memory allocate */
+#ifdef	REPLICATION
+#define xmalloc(size)		malloc(size)
+#define xfree(p)		free(p)
+#define xstrdup(s)		(s == NULL) ? NULL : strdup(s)
+#define	xmalloci(size, l)	malloc(size)
+#define	xfreei(p, l)		free(p)
+#define	xstrdupi(s, l)		(s == NULL) ? NULL : strdup(s)
+#else
 #define xmalloc(size)  xmalloci((size), __LINE__)
 #define xfree(p)  xfreei((p), __LINE__)
 #define xstrdup(s) xstrdupi((s), __LINE__)
 void *xmalloci(size_t size, uint16_t line);
 void xfreei(void *p, uint16_t line);
 char *xstrdupi(const char *s, uint16_t line);
+#endif
 
 /* string functions */
 char *strlwr(char *s);

--- a/src/mock_client.c
+++ b/src/mock_client.c
@@ -249,7 +249,6 @@ mgmt_thrd(void *args)
 	int *cnt = cargs->count;
 	struct timespec now, start, prev, p;
 	char *snapname;
-	int ret;
 
 	snprintf(tinfo, 50, "clientmgmt%d", cargs->workerid);
 	prctl(PR_SET_NAME, tinfo, 0, 0, 0);
@@ -264,11 +263,10 @@ mgmt_thrd(void *args)
 	clock_gettime(CLOCK_MONOTONIC, &prev);
 	while (1) {
 		clock_gettime(CLOCK_MONOTONIC, &p);
-		ret = istgt_lu_create_snapshot(spec, snapname, random() % 2 + 2,
+		(void) istgt_lu_create_snapshot(spec, snapname, random() % 2 + 2,
 		    random() % 2 + 4);
 		clock_gettime(CLOCK_MONOTONIC, &now);
 
-		//REPLICA_LOG("snapshot response: %d time: %ld\n", ret, (now.tv_sec - p.tv_sec));
 		sleep(1);
 		count++;
 		clock_gettime(CLOCK_MONOTONIC, &now);

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -145,7 +145,6 @@ do {														\
 static void
 exit_errored_replica(void *arg)
 {
-	int rc = 0;
 	errored_replica_data_t *rdata = (errored_replica_data_t *)arg;
 
 	if (rdata->mgmtfd != -1)
@@ -694,7 +693,7 @@ try_again:
 						rc = REPL_TEST_RESTART;
 						goto error;
 					}
-					ASSERT(count == mgmtio->len);
+					ASSERT((uint64_t)count == mgmtio->len);
 
 					CONNECTION_CLOSE_ERROR_EPOLL(mgmtfd, epfd, rc, error, err_freq, ERROR_TYPE_MGMT);
 					CONNECTION_CLOSE_ERROR_EPOLL(iofd, epfd, rc, error, err_freq, ERROR_TYPE_DATA);

--- a/src/replication.c
+++ b/src/replication.c
@@ -30,12 +30,8 @@ cstor_conn_ops_t cstor_ops = {
 	.conn_connect = replication_connect,
 };
 
-rte_smempool_t rcmd_mempool;
-rte_smempool_t rcommon_cmd_mempool;
-size_t rcmd_mempool_count = RCMD_MEMPOOL_ENTRIES;
-size_t rcommon_cmd_mempool_count = RCOMMON_CMD_MEMPOOL_ENTRIES;
-
 int replication_initialized = 0;
+size_t rcmd_mempool_count = RCMD_MEMPOOL_ENTRIES;
 
 static int start_rebuild(void *buf, replica_t *replica, uint64_t data_len);
 static void handle_mgmt_conn_error(replica_t *r, int sfd, struct epoll_event *events,
@@ -48,7 +44,8 @@ static int handle_mgmt_event_fd(replica_t *replica);
 
 #define build_rcomm_cmd(rcomm_cmd, cmd, offset, nbytes) 						\
 	do {								\
-		rcomm_cmd = get_from_mempool(&rcommon_cmd_mempool);	\
+		rcomm_cmd = malloc(sizeof (*rcomm_cmd));		\
+		memset(rcomm_cmd, 0, sizeof (*rcomm_cmd));		\
 		rcomm_cmd->copies_sent = 0;				\
 		rcomm_cmd->total_len = 0;				\
 		rcomm_cmd->offset = offset;				\
@@ -578,7 +575,6 @@ is_replica_newly_connected(spec_t *spec, replica_t *new_replica)
 	known_replica_t *kr = NULL;
 	int familiar_replicas = 0;
 	bool newly_connected = false, found = false;
-	replica_t *old_replica = NULL;
 
 	ASSERT(MTX_LOCKED(&spec->rq_mtx));
 
@@ -1417,9 +1413,7 @@ get_replica_stats_json(replica_t *replica, struct json_object **jobj)
 void
 istgt_lu_replica_stats(char *volname, char **resp)
 {
-	bool r;
 	replica_t *replica;
-	int rc;
 	spec_t *spec = NULL;
 	struct json_object *j_stats, *j_replica, *j_spec, *j_obj;
 	const char *json_string = NULL;
@@ -1469,7 +1463,7 @@ istgt_lu_replica_stats(char *volname, char **resp)
 	json_object_object_add(j_obj, "Replica status", j_stats);
 	json_string = json_object_to_json_string_ext(j_obj,
 	    JSON_C_TO_STRING_PLAIN);
-	resp_len = strlen(json_string);
+	resp_len = strlen(json_string) + 1;
 	*resp = malloc(resp_len);
 	memset(*resp, 0, resp_len);
 	strncpy(*resp, json_string, resp_len);
@@ -2236,8 +2230,8 @@ respond_with_error_for_all_outstanding_mgmt_ios(replica_t *r)
 		    sizeof(zvol_io_hdr_t));				\
 		memset(ldata, 0, sizeof(zvol_io_hdr_t) +		\
 		    sizeof(struct zvol_io_rw_hdr));			\
-		rcmd = get_from_mempool(&rcmd_mempool);			\
-		memset(rcmd, 0, sizeof(*rcmd));				\
+		rcmd = malloc(sizeof(*rcmd));				\
+		memset(rcmd, 0, sizeof (*rcmd));			\
 		rcmd->opcode = rcomm_cmd->opcode;			\
 		rcmd->offset = rcomm_cmd->offset;			\
 		rcmd->data_len = rcomm_cmd->data_len;			\
@@ -2424,6 +2418,7 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 	uint64_t num_read_ios = 0;
 	uint64_t inflight_read_ios = 0;
 
+	(void) cmd_read;
 	CHECK_IO_TYPE(cmd, cmd_read, cmd_write, cmd_sync);
 
 again:
@@ -2951,8 +2946,8 @@ initialize_volume(spec_t *spec, int replication_factor, int consistency_factor)
 	VERIFY(replication_factor > 0);
 	VERIFY(consistency_factor > 0);
 
-        init_mempool(&spec->rcommon_deadlist, rcmd_mempool_count, 0, 0,
-            "rcmd_mempool", NULL, NULL, NULL, false);
+	init_mempool(&spec->rcommon_deadlist, rcmd_mempool_count, 0, 0,
+	    "rcmd_mempool", NULL, NULL, NULL, false);
 
 	spec->replication_factor = replication_factor;
 	spec->consistency_factor = consistency_factor;
@@ -2989,87 +2984,11 @@ initialize_volume(spec_t *spec, int replication_factor, int consistency_factor)
 	return 0;
 }
 
-/*
- * This function initializes mempool for replica's command(rcmd_t) and
- * spec's command(rcommon_cmd_t)
- */
-int
-initialize_replication_mempool(bool should_fail)
-{
-	int rc = 0;
-
-	rc = init_mempool(&rcmd_mempool, rcmd_mempool_count, sizeof (rcmd_t), 0,
-	    "rcmd_mempool", NULL, NULL, NULL, true);
-	if (rc == -1) {
-		ISTGT_ERRLOG("Failed to create mempool for command\n");
-		goto error;
-	} else if (rc) {
-		ISTGT_NOTICELOG("rcmd mempool initialized with %u entries\n",
-		    rcmd_mempool.length);
-		if (should_fail) {
-			goto error;
-		}
-		rc = 0;
-	}
-
-	rc = init_mempool(&rcommon_cmd_mempool, rcommon_cmd_mempool_count,
-	    sizeof (rcommon_cmd_t), 0, "rcommon_mempool", NULL, NULL, NULL, true);
-	if (rc == -1) {
-		ISTGT_ERRLOG("Failed to create mempool for command\n");
-		goto error;
-	} else if (rc) {
-		ISTGT_NOTICELOG("rcmd mempool initialized with %u entries\n",
-		    rcommon_cmd_mempool.length);
-		if (should_fail) {
-			goto error;
-		}
-		rc = 0;
-	}
-
-	goto exit;
-
-error:
-	if (rcmd_mempool.ring)
-		destroy_mempool(&rcmd_mempool);
-	if (rcommon_cmd_mempool.ring)
-		destroy_mempool(&rcommon_cmd_mempool);
-
-exit:
-	return rc;
-}
-
-/*
- * This function destroys mempool created for replica's command(rcmd_t)
- * and spec's command(rcommon_cmd_t)
- */
-int
-destroy_replication_mempool(void)
-{
-	int rc = 0;
-
-	rc = destroy_mempool(&rcmd_mempool);
-	if (rc) {
-		ISTGT_ERRLOG("Failed to destroy mempool for rcmd.. err(%d)\n",
-		    rc);
-		goto exit;
-	}
-
-	rc = destroy_mempool(&rcommon_cmd_mempool);
-	if (rc) {
-		ISTGT_ERRLOG("Failed to destroy mempool for rcommon_cmd.."
-		    " err(%d)\n", rc);
-		goto exit;
-	}
-
-exit:
-	return rc;
-}
-
 void
 istgt_lu_mempool_stats(char **resp)
 {
 	struct json_object *j_resp, *j_obj, *j_array;
-	struct json_object *j_spec, *j_replica;
+	struct json_object *j_replica;
 	spec_t *spec;
 	replica_t *r;
 	uint64_t resp_len;
@@ -3077,46 +2996,7 @@ istgt_lu_mempool_stats(char **resp)
 
 	j_resp = json_object_new_array();
 
-	/* rcommon_cmd_mempool */
 	j_obj = json_object_new_object();
-	json_object_object_add(j_obj, "MEMPOOL",
-	    json_object_new_string(rcommon_cmd_mempool.ring->name));
-	json_object_object_add(j_obj, "Size",
-	    json_object_new_int64(rcommon_cmd_mempool.length));
-	json_object_object_add(j_obj, "Free",
-	    json_object_new_int64(get_num_entries_from_mempool(
-	    &rcommon_cmd_mempool)));
-
-	j_array = json_object_new_array();
-
-	MTX_LOCK(&specq_mtx);
-	TAILQ_FOREACH(spec, &spec_q, spec_next) {
-		j_spec = json_object_new_object();
-		json_object_object_add(j_spec, "volume",
-		    json_object_new_string(spec->volname));
-		json_object_object_add(j_spec, "in-flight read",
-		    json_object_new_int64(spec->inflight_read_io_cnt));
-		json_object_object_add(j_spec, "in-flight write",
-		    json_object_new_int64(spec->inflight_write_io_cnt));
-		json_object_object_add(j_spec, "in-flight sync",
-		    json_object_new_int64(spec->inflight_sync_io_cnt));
-		json_object_array_add(j_array, j_spec);
-	}
-	MTX_UNLOCK(&specq_mtx);
-	json_object_object_add(j_obj, "volume usage", j_array);
-	json_object_array_add(j_resp, j_obj);
-
-	/* rcommon_cmd_mempool end */
-
-	/* rcmd_mempool */
-	j_obj = json_object_new_object();
-	json_object_object_add(j_obj, "MEMPOOL",
-	    json_object_new_string(rcommon_cmd_mempool.ring->name));
-	json_object_object_add(j_obj, "Size",
-	    json_object_new_int64(rcmd_mempool.length));
-	json_object_object_add(j_obj, "Free",
-	    json_object_new_int64(get_num_entries_from_mempool(&rcmd_mempool)));
-
 	j_array = json_object_new_array();
 
 	MTX_LOCK(&specq_mtx);
@@ -3134,6 +3014,9 @@ istgt_lu_mempool_stats(char **resp)
 			json_object_object_add(j_replica, "in-flight sync",
 			    json_object_new_int64(
 			    r->replica_inflight_sync_io_cnt));
+			json_object_object_add(j_replica, "in-flight command",
+			    json_object_new_int64(
+			    get_num_entries_from_mempool(&r->cmdq)));
 			json_object_array_add(j_array, j_replica);
 		}
 	}
@@ -3148,7 +3031,7 @@ istgt_lu_mempool_stats(char **resp)
 
 	json_string = json_object_to_json_string_ext(j_obj,
 	    JSON_C_TO_STRING_PLAIN);
-	resp_len = strlen(json_string);
+	resp_len = strlen(json_string) + 1;
 	*resp = malloc(resp_len);
 	memset(*resp, 0, resp_len);
 	strncpy(*resp, json_string, resp_len);
@@ -3201,8 +3084,7 @@ cleanup_deadlist(void *arg)
 				for (i=1; i<rcomm_cmd->iovcnt + 1; i++)
 					xfree(rcomm_cmd->iov[i].iov_base);
 
-				memset(rcomm_cmd, 0, sizeof(rcommon_cmd_t));
-				put_to_mempool(&rcommon_cmd_mempool, rcomm_cmd);
+				free(rcomm_cmd);
 			} else {
 				put_to_mempool(&spec->rcommon_deadlist, rcomm_cmd);
 			}

--- a/src/replication.h
+++ b/src/replication.h
@@ -24,14 +24,14 @@
 #define MAXIPLEN 56
 #define MAXNAMELEN 256
 
-#define RCOMMON_CMD_MEMPOOL_ENTRIES     100000
-
 #include "istgt_lu.h"
 
 /*
  * NOTE : RCMD_MEMPOOL_ENTRIES depends on number of replicas ISGT can support
+ * current limit is 524288 per replica. Replica will be able to serve
+ * 524288 in-flight IOs.
  */
-#define RCMD_MEMPOOL_ENTRIES    (3 * RCOMMON_CMD_MEMPOOL_ENTRIES)
+#define RCMD_MEMPOOL_ENTRIES    (1 << 19)
 
 #define MAX(a,b) (((a)>(b))?(a):(b))
 
@@ -169,8 +169,6 @@ int make_socket_non_blocking(int);
 int send_mgmtack(int, zvol_op_code_t, void *, char *, int);
 int zvol_handshake(spec_t *, replica_t *);
 void accept_mgmt_conns(int, int);
-int initialize_replication_mempool(bool should_fail);
-int destroy_replication_mempool(void);
 void clear_rcomm_cmd(rcommon_cmd_t *);
 void ask_replica_status(spec_t *spec, replica_t *replica);
 extern void * replica_thread(void *);

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -607,7 +607,7 @@ again:
 					if (count < 0) {
 						rc = -1;
 						goto error;
-					} else if (count != mgmtio->len) {
+					} else if ((uint64_t)count != mgmtio->len) {
 						REPLICA_ERRLOG("failed to getch mgmt data.. got only %ld bytes out of %lu\n",
 						    count, mgmtio->len);
 						rc = -1;


### PR DESCRIPTION
Changes : 
- Enabling compilation warning for unused and uninitialized variables and sign compare
   (`-Wuninitialized -Wunused-variable -Wunused-label -Wunused-function -Wsign-compare`)
- Removing logging from istgt_create_uctl regarding address `(sock=%d, addr=%s, peer=%s)`
- Changing istgt malloc/free/strdup API to glibc API
- Changing memory allocation for cmd(for spec and replica in replication module) from mempool to malloc/free
- Disabling mempool allocation for ISTGT.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>