### PR TITLE
feat(build): build docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: c
 sudo: required
 dist: trusty
+group: edge
+services:
+  - docker
 before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update -qq
     - sudo apt-get install --yes -qq gcc-6 g++-6 gdb
-    - sudo apt-get install libssl-dev open-iscsi docker.io libjson-c-dev
+    - sudo apt-get install libssl-dev open-iscsi libjson-c-dev
     # use gcc-6 by default
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
@@ -24,3 +27,5 @@ script:
     # run ztest and test supported zio backends
     - sudo bash ./print_debug_info.sh &
     - travis_wait 60 sudo bash ./test_istgt.sh || travis_terminate 1;
+    - pwd
+    - ./build_image.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # top Makefile
-
 top_srcdir = .
 srcdir   = .
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
-. ./fetch-zfs-branch.sh
+if [ ! -z ${TRAVIS_TAG} ];
+then
+  ZFS_BUILD_BRANCH=${TRAVIS_TAG}
+else
+  . ./fetch-zfs-branch.sh
+fi
+
 echo "Using zfs branch - ${ZFS_BUILD_BRANCH}"
 echo $(wget -O /tmp/zrepl_prot.h https://raw.githubusercontent.com/openebs/zfs/${ZFS_BUILD_BRANCH}/include/zrepl_prot.h)
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+BUILD_DATE=$(date +'%Y%m%d%H%M%S')
+REPO_NAME="openebs/cstor-istgt"
+
+echo "Build image ${REPO_NAME}:ci with BUILD_DATE=${BUILD_DATE}"
+
+cp src/istgt ./docker
+cp src/istgtcontrol ./docker
+cp src/istgt.conf ./docker
+cp src/istgtcontrol.conf ./docker
+
+sudo docker version
+sudo docker build --help
+
+cd docker && \
+ sudo docker build -f Dockerfile -t ${REPO_NAME}:ci --build-arg BUILD_DATE=${BUILD_DATE} . && \
+ IMAGE_REPO=${REPO_NAME} ./push && \
+ cd ..
+
+rm -rf ./docker/istgt*
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+#
+# This Dockerfile builds cstor istgt container running istgt from istgt base image
+#
+
+FROM ubuntu:14.04
+RUN apt-get update; exit 0
+RUN apt-get -y install rsyslog
+RUN apt-get -y install net-tools iputils-ping
+RUN apt-get -y install libssl-dev libjson-c-dev libjemalloc-dev
+RUN apt -y install apt-file && apt-file update
+
+RUN mkdir -p /usr/local/etc/bkpistgt
+RUN mkdir -p /usr/local/etc/istgt
+COPY istgt istgtcontrol /usr/local/bin/
+COPY istgt.conf istgtcontrol.conf /usr/local/etc/bkpistgt/
+RUN touch /usr/local/etc/bkpistgt/auth.conf
+RUN touch /usr/local/etc/bkpistgt/logfile
+
+COPY entrypoint-istgtimage.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor"
+LABEL org.label-schema.description="OpenEBS cstor"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint-istgtimage.sh
+EXPOSE 3260 6060

--- a/docker/entrypoint-istgtimage.sh
+++ b/docker/entrypoint-istgtimage.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -o errexit
+trap 'call_exit $LINE_NO' EXIT
+
+call_exit()
+{
+echo "at call_exit.."     
+echo  "exit code:" $?
+echo "reference: "  $0 
+}
+
+if [ ! -f "/usr/local/etc/istgt/istgt.conf" ];then
+	cp /usr/local/etc/bkpistgt/istgt.conf /usr/local/etc/istgt/
+	sed -i -n '/LogicalUnit section/,$!p' /usr/local/etc/istgt/istgt.conf
+fi
+cp /usr/local/etc/bkpistgt/istgtcontrol.conf /usr/local/etc/istgt/
+touch /usr/local/etc/istgt/auth.conf
+touch /usr/local/etc/istgt/logfile
+export externalIP=0.0.0.0
+service rsyslog start
+
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+exec /usr/local/bin/istgt
+

--- a/docker/push
+++ b/docker/push
@@ -15,7 +15,7 @@ then
   exit 1
 fi
 
-# In case of cstor, the commit id doesn't change so using date. 
+# Generate a uniqe tag based on the commit and tag
 BUILD_ID=$(git describe --tags --always)
 
 # Determine the current branch

--- a/docker/push
+++ b/docker/push
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+
+if [ -z ${IMAGE_REPO} ];
+then
+  echo "Error: IMAGE_REPO is not specified";
+  exit 1
+fi
+
+IMAGEID=$( sudo docker images -q ${IMAGE_REPO}:ci )
+echo $IMAGEID 
+if [ -z ${IMAGEID} ];
+then
+  echo "Error: unable to get IMAGEID for ${IMAGE_REPO}:ci";
+  exit 1
+fi
+
+# In case of cstor, the commit id doesn't change so using date. 
+BUILD_ID=$(git describe --tags --always)
+
+# Determine the current branch
+CURRENT_BRANCH=""
+if [ -z ${TRAVIS_BRANCH} ];
+then
+  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+else
+  CURRENT_BRANCH=${TRAVIS_BRANCH}
+fi
+
+#Depending on the branch where builds are generated, 
+# set the tag CI (fixed) and build tags.
+BUILD_TAG="${CURRENT_BRANCH}-${BUILD_ID}"
+CI_TAG="${CURRENT_BRANCH}-ci"
+if [ ${CURRENT_BRANCH} = "replication" ]; then
+  CI_TAG="ci"
+fi
+
+echo "Set the fixed ci image tag as: ${CI_TAG}"
+echo "Set the build/unique image tag as: ${BUILD_TAG}"
+
+function TagAndPushImage() {
+  REPO="$1"
+  TAG="$2"
+  
+  IMAGE_URI="${REPO}:${TAG}";
+  sudo docker tag ${IMAGEID} ${IMAGE_URI};
+  echo " push ${IMAGE_URI}";
+  sudo docker push ${IMAGE_URI};
+}
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "${IMAGE_REPO}" "${CI_TAG}"
+
+  # Push unique tagged image - :master-<uuid> or :branch-<uuid>
+  # This unique/build image will be pushed to corresponding ci repo. 
+  TagAndPushImage "${IMAGE_REPO}-ci" "${BUILD_TAG}"
+
+
+  if [ ! -z "${TRAVIS_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    TagAndPushImage "${IMAGE_REPO}" "${TRAVIS_TAG}"
+    TagAndPushImage "${IMAGE_REPO}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${IMAGE_REPO} to docker hub";
+fi;
+
+# Push ci image to quay.io for security scanning
+if [ ! -z "${QNAME}" ] && [ ! -z "${QPASS}" ]; 
+then 
+  sudo docker login -u "${QNAME}" -p "${QPASS}" quay.io;
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "quay.io/${IMAGE_REPO}" "${CI_TAG}"
+
+  if [ ! -z "${TRAVIS_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    TagAndPushImage "quay.io/${IMAGE_REPO}" "${TRAVIS_TAG}"
+    TagAndPushImage "quay.io/${IMAGE_REPO}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${IMAGE_REPO} to quay";
+fi;
+

--- a/fetch-zfs-branch.sh
+++ b/fetch-zfs-branch.sh
@@ -1,49 +1,26 @@
 #!/bin/bash
 set -e
 
-if [ ! -z ${TRAVIS_TAG} ];
-then
-  ZFS_BUILD_BRANCH=${TRAVIS_TAG}
-  echo "Using ZFS repo tag: ${ZFS_BUILD_BRANCH}"
-else
-  #Current active (master) zfs and spl development branch
-  ZFS_MASTER="zfs-0.7-release"
-  ZFS_REPO="https://github.com/openebs/zfs.git"
-
-  #Determinte the current branch depending on the build env.
-  CURRENT_BRANCH=""
-  if [ -z ${TRAVIS_BRANCH} ];
-  then
-    CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
-  else
-    CURRENT_BRANCH=${TRAVIS_BRANCH}
-  fi
-
-  #Depending on the current istgt branch name decide corresponding ZFS Build branch.
-  # If current is master - use $ZFS_MASTER
-  # If current is non master branch and if it exists on remote use non-master branch
-  #   else set it to $ZFS_MASTER
-  ZFS_BUILD_BRANCH=${ZFS_MASTER}
-  if [ -z ${CURRENT_BRANCH} ] || [ ${CURRENT_BRANCH} = "replication" ];
-  then
-    echo "Using ZFS master build branch: ${ZFS_BUILD_BRANCH}"
-  else
-    #If the current branch exists on the remote repo, use it for building
-    # Branch names can be really funky with substring matches.
-    # Extract the branch name from git ls-remote. The output line will be like:
-    #  a8577bdb32e091645df901d8501e44ef50748389        refs/heads/master
-    #  3be04072fa507127e9161283f27024e2bde702e3        refs/heads/rebuild_snapshot
-    #  33218f9966a12f8961f7d7e94307a74328acf928        refs/heads/rebuild_snapshot_1
-    BF=$(git ls-remote --heads ${ZFS_REPO} | cut -d '/' -f3 | grep -x "${CURRENT_BRANCH}" | wc -l)
-    if [ $BF -ne 0 ]; then
-      ZFS_BUILD_BRANCH=${CURRENT_BRANCH}
-      echo "Using ZFS build branch: ${ZFS_BUILD_BRANCH}"
-    else
-      echo "${CURRENT_BRANCH} not found on zfs repo."
-      echo "Using ZFS master build branch: ${ZFS_BUILD_BRANCH}"
-    fi
-  fi
-fi
-
+#This file is used to specify the ZFS branch from
+# where to fetch the zfs header files. Depending 
+# on the release - the header file should be fetched
+# from different location. 
+#
+# For example:
+#  master -> master
+#  v0.7.x -> v0.7.x
+#
+# The above 1:1 mapping can't always be guaranteed when 
+# working in forked repos with branch names like:
+#  fix-ta123
+#
+# Now, `fix-ta123` could be a created either from master or 
+# v0.7.x. This file needs to determine the correct zfs branch
+# by finding the parent of `fix-ta123` and checking if the 
+# correpsonding branch exists on openebs/zfs.
+#
+#For the moment, we will go with making sure the correct
+# branch name is provided as part of the release process.
+ZFS_BUILD_BRANCH="zfs-0.7-release"
 export ZFS_BUILD_BRANCH
 


### PR DESCRIPTION
This repository contains the complete code for istgt
and has a dependency to dynamically fetch a zfs header
file from openebs/zfs repo.

The previous commit (#81) tried to make the fetch automated
by using the current branch name as a key to identify the
dependent branch. However, not all scenarios got covered.
Besides having the images built in openebs/cstor repo - made
it more tricky to determine the current branch that needs
to be used as key.

Also, building in opeenbs/cstor repo kind of de-links the
commits from the images and depend on a manual trigger
by the cstor repo to build a docker image.

This PR addresses the following:
- Add code to build the docker images after a successful build.
- Put a place holder for specifying the dependent zfs branch

Signed-off-by: kmova <kiran.mova@openebs.io>