### PR TITLE
Adding a maximum IO wait time for replication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update -qq
     - sudo apt-get install --yes -qq gcc-6 g++-6 gdb
-    - sudo apt-get install libssl-dev open-iscsi libjson-c-dev
+    - sudo apt-get install libssl-dev open-iscsi libjson-c-dev ioping
     # use gcc-6 by default
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -95,7 +95,6 @@
 ISTGT g_istgt;
 #ifdef	REPLICATION
 extern int replica_timeout;
-extern int extraWait;
 extern rte_smempool_t rcmd_mempool;
 extern rte_smempool_t rcommon_cmd_mempool;
 #endif
@@ -2813,17 +2812,6 @@ void *timerfn(void
 			istgt_queue_enqueue(&closedconns, conn);
 
 #ifdef	REPLICATION
-		const char *s_extra_wait_time = getenv("extraWait");
-		int extra_wait = -1;
-		if (s_extra_wait_time != NULL)
-			extra_wait = (int)strtol(s_extra_wait_time,
-			    NULL, 10);
-		if ((extra_wait >= 0) && (extra_wait != extraWait)) {
-			ISTGT_NOTICELOG("changing extraWait time from %d to "
-			    "%d\n", extraWait, extra_wait);
-			extraWait = extra_wait;
-		}
-
 		const char *s_replica_timeout = getenv("replicaTimeout");
 		int rep_timeout = 0;
 		if (s_replica_timeout != NULL)

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -76,10 +76,6 @@
 
 #define	MAX_MASKBUF 128
 
-#ifdef	REPLICATION
-extern struct timespec io_queue_time[ISTGT_MAX_NUM_LUWORKERS];
-#endif
-
 static int
 istgt_lu_allow_ipv6(const char *netmask, const char *addr)
 {
@@ -4510,7 +4506,6 @@ luworker(void *arg)
 			tdiff(second2, third, r);
 #ifdef REPLICATION
 			lu_task->lu_cmd.luworkerindx = tind;
-			clock_gettime(CLOCK_MONOTONIC, &io_queue_time[tind]);
 #endif
 			lu_task->lu_cmd.flags |= ISTGT_WORKER_PICKED;
 			rc = istgt_lu_disk_queue_start(lu, lu_num, tind);
@@ -4519,9 +4514,6 @@ luworker(void *arg)
 						lu->num, rc == -2 ? "aborted" : "failed", rc);
 			}
 
-#ifdef	REPLICATION
-			io_queue_time[tind].tv_sec = io_queue_time[tind].tv_nsec = 0;
-#endif
 			clock_gettime(clockid, &now1);
 			id = 12;
 			tdiff(third, now1, r);

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -76,6 +76,9 @@
 
 #define	MAX_MASKBUF 128
 
+#ifdef	REPLICATION
+extern struct timespec io_queue_time[ISTGT_MAX_NUM_LUWORKERS];
+#endif
 
 static int
 istgt_lu_allow_ipv6(const char *netmask, const char *addr)
@@ -4507,6 +4510,7 @@ luworker(void *arg)
 			tdiff(second2, third, r);
 #ifdef REPLICATION
 			lu_task->lu_cmd.luworkerindx = tind;
+			clock_gettime(CLOCK_MONOTONIC, &io_queue_time[tind]);
 #endif
 			lu_task->lu_cmd.flags |= ISTGT_WORKER_PICKED;
 			rc = istgt_lu_disk_queue_start(lu, lu_num, tind);
@@ -4515,6 +4519,9 @@ luworker(void *arg)
 						lu->num, rc == -2 ? "aborted" : "failed", rc);
 			}
 
+#ifdef	REPLICATION
+			io_queue_time[tind].tv_sec = io_queue_time[tind].tv_nsec = 0;
+#endif
 			clock_gettime(clockid, &now1);
 			id = 12;
 			tdiff(third, now1, r);

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -652,6 +652,38 @@ istgt_uctl_cmd_replica_stats(UCTL_Ptr uctl)
 	}
 	return (UCTL_CMD_OK);
 }
