### PR TITLE
feat(replica_timeout): making replica_timeout configurable

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -768,6 +768,10 @@ initialize_error:
 		 */
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		timesdiff(CLOCK_MONOTONIC, last_time, now, diff_time);
+		polling_timeout = (replica_timeout / 4) * 1000;
+		if (epoll_timeout > polling_timeout)
+			epoll_timeout = polling_timeout;
+
 		if (((diff_time.tv_sec * 1000) +
 		    (diff_time.tv_nsec / 1000000)) > epoll_timeout) {
 			epoll_timeout = polling_timeout;

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -2795,7 +2795,6 @@ void *timerfn(void
 	ISTGT_LU_CMD_Ptr lu_cmd;
 	int ms;
 	struct timespec now, diff, last_check;
-	int check_interval = (replica_timeout / 4) * 1000;
 	clock_gettime(clockid, &last_check);
 #endif
 
@@ -2813,6 +2812,14 @@ void *timerfn(void
 			istgt_queue_enqueue(&closedconns, conn);
 
 #ifdef	REPLICATION
+		const char *s_replica_timeout = getenv("replicaTimeout");
+		unsigned int rep_timeout = 0;
+		if (s_replica_timeout != NULL)
+			rep_timeout = (unsigned int)strtol(s_replica_timeout, NULL, 10);
+		if (rep_timeout > 30)
+			replica_timeout = rep_timeout;
+		int check_interval = (replica_timeout / 4) * 1000;
+
 		clock_gettime(clockid, &now);
 		timesdiff(clockid, last_check, now, diff);
 		ms = diff.tv_sec * 1000;
@@ -2869,7 +2876,7 @@ void *timerfn(void
 		}
 #endif
 
-		sleep(60);
+		sleep(10);
 	}
 	return ((void *)NULL);
 }


### PR DESCRIPTION
This PR is to make an option 'replica_timeout' as configurable in istgt. An environment variable 'replicaTimeout' is used to read the new replica_timeout value.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>