### PR TITLE
feat(rebuild): start rebuild if there are no inflight IOs

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -58,7 +58,6 @@ sed -i "s|Portal UC1.*|Portal UC1 $portal:3261|g" $CONF_FILE
 sed -i "s|Portal DA1.*|Portal DA1 $portal:3260|g" $CONF_FILE
 sed -i "s|Netmask IP.*|Netmask $portal\/8|g" $CONF_FILE
 sed -i "s|LUN0 Storage.*|LUN0 Storage $size 32k|g" $CONF_FILE
-sed -i "s|MaxBurstLength.*|MaxBurstLength 8388608|g" $CONF_FILE
 
 cp $CONF_FILE /usr/local/etc/istgt/
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -58,11 +58,12 @@ sed -i "s|Portal UC1.*|Portal UC1 $portal:3261|g" $CONF_FILE
 sed -i "s|Portal DA1.*|Portal DA1 $portal:3260|g" $CONF_FILE
 sed -i "s|Netmask IP.*|Netmask $portal\/8|g" $CONF_FILE
 sed -i "s|LUN0 Storage.*|LUN0 Storage $size 32k|g" $CONF_FILE
+sed -i "s|MaxBurstLength.*|MaxBurstLength 8388608|g" $CONF_FILE
 
 cp $CONF_FILE /usr/local/etc/istgt/
 
 export externalIP=$externalIP
-echo $external
+echo $externalIP
 service rsyslog start
 #setting replica timeout to 20 seconds
 /usr/local/bin/istgt -R 20 &

--- a/src/replication.c
+++ b/src/replication.c
@@ -540,8 +540,10 @@ trigger_rebuild(spec_t *spec)
 	non_zero_inflight_replica_found = 0;
 	TAILQ_FOREACH(replica, &spec->rq, r_next) {
 		if (replica->replica_inflight_write_io_cnt != 0 ||
-		    replica->replica_inflight_sync_io_cnt != 0)
+		    replica->replica_inflight_sync_io_cnt != 0) {
 			non_zero_inflight_replica_found = 1;
+			break;
+		}
 	}
 
 #ifdef	DEBUG

--- a/src/replication.c
+++ b/src/replication.c
@@ -529,6 +529,14 @@ trigger_rebuild(spec_t *spec)
 
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
+	/*
+	 * istgt starts rebuild on a replica after 2*timeout of its start time.
+	 * This is done to make sure that if any pending IOs on helping replicas
+	 * are already available at degraded replica before rebuild is started.
+
+	 * optimization is that rebuild will be started on a replica if all the
+	 * connected replicas are not having any pending IOs with them.
+	 */
 	non_zero_inflight_replica_found = 0;
 	TAILQ_FOREACH(replica, &spec->rq, r_next) {
 		if (replica->replica_inflight_write_io_cnt != 0 ||


### PR DESCRIPTION
istgt starts rebuild on a replica after 2*timeout of its start time. This is done to make sure that if any pending IOs on helping replicas are already available at the degraded replica before rebuild is started.

This PR is an optimization of starting rebuild process on the degraded replica. With this PR, rebuild will be started on a replica if all the connected replicas are not having any pending IOs with them.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>