### PR TITLE
fmt(cstyle): fixes in src/istgt_iscsi_xcopy.h

### DIFF
--- a/src/istgt_iscsi_param.c
+++ b/src/istgt_iscsi_param.c
@@ -67,7 +67,7 @@ istgt_iscsi_param_find(ISCSI_PARAM *params, const char *key)
 		return (NULL);
 	for (param = params; param != NULL; param = param->next) {
 		if (param->key != NULL && param->key[0] == key[0] &&
-			strcasecmp(param->key, key) == 0) {
+		    strcasecmp(param->key, key) == 0) {
 			return (param);
 		}
 	}
@@ -84,7 +84,7 @@ istgt_iscsi_param_del(ISCSI_PARAM **params, const char *key)
 		return (0);
 	for (param = *params; param != NULL; param = param->next) {
 		if (param->key != NULL && (param->key[0] == key[0]) &&
-		strcasecmp(param->key, key) == 0) {
+		    strcasecmp(param->key, key) == 0) {
 			if (prev_param != NULL) {
 				prev_param->next = param->next;
 			} else {
@@ -106,7 +106,7 @@ istgt_iscsi_param_add(ISCSI_PARAM **params, const char *key, const char *val,
 	ISCSI_PARAM *param, *last_param;
 
 	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "add %s=%s, list=[%s], type=%d\n",
-	key, val, list, type);
+	    key, val, list, type);
 	if (key == NULL)
 		return (-1);
 	param = istgt_iscsi_param_find(*params, key);

--- a/src/istgt_iscsi_param.c
+++ b/src/istgt_iscsi_param.c
@@ -66,7 +66,7 @@ istgt_iscsi_param_find(ISCSI_PARAM *params, const char *key)
 	if (params == NULL || key == NULL)
 		return (NULL);
 	for (param = params; param != NULL; param = param->next) {
-		if (param->key != NULL && param->key[0] == key[0] && \
+		if (param->key != NULL && param->key[0] == key[0] &&
 			strcasecmp(param->key, key) == 0) {
 			return (param);
 		}
@@ -83,7 +83,7 @@ istgt_iscsi_param_del(ISCSI_PARAM **params, const char *key)
 	if (params == NULL || key == NULL)
 		return (0);
 	for (param = *params; param != NULL; param = param->next) {
-		if (param->key != NULL && (param->key[0] == key[0]) && \
+		if (param->key != NULL && (param->key[0] == key[0]) &&
 		strcasecmp(param->key, key) == 0) {
 			if (prev_param != NULL) {
 				prev_param->next = param->next;
@@ -100,7 +100,7 @@ istgt_iscsi_param_del(ISCSI_PARAM **params, const char *key)
 }
 
 int
-istgt_iscsi_param_add(ISCSI_PARAM **params, const char *key, const char *val, \
+istgt_iscsi_param_add(ISCSI_PARAM **params, const char *key, const char *val,
 	const char *list, int type)
 {
 	ISCSI_PARAM *param, *last_param;

--- a/src/istgt_iscsi_param.c
+++ b/src/istgt_iscsi_param.c
@@ -64,14 +64,14 @@ istgt_iscsi_param_find(ISCSI_PARAM *params, const char *key)
 	ISCSI_PARAM *param;
 
 	if (params == NULL || key == NULL)
-		return NULL;
+		return (NULL);
 	for (param = params; param != NULL; param = param->next) {
-		if (param->key != NULL && param->key[0] == key[0]
-			&& strcasecmp(param->key, key) == 0) {
-			return param;
+		if (param->key != NULL && param->key[0] == key[0] && \
+			strcasecmp(param->key, key) == 0) {
+			return (param);
 		}
 	}
-	return NULL;
+	return (NULL);
 }
 
 int
@@ -81,10 +81,10 @@ istgt_iscsi_param_del(ISCSI_PARAM **params, const char *key)
 
 	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "del %s\n", key);
 	if (params == NULL || key == NULL)
-		return 0;
+		return (0);
 	for (param = *params; param != NULL; param = param->next) {
-		if (param->key != NULL && param->key[0] == key[0]
-			&& strcasecmp(param->key, key) == 0) {
+		if (param->key != NULL && (param->key[0] == key[0]) && \
+		strcasecmp(param->key, key) == 0) {
 			if (prev_param != NULL) {
 				prev_param->next = param->next;
 			} else {
@@ -92,28 +92,29 @@ istgt_iscsi_param_del(ISCSI_PARAM **params, const char *key)
 			}
 			param->next = NULL;
 			istgt_iscsi_param_free(param);
-			return 0;
+			return (0);
 		}
 		prev_param = param;
 	}
-	return -1;
+	return (-1);
 }
 
 int
-istgt_iscsi_param_add(ISCSI_PARAM **params, const char *key, const char *val, const char *list, int type)
+istgt_iscsi_param_add(ISCSI_PARAM **params, const char *key, const char *val, \
+	const char *list, int type)
 {
 	ISCSI_PARAM *param, *last_param;
 
 	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "add %s=%s, list=[%s], type=%d\n",
-				   key, val, list, type);
+	key, val, list, type);
 	if (key == NULL)
-		return -1;
+		return (-1);
 	param = istgt_iscsi_param_find(*params, key);
 	if (param != NULL) {
 		istgt_iscsi_param_del(params, key);
 	}
-	param = xmalloc(sizeof *param);
-	memset(param, 0, sizeof *param);
+	param = xmalloc(sizeof (*param));
+	memset(param, 0, sizeof (*param));
 	param->next = NULL;
 	param->key = xstrdup(key);
 	param->val = xstrdup(val);
@@ -130,7 +131,7 @@ istgt_iscsi_param_add(ISCSI_PARAM **params, const char *key, const char *val, co
 		*params = param;
 	}
 
-	return 0;
+	return (0);
 }
 
 int
@@ -142,13 +143,13 @@ istgt_iscsi_param_set(ISCSI_PARAM *params, const char *key, const char *val)
 	param = istgt_iscsi_param_find(params, key);
 	if (param == NULL) {
 		ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "no key %s\n", key);
-		return -1;
+		return (-1);
 	}
 
 	xfree(param->val);
 	param->val = xstrdup(val);
 
-	return 0;
+	return (0);
 }
 
 int
@@ -161,14 +162,14 @@ istgt_iscsi_param_set_int(ISCSI_PARAM *params, const char *key, int val)
 	param = istgt_iscsi_param_find(params, key);
 	if (param == NULL) {
 		ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "no key %s\n", key);
-		return -1;
+		return (-1);
 	}
 
 	xfree(param->val);
-	snprintf(buf, sizeof buf, "%d", val);
+	snprintf(buf, sizeof (buf), "%d", val);
 	param->val = xstrdup(buf);
 
-	return 0;
+	return (0);
 }
 
 int
@@ -202,7 +203,7 @@ istgt_iscsi_parse_params(ISCSI_PARAM **params, const uint8_t *data, int len)
 		error_return:
 			xfree(key);
 			xfree(val);
-			return -1;
+			return (-1);
 		}
 		n = q - p;
 		if (n > ISCSI_TEXT_MAX_KEY_LEN) {
@@ -240,5 +241,5 @@ istgt_iscsi_parse_params(ISCSI_PARAM **params, const uint8_t *data, int len)
 
 	xfree(key);
 	xfree(val);
-	return 0;
+	return (0);
 }

--- a/src/istgt_iscsi_xcopy.h
+++ b/src/istgt_iscsi_xcopy.h
@@ -63,12 +63,12 @@ typedef struct istgt_xcopy_tgt_t {
 
 int istgt_lu_disk_receive_copy_results(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
 int istgt_lu_disk_xcopy(ISTGT_LU_DISK *spec,
-	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
+    CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
 int istgt_lu_disk_process_xcopy(ISTGT_LU_DISK *spec,
-	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, uint8_t *data_buf, int dlen);
+    CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, uint8_t *data_buf, int dlen);
 int istgt_lu_disk_lbxcopy(ISTGT_XCOPY_TGT *src_tgt, ISTGT_XCOPY_TGT *dst_tgt,
-	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, int dc, int cat,
-	uint64_t num_blks_byts, uint8_t sd_opcode);
+    CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, int dc, int cat,
+    uint64_t num_blks_byts, uint8_t sd_opcode);
 
 
 #endif /* ISTGT_ISCSI_XCOPY_H */

--- a/src/istgt_iscsi_xcopy.h
+++ b/src/istgt_iscsi_xcopy.h
@@ -62,12 +62,12 @@ typedef struct istgt_xcopy_tgt_t {
 } ISTGT_XCOPY_TGT;
 
 int istgt_lu_disk_receive_copy_results(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
-int istgt_lu_disk_xcopy(ISTGT_LU_DISK *spec, \
+int istgt_lu_disk_xcopy(ISTGT_LU_DISK *spec,
 	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
-int istgt_lu_disk_process_xcopy(ISTGT_LU_DISK *spec, \
+int istgt_lu_disk_process_xcopy(ISTGT_LU_DISK *spec,
 	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, uint8_t *data_buf, int dlen);
-int istgt_lu_disk_lbxcopy(ISTGT_XCOPY_TGT *src_tgt, ISTGT_XCOPY_TGT *dst_tgt, \
-	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, int dc, int cat,  \
+int istgt_lu_disk_lbxcopy(ISTGT_XCOPY_TGT *src_tgt, ISTGT_XCOPY_TGT *dst_tgt,
+	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, int dc, int cat,
 	uint64_t num_blks_byts, uint8_t sd_opcode);
 
 

--- a/src/istgt_iscsi_xcopy.h
+++ b/src/istgt_iscsi_xcopy.h
@@ -1,4 +1,4 @@
-/* ****************************************************************************
+/*
  *  (C) Copyright 2014 CloudByte, Inc.
  *  All Rights Reserved.
  *
@@ -14,9 +14,9 @@
  *  secret laws, punishable by civil and criminal penalties.
  *
  *
- ****************************************************************************/
+ */
 #ifndef ISTGT_ISCSI_XCOPY_H
-#define ISTGT_ISCSI_XCOPY_H
+#define	ISTGT_ISCSI_XCOPY_H
 
 #include <stdint.h>
 #include <pthread.h>
@@ -26,12 +26,14 @@
 #include "istgt_scsi.h"
 #include "istgt_lu.h"
 
-#define	SNLID	1	/* Support no list id Refer 6.22 / 6.4.3.2 of spc4r36s */
+#define	SNLID	1 /* Support no list id Refer 6.22 / 6.4.3.2 of spc4r36s */
 #define	MAX_CSCD_DESCRIPTOR_COUNT	2
 #define	MAX_SEGMENT_DESCRIPTOR_COUNT	1
 #define	MAX_DESCRIPTOR_LIST_LENGTH	800
-#define	MAX_SEGMENT_LENGTH	0	/* No limit on the amount of data written by a single segment */
-#define	MAX_INLINE_DATA_LENGTH	0	/* Set to zero since 04h descriptor code not supported */
+/* No limit on the amount of data written by a single segment */
+#define	MAX_SEGMENT_LENGTH	0
+/* Set to zero since 04h descriptor code not supported */
+#define	MAX_INLINE_DATA_LENGTH	0
 #define	HELD_DATA_LIMIT	1
 #define	MAX_STREAM_DEVICE_TRANSFER_SIZE	0
 #define	TOTAL_CONCURRENT_COPIES	MAX_CONCURRENT_COPIES	/* Since snlid=1 */
@@ -45,7 +47,8 @@
 #define	CSCD_IDENTIFICATION_DESCRIPTOR	0xE4	/* 228d */
 #define	CSCD_DESCRIPTOR_LENGTH		32	/* 32 bytes */
 #define	LIST_ID_USAGE	3	/* 11b */
-#define	PARAMETER_HEADER_DATA	16	/* Actual parameter data for copy starts from 16th byte */
+/* Actual parameter data for copy starts from 16th byte */
+#define	PARAMETER_HEADER_DATA	16
 #define	NAA_IDENTIFIER	0x03
 #define	PDT_DIRECT_ACCESS_BLK_DEV 0x00
 #define	PDT_SIMPLIFIED_DIRECT_ACCESS_DEV	0x0E
@@ -59,12 +62,13 @@ typedef struct istgt_xcopy_tgt_t {
 } ISTGT_XCOPY_TGT;
 
 int istgt_lu_disk_receive_copy_results(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
-int istgt_lu_disk_xcopy(ISTGT_LU_DISK *spec, CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
-int istgt_lu_disk_process_xcopy(ISTGT_LU_DISK *spec, CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, uint8_t *data_buf, int dlen);
-int istgt_lu_disk_lbxcopy(ISTGT_XCOPY_TGT *src_tgt, ISTGT_XCOPY_TGT *dst_tgt, CONN_Ptr conn,
-		ISTGT_LU_CMD_Ptr lu_cmd, int dc, int cat,  uint64_t num_blks_byts, uint8_t sd_opcode);
+int istgt_lu_disk_xcopy(ISTGT_LU_DISK *spec, \
+	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd);
+int istgt_lu_disk_process_xcopy(ISTGT_LU_DISK *spec, \
+	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, uint8_t *data_buf, int dlen);
+int istgt_lu_disk_lbxcopy(ISTGT_XCOPY_TGT *src_tgt, ISTGT_XCOPY_TGT *dst_tgt, \
+	CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, int dc, int cat,  \
+	uint64_t num_blks_byts, uint8_t sd_opcode);
 
 
 #endif /* ISTGT_ISCSI_XCOPY_H */
-
-

--- a/src/ring_mempool.h
+++ b/src/ring_mempool.h
@@ -17,8 +17,10 @@ typedef struct {
 	mempool_reclaim_t *reclaim;
 } rte_smempool_t;
 
-int init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size, size_t offset, const char *mempool_name,
-		mempool_constructor_t *create, mempool_destructor_t *free, mempool_reclaim_t *reclaim, bool initialize);
+int init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size, \
+	size_t offset, const char *mempool_name,	\
+		mempool_constructor_t *create, mempool_destructor_t *free, \
+		mempool_reclaim_t *reclaim, bool initialize);
 int destroy_mempool(rte_smempool_t *obj);
 void * get_from_mempool(rte_smempool_t *obj);
 void put_to_mempool(rte_smempool_t *obj, void *node);
@@ -35,7 +37,7 @@ unsigned get_num_entries_from_mempool(rte_smempool_t *obj);
 
 #ifndef REPLICATION
 #define	REPLICA_LOG
-#define REPLICA_NOTICELOG
+#define	REPLICA_NOTICELOG
 #define	REPLICA_ERRLOG
 #define	REPLICA_WARNLOG
 #endif

--- a/src/ring_mempool.h
+++ b/src/ring_mempool.h
@@ -17,10 +17,9 @@ typedef struct {
 	mempool_reclaim_t *reclaim;
 } rte_smempool_t;
 
-int init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size, \
-	size_t offset, const char *mempool_name,	\
-		mempool_constructor_t *create, mempool_destructor_t *free, \
-		mempool_reclaim_t *reclaim, bool initialize);
+int init_mempool(rte_smempool_t *obj, size_t count, size_t mem_size,
+    size_t offset, const char *mempool_name, mempool_constructor_t *create,
+    mempool_destructor_t *free, mempool_reclaim_t *reclaim, bool initialize);
 int destroy_mempool(rte_smempool_t *obj);
 void * get_from_mempool(rte_smempool_t *obj);
 void put_to_mempool(rte_smempool_t *obj, void *node);


### PR DESCRIPTION
Fixed improper first line of block comment, line > 80 characters, missing blank before close comment.