### PR TITLE
Adding debug message for IO latency in ISTGT

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -532,6 +532,9 @@ handle_epoll_in_event(replica_t *r)
 	bool task_completed = false;
 	bool unblocked = false;
 	pthread_cond_t *cond_var;
+#ifdef	DEBUG
+	struct timespec now;
+#endif
 
 start:
 	ret = read_cmd(r);
@@ -549,7 +552,12 @@ start:
 		rcomm_cmd->resp_list[idx].data_ptr = r->ongoing_io_buf;
 
 		DECREMENT_INFLIGHT_REPLICA_IO_CNT(r, rcomm_cmd->opcode);
-
+#ifdef	DEBUG
+		if (r->ongoing_io->r_io) {
+			r->ongoing_io->r_io->zvol_guid = r->zvol_guid;
+			timesdiff(CLOCK_MONOTONIC, r->ongoing_io->l_queued_time, now, r->ongoing_io->r_io->diff);
+		}
+#endif
 		/*
 		 * cleanup_deadlist thread performs cleanup of rcomm_cmd.
 		 * if the response from all replica is received. Since we are

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -80,6 +80,12 @@
 #include "istgt_scsi.h"
 #include "istgt_queue.h"
 
+#if defined(REPLICATION) && defined(DEBUG)
+#include "replication.h"
+extern spec_io_latency io_arr[MAX_LATENCY_IO];
+extern uint64_t io_arr_idx;
+#endif
+
 #include <netinet/in.h>
 
 #if !defined(__GNUC__)
@@ -5692,6 +5698,15 @@ sender(void *arg)
 				goto dequeue_result_queue;
 			}
 		}
+#if defined(REPLICATION) && defined(DEBUG)
+		int64_t latency_idx;
+		struct timespec l_now;
+
+		latency_idx = lu_task->lu_cmd.io_arr_idx;
+		if (latency_idx >= 0) {
+			timesdiff(CLOCK_MONOTONIC, io_arr[latency_idx].queued_time, l_now, io_arr[latency_idx].diff);
+		}
+#endif
 		if(lu_task->lu_cmd.aborted == 1 || lu_task->lu_cmd.release_aborted == 1)
 		{
 			ISTGT_LOG("Aborted from result queue\n");

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -430,6 +430,10 @@ typedef struct istgt_lu_cmd_t {
 #ifdef REPLICATION
 	uint32_t   luworkerindx;
 #endif
+
+#if defined(REPLICATION) && defined(DEBUG)
+	int32_t io_arr_idx;
+#endif
 } ISTGT_LU_CMD;
 typedef ISTGT_LU_CMD *ISTGT_LU_CMD_Ptr;
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -34,6 +34,26 @@
 #define RCMD_MEMPOOL_ENTRIES    (1 << 19)
 
 #define MAX(a,b) (((a)>(b))?(a):(b))
+#define	ARRAY_SIZE(x)	(sizeof(x)/sizeof(x[0]))
+
+#ifdef	DEBUG
+#define	MAX_LATENCY_IO	(1 << 18)
+uint32_t is_io_arr_full;
+typedef struct {
+	uint64_t zvol_guid;
+	struct timespec diff;
+} r_io_latency;
+
+typedef struct {
+	uint8_t type;
+	size_t size;
+	off_t offset;
+	int lu_idx;
+	r_io_latency r_io[MAXREPLICA];
+	struct timespec diff;
+	struct timespec queued_time;
+} spec_io_latency;
+#endif
 
 typedef enum zvol_cmd_type_e {
 	CMD_IO = 1,
@@ -102,6 +122,10 @@ typedef struct rcmd_s {
 	uint64_t data_len;
 	struct iovec iov[41];
 	struct timespec queued_time;
+#ifdef	DEBUG
+	struct timespec l_queued_time;
+	r_io_latency *r_io;
+#endif
 } rcmd_t;
 
 typedef struct replica_s replica_t;


### PR DESCRIPTION
Changes : 
- Added debug message for printing IO latency for the 4k number of IOs (This limit can be increased by changing `MAX_IO_LATENCY` in `replication.h`).
Command: `istgtcontrol  dump`
The output of the above command will be dumped in `ISTGT` logs.
Sample output: 
```cmd type read:1 write:2 sync:3
idx:27 type:1 size:4096 off:0 lu_idx:1 total_time:0.490699 zvol:6062 time : 0.298930 zvol:6063 time : 0.361183 zvol:6061 time : 0.323044 
idx:28 type:1 size:4096 off:4096 lu_idx:0 total_time:0.295407 zvol:6062 time : 0.219168 zvol:6063 time : 0.251822 zvol:6061 time : 0.240076 
idx:29 type:1 size:4096 off:12288 lu_idx:1 total_time:0.273931 zvol:6062 time : 0.216096 zvol:6063 time : 0.245483 zvol:6061 time : 0.234878 
```
Here,
`idx`: is for indexing purpose 
`type` : command type (read:1 write:2 sync:3)
`size` : IO size
`off` : offset
`lu_idx` : lu worker index
`total_time` : Total time ISTGT have taken to serve this IO (in seconds.nano_seconds)
`zvol` :  Replica ZVOL guid
`time` : Time taken by replica `zvol` to serve this IO (in seconds.nano_seconds)

Signed-off-by: mayank <mayank.patel@cloudbyte.com>