### PR TITLE
[TA3393] fix(ongoing_snap): err out dw replica of rebuild when healthy replica…

### DIFF
--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -849,8 +849,11 @@ typedef struct istgt_lu_disk_t {
 	int healthy_rcount;
 	int degraded_rcount;
 	bool ready;
-	bool rebuild_in_progress;
-	struct replica_s *target_replica;
+	struct {
+		struct replica_s *dw_replica;
+		void *healthy_replica;
+		bool rebuild_in_progress;
+	} rebuild_info;
 
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/


### PR DESCRIPTION
… of rebuild fails to respond

Two scenarios are covered in this PR.

One being: If replica that is healthy and in rebuild process doesn't respond for SNAP_CREATE, dw replica that is involved in rebuild process need to be disconnected. After reconnection, both of them will get this snap if it is successful

Another case: If replica that is healthy and in rebuild process responds failure for SNAP_CREATE, dw replica that is involved in rebuild process need to be disconnected. After reconnection, dwreplica will get this snap if snap create was successful. Healthy replica will disconnect by itself, and, gets the snap after reconnecting as part of its rebuild.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>