### PR TITLE
fmt(cstyle): do not validate src/config.h

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -71,7 +71,7 @@ distdir:
 
 cstyle:
 	find $(top_srcdir) -name '*.[hc]' \
-                ! -wholename './src/config.h' \
+                ! -path './src/config.h' \
                 ! -name 'rte_*.[hc]' -type f -exec $(top_srcdir)/cstyle.pl -cpP {} \+
 
 clean: local-clean

--- a/Makefile.in
+++ b/Makefile.in
@@ -71,6 +71,7 @@ distdir:
 
 cstyle:
 	find $(top_srcdir) -name '*.[hc]' \
+                ! -wholename './src/config.h' \
                 ! -name 'rte_*.[hc]' -type f -exec $(top_srcdir)/cstyle.pl -cpP {} \+
 
 clean: local-clean


### PR DESCRIPTION
This file is auto-generated so it should not be validated when running `make
cstyle`.

You can find out more information here: 
https://github.com/openebs/openebs/issues/2009#issuecomment-427594728