### PR TITLE
fix(build): fetch the zfs header from the correct branch

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
+. ./fetch-zfs-branch.sh
+echo "Using zfs branch - ${ZFS_BUILD_BRANCH}"
+echo $(wget -O /tmp/zrepl_prot.h https://raw.githubusercontent.com/openebs/zfs/${ZFS_BUILD_BRANCH}/include/zrepl_prot.h)
+
 autoreconf -fiv
 rm -Rf autom4te.cache

--- a/configure.ac
+++ b/configure.ac
@@ -187,7 +187,7 @@ AC_ARG_ENABLE([replication],
   AC_SUBST([target_header_files], ['${istgt_header} ${replication_header}'])
   AC_MSG_NOTICE([fetching zrepl_prot.h file...])
   AC_SUBST([replication_bin], ['istgt_integration replication_test mempool_test'])
-  AS_IF([$( wget -O src/zrepl_prot.h https://raw.githubusercontent.com/openebs/zfs/zfs-0.7-release/include/zrepl_prot.h >> /dev/null 2>&1 )], , [AC_MSG_ERROR([failed to fetch zrepl_prot.h])]),
+  AS_IF([$( cp /tmp/zrepl_prot.h src/zrepl_prot.h )], , [AC_MSG_ERROR([failed to fetch zrepl_prot.h])]),
   AC_MSG_RESULT(no)
   AC_SUBST([replication_bin], ['']))
 AC_SUBST([REPLICATION])

--- a/fetch-zfs-branch.sh
+++ b/fetch-zfs-branch.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+if [ ! -z ${TRAVIS_TAG} ];
+then
+  ZFS_BUILD_BRANCH=${TRAVIS_TAG}
+  echo "Using ZFS repo tag: ${ZFS_BUILD_BRANCH}"
+else
+  #Current active (master) zfs and spl development branch
+  ZFS_MASTER="zfs-0.7-release"
+  ZFS_REPO="https://github.com/openebs/zfs.git"
+
+  #Determinte the current branch depending on the build env.
+  CURRENT_BRANCH=""
+  if [ -z ${TRAVIS_BRANCH} ];
+  then
+    CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+  else
+    CURRENT_BRANCH=${TRAVIS_BRANCH}
+  fi
+
+  #Depending on the current istgt branch name decide corresponding ZFS Build branch.
+  # If current is master - use $ZFS_MASTER
+  # If current is non master branch and if it exists on remote use non-master branch
+  #   else set it to $ZFS_MASTER
+  ZFS_BUILD_BRANCH=${ZFS_MASTER}
+  if [ -z ${CURRENT_BRANCH} ] || [ ${CURRENT_BRANCH} = "replication" ];
+  then
+    echo "Using ZFS master build branch: ${ZFS_BUILD_BRANCH}"
+  else
+    #If the current branch exists on the remote repo, use it for building
+    # Branch names can be really funky with substring matches.
+    # Extract the branch name from git ls-remote. The output line will be like:
+    #  a8577bdb32e091645df901d8501e44ef50748389        refs/heads/master
+    #  3be04072fa507127e9161283f27024e2bde702e3        refs/heads/rebuild_snapshot
+    #  33218f9966a12f8961f7d7e94307a74328acf928        refs/heads/rebuild_snapshot_1
+    BF=$(git ls-remote --heads ${ZFS_REPO} | cut -d '/' -f3 | grep -x "${CURRENT_BRANCH}" | wc -l)
+    if [ $BF -ne 0 ]; then
+      ZFS_BUILD_BRANCH=${CURRENT_BRANCH}
+      echo "Using ZFS build branch: ${ZFS_BUILD_BRANCH}"
+    else
+      echo "${CURRENT_BRANCH} not found on zfs repo."
+      echo "Using ZFS master build branch: ${ZFS_BUILD_BRANCH}"
+    fi
+  fi
+fi
+
+export ZFS_BUILD_BRANCH
+


### PR DESCRIPTION
autoreconf is always fetching the zfs header file from zfs repo
master branch. This make it incompatible to build on released
branches if there has been a change to the header file on the master.

Added script to determine the zfs branch from which the header
file should be fetched.
- If tagged build, fetch from the corresponding tag
- If master (replication), fetch from the zfs master
- If non-master, fetch from corresponding zfs branch if it exists
  or use the zfs master

Signed-off-by: kmova <kiran.mova@openebs.io>
(cherry picked from commit c1d53eb2b414a61cb845fe55fe3e043adc429293)