### PR TITLE
Updating extraWait time according to max delay from replica

### DIFF
--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -95,6 +95,7 @@ typedef struct replica_s {
 
 	/* header recieved on data connection */
 	zvol_io_hdr_t *io_resp_hdr;
+	uint32_t last_io_delay;
 	/* state of command on data connection */
 	int io_state;
 	/* amount of IO data read in current IO state for data connection */

--- a/src/replication_log.h
+++ b/src/replication_log.h
@@ -1,6 +1,7 @@
 #ifndef	REPLICATION_LOG_H
 #define	REPLICATION_LOG_H
 
+#include <stdio.h>
 #include <sys/time.h>
 #include <time.h>
 


### PR DESCRIPTION
Changes:
- Updating `extraWait` time for inflight IOs according to slowest replica

Signed-off-by: mayank <mayank.patel@cloudbyte.com>