### PR TITLE
fixed typo in json tag in istgt

### DIFF
--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -3455,7 +3455,7 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 			jtotalwritetime);
 		json_object_object_add(jobj, "TotalReadBlockCount",
 			jtotalreadblockcount);
-		json_object_object_add(jobj, "TotatWriteBlockCount",
+		json_object_object_add(jobj, "TotalWriteBlockCount",
 			jtotalwriteblockcount);
 
 		istgt_uctl_snprintf(uctl, "%s  %s\n",


### PR DESCRIPTION
**What this PR does / why we need it**: fixes typos in istgt/src/istgt_lu_ctl.c `TotatWriteBlockCount`
to `TotalWriteBlockCount`
 
**Which issue this PR fixes** : fixes openebs issue [#2214](https://github.com/openebs/openebs/issues/2214)
 
**Special notes for your reviewer**: N/A