### PR TITLE
feat(stats): Adding vol status to istgtcontrol replica cmd

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1522,6 +1522,30 @@ get_cv_status(spec_t *spec, int replica_cnt, int healthy_replica_cnt)
 	return 3;
 }
 
+static const char *
+status_to_str(int status)
+{
+	const char *str;
+	switch (status) {
+		case 1:
+			str = "offline";
+			break;
+		case 2:
+			str = "disabled_feats";
+			break;
+		case 3:
+			str = "degraded";
+			break;
+		case 4:
+			str = "healthy";
+			break;
+		default:
+			str = "unknown";
+			break;
+	}
+	return str;
+}
+
 void
 istgt_lu_replica_stats(char *volname, char **resp)
 {
@@ -1559,7 +1583,7 @@ istgt_lu_replica_stats(char *volname, char **resp)
 				status = get_cv_status(spec, replica_cnt, healthy_replica_cnt);
 				MTX_UNLOCK(&spec->rq_mtx);
 				json_object_object_add(j_spec, "status",
-				    json_object_new_int64(status));
+				    json_object_new_string(status_to_str(status)));
 				json_object_object_add(j_spec,
 				    "Replica status", j_replica);
 				json_object_array_add(j_all_spec, j_spec);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1528,19 +1528,19 @@ status_to_str(int status)
 	const char *str;
 	switch (status) {
 		case 1:
-			str = "offline";
+			str = "Offline";
 			break;
 		case 2:
-			str = "disabled_feats";
+			str = "DisabledFeatures";
 			break;
 		case 3:
-			str = "degraded";
+			str = "DegradedPerformance";
 			break;
 		case 4:
-			str = "healthy";
+			str = "Healthy";
 			break;
 		default:
-			str = "unknown";
+			str = "Unknown";
 			break;
 	}
 	return str;
@@ -1611,7 +1611,7 @@ istgt_lu_replica_stats(char *volname, char **resp)
 			status = get_cv_status(spec, replica_cnt, healthy_replica_cnt);
 			MTX_UNLOCK(&spec->rq_mtx);
 			json_object_object_add(j_spec, "status",
-			    json_object_new_int64(status));
+			    json_object_new_string(status_to_str(status)));
 			json_object_object_add(j_spec,
 			    "Replica status", j_replica);
 			json_object_array_add(j_all_spec, j_spec);

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -533,7 +533,7 @@ run_rebuild_time_test_in_single_replica()
 
 	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 	rt=$(eval $cmd)