+
+static int
+istgt_uctl_cmd_max_io_wait(UCTL_Ptr uctl)
+{
+	const char *delim = ARGS_DELIM;
+	int rc = 0;
+	char *arg;
+	int max_wait_time, new_wait_time = -1;
+	char *s_io_wait_time = NULL;
+	arg = uctl->arg;
+
+	if (arg) {
+		s_io_wait_time = strsepq(&arg, delim);
+		new_wait_time = (int) strtol(s_io_wait_time, NULL, 10);
+		istgt_set_max_io_wait_time(new_wait_time);
+	}
+
+	max_wait_time = istgt_get_max_io_wait_time();
+	istgt_uctl_snprintf(uctl, "%s  %d\n", uctl->cmd, max_wait_time);
+	rc = istgt_uctl_writeline(uctl);
+	if (rc != UCTL_CMD_OK) {
+		return (rc);
+	}
+
+	istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);
+	rc = istgt_uctl_writeline(uctl);
+	if (rc != UCTL_CMD_OK) {
+		return (rc);
+	}
+	return (UCTL_CMD_OK);
+}
+
 #endif
 
 static int
@@ -3673,6 +3705,7 @@ static ISTGT_UCTL_CMD_TABLE istgt_uctl_cmd_table[] =
 	{ "SNAPCREATE", istgt_uctl_cmd_snap},
 	{ "SNAPDESTROY", istgt_uctl_cmd_snap},
 	{ "REPLICA", istgt_uctl_cmd_replica_stats},
+	{ "MAXIOWAIT", istgt_uctl_cmd_max_io_wait},
 #endif
 	{ NULL, NULL },
 };

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -658,18 +658,24 @@ istgt_uctl_cmd_max_io_wait(UCTL_Ptr uctl)
 	const char *delim = ARGS_DELIM;
 	int rc = 0;
 	char *arg;
-	int max_wait_time, new_wait_time = -1;
+	uint64_t max_wait_time, new_wait_time;
 	char *s_io_wait_time = NULL;
 	arg = uctl->arg;
 
 	if (arg) {
 		s_io_wait_time = strsepq(&arg, delim);
-		new_wait_time = (int) strtol(s_io_wait_time, NULL, 10);
+		new_wait_time = strtoull(s_io_wait_time, NULL, 10);
+		if (errno) {
+			istgt_uctl_snprintf(uctl, "ERR error code:%d\n", errno);
+			(void) istgt_uctl_writeline(uctl);
+			return (UCTL_CMD_ERR);
+		}
+
 		istgt_set_max_io_wait_time(new_wait_time);
 	}
 
 	max_wait_time = istgt_get_max_io_wait_time();
-	istgt_uctl_snprintf(uctl, "%s  %d\n", uctl->cmd, max_wait_time);
+	istgt_uctl_snprintf(uctl, "%s  %lu\n", uctl->cmd, max_wait_time);
 	rc = istgt_uctl_writeline(uctl);
 	if (rc != UCTL_CMD_OK) {
 		return (rc);

--- a/src/istgt_misc.h
+++ b/src/istgt_misc.h
@@ -209,6 +209,9 @@ void poolinit(void);
 void poolfini(void);
 int poolprint(char *inbuf, int len);
 
+/*
+ * Calculate time difference
+ */
 #define timesdiff(_clockid, _st, _now, _re)				\
 {									\
 	clock_gettime(_clockid, &_now);					\
@@ -221,4 +224,17 @@ int poolprint(char *inbuf, int len);
 	}								\
 }
 
+/*
+ * Calculate difference with fixed values
+ */
+#define time_diff(_st, _end, _re)					\
+{									\
+	if ((_end.tv_nsec - _st.tv_nsec)<0) {				\
+		_re.tv_sec  = _end.tv_sec - _st.tv_sec - 1;		\
+		_re.tv_nsec = 1000000000 + _end.tv_nsec - _st.tv_nsec;	\
+	} else {							\
+		_re.tv_sec  = _end.tv_sec - _st.tv_sec;			\
+		_re.tv_nsec = _end.tv_nsec - _st.tv_nsec;		\
+	}								\
+}
 #endif /* ISTGT_MISC_H */

