### PR TITLE
Reworked Docker image to suit style guidelines

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,22 +2,7 @@
 # This Dockerfile builds cstor istgt container running istgt from istgt base image
 #
 
-FROM ubuntu:14.04
-RUN apt-get update; exit 0
-RUN apt-get -y install rsyslog
-RUN apt-get -y install net-tools iputils-ping
-RUN apt-get -y install libssl-dev libjson-c-dev libjemalloc-dev
-RUN apt -y install apt-file && apt-file update
-
-RUN mkdir -p /usr/local/etc/bkpistgt
-RUN mkdir -p /usr/local/etc/istgt
-COPY istgt istgtcontrol /usr/local/bin/
-COPY istgt.conf istgtcontrol.conf /usr/local/etc/bkpistgt/
-RUN touch /usr/local/etc/bkpistgt/auth.conf
-RUN touch /usr/local/etc/bkpistgt/logfile
-
-COPY entrypoint-istgtimage.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
+FROM ubuntu:16.04
 
 ARG BUILD_DATE
 LABEL org.label-schema.name="cstor"
@@ -27,5 +12,19 @@ LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 
-ENTRYPOINT entrypoint-istgtimage.sh
 EXPOSE 3260 6060
+
+COPY istgt istgtcontrol /usr/local/bin/
+COPY istgt.conf istgtcontrol.conf /usr/local/etc/bkpistgt/
+COPY entrypoint-istgtimage.sh /usr/local/bin/
+
+RUN apt-get update && \
+    apt-get install -y rsyslog net-tools iputils-ping libssl-dev libjson-c-dev libjemalloc-dev && \
+    mkdir -p /usr/local/etc/bkpistgt /usr/local/etc/istgt && \
+    touch /usr/local/etc/bkpistgt/auth.conf && \
+    touch /usr/local/etc/bkpistgt/logfile && \
+    chmod +x /usr/local/bin/entrypoint-istgtimage.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT entrypoint-istgtimage.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 
 EXPOSE 3260 6060
 
-COPY istgt istgtcontrol /usr/local/bin/
-COPY istgt.conf istgtcontrol.conf /usr/local/etc/bkpistgt/
-COPY entrypoint-istgtimage.sh /usr/local/bin/
-
 RUN apt-get update && \
     apt-get install -y rsyslog net-tools iputils-ping libssl-dev libjson-c-dev libjemalloc-dev && \
     mkdir -p /usr/local/etc/bkpistgt /usr/local/etc/istgt && \
@@ -26,5 +22,9 @@ RUN apt-get update && \
     chmod +x /usr/local/bin/entrypoint-istgtimage.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY istgt istgtcontrol /usr/local/bin/
+COPY istgt.conf istgtcontrol.conf /usr/local/etc/bkpistgt/
+COPY entrypoint-istgtimage.sh /usr/local/bin/
 
 ENTRYPOINT entrypoint-istgtimage.sh


### PR DESCRIPTION
The provided Docker image did not suit the Docker style guidelines as defined
by the Docker documentation [1]. This change greatly reduces the number of
layers which in effect reduces the image size by about 330MB [2]. Although this
size can differ a bit depending on the source.

This change also updates the base image to Ubuntu 16 instead of 14. I did this
because Ubuntu 14 will be end of life next year, while the Ubuntu 16 LTS will
only be EOL in 2021 [3].

 * [1] https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
 * [2] https://imgur.com/a/SQg7ka4
 * [3] https://wiki.ubuntu.com/Releases