-	if [ ${rt} != "\"offline\"" ]; then
+	if [ ${rt} != "\"Offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 1"
 		exit 1
@@ -544,7 +544,7 @@ run_rebuild_time_test_in_single_replica()
 	sleep 2
 
 	rt=$(eval $cmd)
-	if [ ${rt} != "\"disabled_feats\"" ]; then
+	if [ ${rt} != "\"DisabledFeatures\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 2"
 		exit 1
@@ -568,7 +568,7 @@ run_rebuild_time_test_in_single_replica()
 			else
 				cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 				rt=$(eval $cmd)
-				if [ ${rt} != "\"healthy\"" ]; then
+				if [ ${rt} != "\"Healthy\"" ]; then
 					$ISTGTCONTROL -q REPLICA vol1
 					echo "volume status is supposed to be 4"
 					exit 1
@@ -606,7 +606,7 @@ run_rebuild_time_test_in_multiple_replicas()
 
 	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 	rt=$(eval $cmd)
-	if [ ${rt} != "\"offline\"" ]; then
+	if [ ${rt} != "\"Offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 1"
 		exit 1
@@ -617,7 +617,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	sleep 2
 
 	rt=$(eval $cmd)
-	if [ ${rt} != "\"offline\"" ]; then
+	if [ ${rt} != "\"Offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 1"
 		exit 1
@@ -629,7 +629,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	sleep 2
 
 	rt=$(eval $cmd)
-	if [ ${rt} != "\"disabled_feats\"" ]; then
+	if [ ${rt} != "\"DisabledFeatures\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 2"
 		exit 1
@@ -641,7 +641,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	sleep 3
 
 	rt=$(eval $cmd)
-	if [ ${rt} != "\"disabled_feats\"" ]; then
+	if [ ${rt} != "\"DisabledFeatures\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 2"
 		exit 1
@@ -665,7 +665,7 @@ run_rebuild_time_test_in_multiple_replicas()
 					if [ ${rstatus} == "\"HEALTHY\"" ]; then
 						cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 						rstatus=$(eval $cmd)
-						if [ ${rstatus} != "\"disabled_feats\"" ]; then
+						if [ ${rstatus} != "\"DisabledFeatures\"" ]; then
 							$ISTGTCONTROL -q REPLICA vol1
 							echo "volume status is supposed to be 2"
 							exit 1
@@ -715,7 +715,7 @@ run_rebuild_time_test_in_multiple_replicas()
 		if [ ${cnt} == 2 ]; then
 			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 			rstatus=$(eval $cmd)
-			if [ ${rstatus} != "\"degraded\"" ]; then
+			if [ ${rstatus} != "\"DegradedPerformance\"" ]; then
 				$ISTGTCONTROL -q REPLICA vol1
 				echo "volume status is supposed to be 3"
 				exit 1

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -533,7 +533,7 @@ run_rebuild_time_test_in_single_replica()
 
 	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 	rt=$(eval $cmd)
-	if [ $rt -ne 1 ]; then
+	if [ ${rt} != "\"offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 1"
 		exit 1
@@ -544,7 +544,7 @@ run_rebuild_time_test_in_single_replica()
 	sleep 2
 
 	rt=$(eval $cmd)
-	if [ $rt -ne 2 ]; then
+	if [ ${rt} != "\"disabled_feats\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 2"
 		exit 1
@@ -568,7 +568,7 @@ run_rebuild_time_test_in_single_replica()
 			else
 				cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 				rt=$(eval $cmd)
-				if [ $rt -ne 4 ]; then
+				if [ ${rt} != "\"healthy\"" ]; then
 					$ISTGTCONTROL -q REPLICA vol1
 					echo "volume status is supposed to be 4"
 					exit 1
@@ -606,7 +606,7 @@ run_rebuild_time_test_in_multiple_replicas()
 
 	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 	rt=$(eval $cmd)
-	if [ $rt -ne 1 ]; then
+	if [ ${rt} != "\"offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 1"
 		exit 1
@@ -617,7 +617,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	sleep 2
 
 	rt=$(eval $cmd)
-	if [ $rt -ne 1 ]; then
+	if [ ${rt} != "\"offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 1"
 		exit 1
@@ -629,7 +629,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	sleep 2
 
 	rt=$(eval $cmd)
-	if [ $rt -ne 2 ]; then
+	if [ ${rt} != "\"disabled_feats\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 2"
 		exit 1
@@ -641,7 +641,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	sleep 3
 
 	rt=$(eval $cmd)
-	if [ $rt -ne 2 ]; then
+	if [ ${rt} != "\"disabled_feats\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
 		echo "volume status is supposed to be 2"
 		exit 1
@@ -665,7 +665,7 @@ run_rebuild_time_test_in_multiple_replicas()
 					if [ ${rstatus} == "\"HEALTHY\"" ]; then
 						cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 						rstatus=$(eval $cmd)
-						if [ $rstatus -ne 2 ]; then
+						if [ ${rstatus} != "\"disabled_feats\"" ]; then
 							$ISTGTCONTROL -q REPLICA vol1
 							echo "volume status is supposed to be 2"
 							exit 1
@@ -715,7 +715,7 @@ run_rebuild_time_test_in_multiple_replicas()
 		if [ ${cnt} == 2 ]; then
 			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
 			rstatus=$(eval $cmd)
-			if [ $rstatus -ne 3 ]; then
+			if [ ${rstatus} != "\"degraded\"" ]; then
 				$ISTGTCONTROL -q REPLICA vol1
 				echo "volume status is supposed to be 3"
 				exit 1


### PR DESCRIPTION
This PR is to add volume status based on various conditions to 'istgtcontrol replica' command.

With this PR, response of 'istgtcontrol -q replica vol1' will be as below:
```
{
  "Volume status": [
    {
      "name": "vol1",
      "status": "Healthy",
      "Replica status": [
        {
          "replica": "6161",
          "status": "HEALTHY",
          "checkpointed_io_seq": "1000",
          "inflight_read": "0",
          "inflight_write": "0",
          "inflight_sync": "0",
          "connected since(in seconds)": 1276
        },
        {
          "replica": "6162",
          "status": "HEALTHY",
          "checkpointed_io_seq": "1000",
          "inflight_read": "0",
          "inflight_write": "0",
          "inflight_sync": "0",
          "connected since(in seconds)": 1274
        },
        {
          "replica": "6163",
          "status": "HEALTHY",
          "checkpointed_io_seq": "1000",
          "inflight_read": "0",
          "inflight_write": "0",
          "inflight_sync": "0",
          "connected since(in seconds)": 1027
        }
      ]
    }
  ]
}
```
Below are possible 'status' values in 'volume status':
Status being Offline means no IOs are served
Status being DisabledFeatures means volume is performing in degraded mode and some features might be disabled
Status being DegradedPerformance means volume is performing in degraded mode but all features are enabled
Status being Healthy means all the components are working in healthy mode
This also have testcases to verify the volume status in 'istgtcontrol replica' command.
Signed-off-by: Vishnu Itta <vitta@mayadata.io>