### PR TITLE
[US3445] cherrypick to 0.7.1

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -148,10 +148,10 @@ unblock_cmds(replica_t *r)
 		cmd_blocked = false;
 		CHECK_BLOCKAGE_IN_Q(&r->readyq, next);
 		if (cmd_blocked == true)
-			continue;
+			break;
 		CHECK_BLOCKAGE_IN_Q(&r->waitq, next);
 		if (cmd_blocked == true)
-			continue;
+			break;
 		TAILQ_REMOVE(&r->blockedq, cmd, next);
 		TAILQ_INSERT_TAIL(&r->readyq, cmd, next);
 		unblocked = true;


### PR DESCRIPTION
Changes : 
- Commits from `replication` branch
```
commit e26dc3e267836fe6d13a387308cda4bad4cbb2fc
Author: Mayank <33252549+mynktl@users.noreply.github.com>
Date:   Tue Sep 11 15:16:45 2018 +0530

    - Avoid iterating through a replica's blocked_queue if the (#78)
    
    next command in the blocked_queue is in a blocked state.
    
    Signed-off-by: mayank <mayank.patel@cloudbyte.com>
```