### PR TITLE
fix(poll_time): changed replica stats/health polling time from 30s to…

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2985,7 +2985,7 @@ handle_read_data_event(replica_t *replica)
 	return (rc);
 }
 
-int replica_poll_time = 30;
+int replica_poll_time = 10;
 
 /*
  * initializes replication

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -558,14 +558,12 @@ run_rebuild_time_test_in_single_replica()
 	fi
 
 	while [ 1 ]; do
-		# We have started istgt with 20 second replica timeout
-		# and rf=cf=1. so, it will take around 2 minutes for the
-		# replica to become healthy. So on safe side, we will
-		# check replica status after 130 seconds.
+		# With replica poll timeout as 10, volume should become
+		# healthy in less than 40 seconds.
 		cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].\"upTime\"'"
 		rt=$(eval $cmd)
 		echo "replica start time $rt"
-		if [ $rt -gt 130 ]; then
+		if [ $rt -gt 40 ]; then
 			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].status'"
 			rstatus=$(eval $cmd)
 			echo "replica status $rstatus"
@@ -665,7 +663,7 @@ run_rebuild_time_test_in_multiple_replicas()
 			rt=$(eval $cmd)
 			echo "replica start time $rt"
 			if [ $1 -eq 0 ]; then
-				if [ $rt -gt 130 ]; then
+				if [ $rt -gt 40 ]; then
 					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"
 					rstatus=$(eval $cmd)
 					echo "replica status $rstatus"
@@ -682,7 +680,7 @@ run_rebuild_time_test_in_multiple_replicas()
 					fi
 				fi
 			else
-				if [ $rt -le 140 ]; then
+				if [ $rt -le 30 ]; then
 					cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].status'"
 					rstatus=$(eval $cmd)
 					echo "replica status $rstatus"
@@ -697,7 +695,7 @@ run_rebuild_time_test_in_multiple_replicas()
 			fi
 		done
 		if [ $1 -eq 0 ]; then
-			if [ $rt -gt 130 ]; then
+			if [ $rt -gt 40 ]; then
 				echo "replica start time $rt done_test: $done_test"
 				if [ $done_test -eq 0 ]; then
 					echo "replication factor(2) test failed"


### PR DESCRIPTION
… 10s

Currently, istgt polls for health and stats from replica every 30 seconds. This decides the time taken to trigger rebuild.
This PR changes the poll interval to 10 seconds to make volume healthy faster.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>