--- a/src/istgt_misc.h
+++ b/src/istgt_misc.h
@@ -223,18 +223,4 @@ int poolprint(char *inbuf, int len);
 		_re.tv_nsec = _now.tv_nsec - _st.tv_nsec;		\
 	}								\
 }
-
-/*
- * Calculate difference with fixed values
- */
-#define time_diff(_st, _end, _re)					\
-{									\
-	if ((_end.tv_nsec - _st.tv_nsec)<0) {				\
-		_re.tv_sec  = _end.tv_sec - _st.tv_sec - 1;		\
-		_re.tv_nsec = 1000000000 + _end.tv_nsec - _st.tv_nsec;	\
-	} else {							\
-		_re.tv_sec  = _end.tv_sec - _st.tv_sec;			\
-		_re.tv_nsec = _end.tv_nsec - _st.tv_nsec;		\
-	}								\
-}
 #endif /* ISTGT_MISC_H */

--- a/src/istgt_proto.h
+++ b/src/istgt_proto.h
@@ -94,6 +94,8 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int, int);
 int istgt_lu_destroy_snapshot(spec_t *spec, char *snapname);
 void istgt_lu_mempool_stats(char **resp);
 void istgt_lu_replica_stats(char *volname, char **resp);
+void istgt_set_max_io_wait_time(int new_io_wait_time);
+int istgt_get_max_io_wait_time(void);
 #endif
 int istgt_lu_add_nexus(ISTGT_LU_Ptr lu, char *initiator_port);
 int istgt_lu_remove_nexus(ISTGT_LU_Ptr lu, char *initiator_port);

--- a/src/istgt_proto.h
+++ b/src/istgt_proto.h
@@ -94,8 +94,8 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int, int);
 int istgt_lu_destroy_snapshot(spec_t *spec, char *snapname);
 void istgt_lu_mempool_stats(char **resp);
 void istgt_lu_replica_stats(char *volname, char **resp);
-void istgt_set_max_io_wait_time(int new_io_wait_time);
-int istgt_get_max_io_wait_time(void);
+void istgt_set_max_io_wait_time(uint64_t new_io_wait_time);
+uint64_t istgt_get_max_io_wait_time(void);
 #endif
 int istgt_lu_add_nexus(ISTGT_LU_Ptr lu, char *initiator_port);
 int istgt_lu_remove_nexus(ISTGT_LU_Ptr lu, char *initiator_port);

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -1013,11 +1013,7 @@ exec_max_io_wait(UCTL_Ptr uctl)
 		strupr(result);
 		if (strcmp(result, uctl->cmd) != 0)
 			break;
