### PR TITLE
refactor(cstor-volume): Make json keys camel case.

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1484,27 +1484,27 @@ get_replica_stats_json(replica_t *replica, struct json_object **jobj)
 	struct timespec now;
 
 	j_stats = json_object_new_object();
-	json_object_object_add(j_stats, "replica",
+	json_object_object_add(j_stats, "replicaId",
 	    json_object_new_uint64(replica->zvol_guid));
 
 	json_object_object_add(j_stats, "status",
 	    json_object_new_string((replica->state == ZVOL_STATUS_HEALTHY) ?
 	    "HEALTHY" : "DEGRADED"));
 
-	json_object_object_add(j_stats, "checkpointed_io_seq",
+	json_object_object_add(j_stats, "checkpointedIOSeq",
 	    json_object_new_uint64(replica->initial_checkpointed_io_seq));
 
-	json_object_object_add(j_stats, "inflight_read",
+	json_object_object_add(j_stats, "inflightRead",
 	    json_object_new_uint64(replica->replica_inflight_read_io_cnt));
 
-	json_object_object_add(j_stats, "inflight_write",
+	json_object_object_add(j_stats, "inflightWrite",
 	    json_object_new_uint64(replica->replica_inflight_write_io_cnt));
 
-	json_object_object_add(j_stats, "inflight_sync",
+	json_object_object_add(j_stats, "inflightSync",
 	    json_object_new_uint64(replica->replica_inflight_sync_io_cnt));
 
 	clock_gettime(CLOCK_MONOTONIC, &now);
-	json_object_object_add(j_stats, "connected since(in seconds)",
+	json_object_object_add(j_stats, "upTime",
 	    json_object_new_int64(now.tv_sec - replica->create_time.tv_sec));
 
 	*jobj = j_stats;
@@ -1585,7 +1585,7 @@ istgt_lu_replica_stats(char *volname, char **resp)
 				json_object_object_add(j_spec, "status",
 				    json_object_new_string(status_to_str(status)));
 				json_object_object_add(j_spec,
-				    "Replica status", j_replica);
+				    "replicaStatus", j_replica);
 				json_object_array_add(j_all_spec, j_spec);
 				break;
 			}
@@ -1613,7 +1613,7 @@ istgt_lu_replica_stats(char *volname, char **resp)
 			json_object_object_add(j_spec, "status",
 			    json_object_new_string(status_to_str(status)));
 			json_object_object_add(j_spec,
-			    "Replica status", j_replica);
+			    "replicaStatus", j_replica);
 			json_object_array_add(j_all_spec, j_spec);
 		}
 	}
@@ -1621,7 +1621,7 @@ istgt_lu_replica_stats(char *volname, char **resp)
 	MTX_UNLOCK(&specq_mtx);
 
 	j_obj = json_object_new_object();
-	json_object_object_add(j_obj, "Volume status", j_all_spec);
+	json_object_object_add(j_obj, "volumeStatus", j_all_spec);
 	json_string = json_object_to_json_string_ext(j_obj,
 	    JSON_C_TO_STRING_PLAIN);
 	resp_len = strlen(json_string) + 1;
@@ -3178,7 +3178,7 @@ istgt_lu_mempool_stats(char **resp)
 	TAILQ_FOREACH(spec, &spec_q, spec_next) {
 		TAILQ_FOREACH(r, &spec->rq, r_next) {
 			j_replica = json_object_new_object();
-			json_object_object_add(j_replica, "replica",
+			json_object_object_add(j_replica, "replicaId",
 			    json_object_new_uint64(r->zvol_guid));
 			json_object_object_add(j_replica, "in-flight read",
 			    json_object_new_uint64(

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -531,7 +531,7 @@ run_rebuild_time_test_in_single_replica()
 	CONSISTENCY_FACTOR=1
 	setup_test_env
 
-	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
+	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
 	rt=$(eval $cmd)
 	if [ ${rt} != "\"Offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
@@ -555,18 +555,18 @@ run_rebuild_time_test_in_single_replica()
 		# and rf=cf=1. so, it will take around 2 minutes for the
 		# replica to become healthy. So on safe side, we will
 		# check replica status after 130 seconds.
-		cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].\"Replica status\"[0].\"connected since(in seconds)\"'"
+		cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].\"upTime\"'"
 		rt=$(eval $cmd)
 		echo "replica start time $rt"
 		if [ $rt -gt 130 ]; then
-			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].\"Replica status\"[0].status'"
+			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].status'"
 			rstatus=$(eval $cmd)
 			echo "replica status $rstatus"
 			if [ ${rstatus} != "\"HEALTHY\"" ]; then
 				echo "replication factor(1) test failed"
 				exit 1
 			else
-				cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
+				cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
 				rt=$(eval $cmd)
 				if [ ${rt} != "\"Healthy\"" ]; then
 					$ISTGTCONTROL -q REPLICA vol1
@@ -604,7 +604,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	CONSISTENCY_FACTOR=2
 	setup_test_env
 
-	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
+	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
 	rt=$(eval $cmd)
 	if [ ${rt} != "\"Offline\"" ]; then
 		$ISTGTCONTROL -q REPLICA vol1
@@ -654,16 +654,16 @@ run_rebuild_time_test_in_multiple_replicas()
 		# replica to become healthy. So on safe side, we will
 		# check replica status after 130 seconds.
 		for (( i = 0; i < 3; i++ )) do
-			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].\"Replica status\"["$i"].\"connected since(in seconds)\"'"
+			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].\"upTime\"'"
 			rt=$(eval $cmd)
 			echo "replica start time $rt"
 			if [ $1 -eq 0 ]; then
 				if [ $rt -gt 130 ]; then
-					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].\"Replica status\"["$i"].status'"
+					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"
 					rstatus=$(eval $cmd)
 					echo "replica status $rstatus"
 					if [ ${rstatus} == "\"HEALTHY\"" ]; then
-						cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
+						cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
 						rstatus=$(eval $cmd)
 						if [ ${rstatus} != "\"DisabledFeatures\"" ]; then
 							$ISTGTCONTROL -q REPLICA vol1
@@ -676,7 +676,7 @@ run_rebuild_time_test_in_multiple_replicas()
 				fi
 			else
 				if [ $rt -le 140 ]; then
-					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].\"Replica status\"["$i"].status'"
+					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"
 					rstatus=$(eval $cmd)
 					echo "replica status $rstatus"
 					if [ ${rstatus} == "\"HEALTHY\"" ]; then
@@ -706,14 +706,14 @@ run_rebuild_time_test_in_multiple_replicas()
 	while [ 1 ]; do
 		cnt=0
 		for (( i = 0; i < 3; i++ )) do
-			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].\"Replica status\"["$i"].status'"
+			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"
 			rt=$(eval $cmd)
 			if [ ${rt} == "\"HEALTHY\"" ]; then
 				cnt=`expr $cnt + 1`
 			fi
 		done
 		if [ ${cnt} == 2 ]; then
-			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"Volume status\"[0].status'"
+			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
 			rstatus=$(eval $cmd)
 			if [ ${rstatus} != "\"DegradedPerformance\"" ]; then
 				$ISTGTCONTROL -q REPLICA vol1


### PR DESCRIPTION
Some keys of output json for istgtcontrol replica command had
space separated strings or snake case. This was violating uniformity.
Made all the keys camel case and remove any description which
was present along with key name.
    eg. "Volume Status" -> "volumeStatus"

Signed-off-by: princerachit <prince.rachit@mayadata.io>
