### PR TITLE
Avoid iterating through a replica's blocked_queue if the next command in the blocked_queue is in a blocked state.

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -148,10 +148,10 @@ unblock_cmds(replica_t *r)
 		cmd_blocked = false;
 		CHECK_BLOCKAGE_IN_Q(&r->readyq, next);
 		if (cmd_blocked == true)
-			continue;
+			break;
 		CHECK_BLOCKAGE_IN_Q(&r->waitq, next);
 		if (cmd_blocked == true)
-			continue;
+			break;
 		TAILQ_REMOVE(&r->blockedq, cmd, next);
 		TAILQ_INSERT_TAIL(&r->readyq, cmd, next);
 		unblocked = true;


### PR DESCRIPTION
Changes : 
- Avoid iterating through a replica's blocked_queue if the next command in the blocked_queue is in a blocked state.
   As of now, we are iterating through a replica's blocked_cmd_queue and if a command is not blocked then we are enqueuing it to the ready_queue. With this approach, There are chances that the command sequence will be different in the replica's ready_queue compare to the replica's cmd_queue. To avoid this, iterating through a blocked_queue should be stopped if a command from blocked_queue is in the blocked state.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>