-		if (uctl->iqn != NULL) {
-			printf("%s\n", arg);
-		} else {
-			printf("%s\n", arg);
-		}
+		printf("%s\n", arg);
 	}
 	if (strcmp(result, "OK") != 0) {
 		if (is_err_req_auth(uctl, arg))

--- a/src/replication.c
+++ b/src/replication.c
@@ -24,7 +24,7 @@
 #include "istgt_scsi.h"
 #include "assert.h"
 
-int io_max_wait_time = 5;
+int io_max_wait_time = 60;
 struct timespec io_queue_time[ISTGT_MAX_NUM_LUWORKERS];
 extern int replica_timeout;
 cstor_conn_ops_t cstor_ops = {
@@ -494,41 +494,37 @@ start_rebuild(void *buf, replica_t *replica, uint64_t data_len)
 
 /*
  * Compare time..
- * results: (T1 > T2) ? T1 : T2
+ * results: (T1 > T2) ? TRUE: FALSE
  */
-static int
+static bool
 compare_time(struct timespec t1, struct timespec t2)
 {
 	if (t1.tv_sec > t2.tv_sec)
-		return 1;
+		return TRUE;
 
 	if ((t1.tv_sec == t2.tv_sec) &&
 	    (t1.tv_nsec > t2.tv_nsec))
-		return 1;
-	return 0;
+		return TRUE;
+	return FALSE;
 }
 
 static int
 check_for_old_ios(spec_t *spec, struct timespec last)
 {
-	struct timespec diff1, diff2 = { 0 }, now, io_time;
+	struct timespec io_time;
 	int ret = 0;
 	int i = 0;
-
-	clock_gettime(CLOCK_MONOTONIC, &now);
 
 	for (i = 0; i < spec->luworkers; i++) {
 		io_time = io_queue_time[i];
 		if (!(io_time.tv_sec == 0 && io_time.tv_nsec == 0)) {
-			time_diff(io_time, now, diff1);
-			if (compare_time(diff1, diff2))
-				diff2 = diff1;
+			if (!compare_time(io_time, last)) {
+				ret = 1;
+				break;
+			}
 		}
 	}
 
-	time_diff(last, now, diff1);
-	if (compare_time(diff2, diff1))
-		ret = 1;
 	return ret;
 }
 
@@ -587,6 +583,19 @@ trigger_rebuild(spec_t *spec)
 
 	if (dw_replica == NULL)
 		return;
+
+#ifdef DEBUG
+	const char* non_zero_inflight_replica_str =
+	    getenv("non_zero_inflight_replica_cnt");
+	unsigned int non_zero_inflight_replica_cnt = 0;
+	io_queue_time[0].tv_sec = 0;
+
+	if (non_zero_inflight_replica_str != NULL)
+		non_zero_inflight_replica_cnt =
+	            (unsigned int)strtol(non_zero_inflight_replica_str, NULL, 10);
+	if (non_zero_inflight_replica_cnt == 1)
+		io_queue_time[0].tv_sec = dw_replica->create_time.tv_sec - 1;
+#endif
 
 	/*
 	 * Check if healthy replica or all replica have any inflight IOs
@@ -2600,6 +2609,9 @@ again:
 
 	ASSERT(spec->io_seq);
 	build_rcomm_cmd(rcomm_cmd, cmd, offset, nbytes);
+
+	clock_gettime(CLOCK_MONOTONIC, &io_queue_time[cmd->luworkerindx]);
+
 retry_read:
 	replica_choosen = false;
 	skip_count = 0;
@@ -2671,6 +2683,28 @@ retry_read:
 
 	// now wait for command to complete
 	while (1) {
+		timesdiff(CLOCK_MONOTONIC, queued_time, now, diff);
+		count = 0;
+		for (i = 0; i < rcomm_cmd->copies_sent; i++) {
+			if (rcomm_cmd->resp_list[i].status &
+			    (RECEIVED_OK|RECEIVED_ERR|REPLICATE_TIMED_OUT))
+				count++;
+			else if (diff.tv_sec >= io_max_wait_time) {
+				ASSERT(rcomm_cmd->resp_list[i].replica);
+				rcomm_cmd->resp_list[i].status |=
+				    REPLICATE_TIMED_OUT;
+
+				MTX_LOCK(&rcomm_cmd->resp_list[i].replica->r_mtx);
+				inform_mgmt_conn(rcomm_cmd->resp_list[i].replica);
+				MTX_UNLOCK(&rcomm_cmd->resp_list[i].replica->r_mtx);
+
+				count++;
+			}
+		}
+
+		if (count != rcomm_cmd->copies_sent)
+			goto wait_for_other_responses;
+
 		// check for status of rcomm_cmd
 		rc = check_for_command_completion(spec, rcomm_cmd, cmd);
 		if (rc) {
@@ -2689,27 +2723,6 @@ retry_read:
 				goto retry_read;
 			}
 
-
-			timesdiff(CLOCK_MONOTONIC, queued_time, now, diff);
-			count = 0;
-			if (rcomm_cmd->opcode == ZVOL_OPCODE_WRITE) {
-				for (i = 0; i < rcomm_cmd->copies_sent; i++) {
-					if (rcomm_cmd->resp_list[i].status &
-					    (RECEIVED_OK|RECEIVED_ERR))
-						count++;
-					else if (diff.tv_sec >= io_max_wait_time) {
-						ASSERT(rcomm_cmd->resp_list[i].replica);
-
-						MTX_LOCK(&rcomm_cmd->resp_list[i].replica->r_mtx);
-						inform_mgmt_conn(rcomm_cmd->resp_list[i].replica);
-						MTX_UNLOCK(&rcomm_cmd->resp_list[i].replica->r_mtx);
-
-						count++;
-					}
-				}
-				if (count != rcomm_cmd->copies_sent)
-					goto wait_for_other_responses;
-			}
 			rcomm_cmd->state = CMD_EXECUTION_DONE;
 #ifdef	DEBUG
 			/*
@@ -2747,6 +2760,9 @@ wait_for_other_responses:
 		err_num = errno;
 		MTX_UNLOCK(rcomm_cmd->mutex);
 	}
+
+	io_queue_time[cmd->luworkerindx].tv_sec =
+	    io_queue_time[cmd->luworkerindx].tv_nsec = 0;
 
 	return rc;
 }

--- a/src/replication.h
+++ b/src/replication.h
@@ -48,10 +48,19 @@ typedef enum rcomm_cmd_state_s {
 } rcomm_cmd_state_t;
 
 typedef enum rcmd_state_s {
+	/*  Received successful response from replica */
 	RECEIVED_OK = 1 << 0,
+
+	/* Received error from replica */
 	RECEIVED_ERR = 1 << 1,
+
+	/* Didn't received a response within io_max_wait_time seconds for rcmd*/
 	REPLICATE_TIMED_OUT = 1 << 2,
+
+	/* command sent to healthy replica */
 	SENT_TO_HEALTHY = 1 << 3,
+
+	/* command sent to degraded replica */
 	SENT_TO_DEGRADED = 1 << 4,
 } rcmd_state_t;
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -50,8 +50,9 @@ typedef enum rcomm_cmd_state_s {
 typedef enum rcmd_state_s {
 	RECEIVED_OK = 1 << 0,
 	RECEIVED_ERR = 1 << 1,
-	SENT_TO_HEALTHY = 1 << 2,
-	SENT_TO_DEGRADED = 1 << 3,
+	REPLICATE_TIMED_OUT = 1 << 2,
+	SENT_TO_HEALTHY = 1 << 3,
+	SENT_TO_DEGRADED = 1 << 4,
 } rcmd_state_t;
 
 typedef struct resp_data {

--- a/src/replication.h
+++ b/src/replication.h
@@ -60,6 +60,7 @@ typedef struct resp_data {
 } resp_data_t;
 
 struct replica_rcomm_resp {
+	struct replica_s *replica;
 	zvol_io_hdr_t io_resp_hdr;
 	uint8_t *data_ptr;
 	rcmd_state_t status;

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -675,7 +675,7 @@ run_rebuild_time_test_in_multiple_replicas()
 					fi
 				fi
 			else
-				if [ $rt -le 140 ]; then
+				if [ $rt -le 120 ]; then
 					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"
 					rstatus=$(eval $cmd)
 					echo "replica status $rstatus"

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -675,7 +675,7 @@ run_rebuild_time_test_in_multiple_replicas()
 					fi
 				fi
 			else
-				if [ $rt -le 120 ]; then
+				if [ $rt -le 140 ]; then
 					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"
 					rstatus=$(eval $cmd)
 					echo "replica status $rstatus"
@@ -704,6 +704,9 @@ run_rebuild_time_test_in_multiple_replicas()
 		sleep 10
 	done
 	while [ 1 ]; do
+		if [ $1 -eq 1 ]; then
+			break
+		fi
 		cnt=0
 		for (( i = 0; i < 3; i++ )) do
 			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"


### PR DESCRIPTION
Changes:
- Checking rebuild trigger condition based on replica create time
 
   If there are no IOs queued in replication module older than `replica->create_time`
   then rebuild for that replica will get triggered else it will be delayed.

- Adding a maximum IO wait time for replication feature

  With this changes, ISTGT will wait for a fixed time until it receives
  response from all the replicas.
  If ISTGT does not receive a response from a replica within a fixed time then
  it will initiate disconnection of that replica.

  This wait time is configurable through ISTGTCONTROL.
  Command:
        1. To get the maximum IO wait time
           -- `istgtcontrol maxiowait`
        2/ To set maximum IO wait time
           -- `istgtcontrol maxiowait 3`

```
mayank@mayank:~$ sudo ./istgtcontrol -q maxiowait
5
mayank@mayank:~$ sudo ./istgtcontrol -q maxiowait 3
3
```
Signed-off-by: mayank <mayank.patel@cloudbyte.com>