### PR TITLE
feat(stats): replication latency stats 

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -528,7 +528,7 @@ handle_epoll_out_event(replica_t *r)
 }
 
 #define	ADD_TIMESPEC(var, s, d)	\
-	(var) += (uint64_t)(d.tv_sec - s.tv_sec) * (uint64_t)1000000000L + d.tv_nsec - s.tv_nsec;
+	(var) += (uint64_t)(d.tv_sec - s.tv_sec) * (uint64_t)SEC_IN_NS + d.tv_nsec - s.tv_nsec;
 
 static int
 handle_epoll_in_event(replica_t *r)

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -2778,7 +2778,8 @@ is_persist_enabled(void)
 	return (persist);
 }
 
-clockid_t clockid = CLOCK_UPTIME_FAST; // CLOCK_SECOND  CLOCK_MONOTONIC_FAST
+/* COARSE have precision till 1000Hz, which might be 1ms usually */
+clockid_t clockid = CLOCK_MONOTONIC_COARSE; // CLOCK_SECOND  CLOCK_MONOTONIC_FAST
 extern int detectDoubleFree;
 // int enable_xcopy = 0;
 int enable_oldBL = 0;

--- a/src/istgt.h
+++ b/src/istgt.h
@@ -111,6 +111,7 @@
 #define DEFAULT_MAXR2T 16
 #define TMF_TIMEOUT 2 
 
+#define	SEC_IN_NS	(1000000000L)
 #define ISTGT_PG_TAG_MAX 0x0000ffff
 #define ISTGT_LU_TAG_MAX 0x0000ffff
 #define ISTGT_UC_TAG     0x00010000

--- a/src/istgt.h
+++ b/src/istgt.h
@@ -27,7 +27,6 @@
 
 #ifndef ISTGT_H
 #define ISTGT_H
-#define CLOCK_UPTIME_FAST       8
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -87,6 +87,10 @@ typedef struct replica_s {
 	int dont_free;
 
 	struct timespec create_time;
+	uint64_t totalreadytime;
+	uint64_t totalwritedonetime;
+	uint64_t totalreadtime;
+	uint64_t totalreaddonetime;
 
 	/*
 	 * Following variables should be updated with atomic operation only

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -87,10 +87,17 @@ typedef struct replica_s {
 	int dont_free;
 
 	struct timespec create_time;
-	uint64_t totalread_reqtime;
-	uint64_t totalread_resptime;
 
+	/* This is calculated from create time till the queued time into readyQ */
+	/* Total time(ns) waited in queue to send read_IO req */
+	uint64_t totalread_reqtime;
+	/* Total time(ns) waited in queue to send write_IO req */
 	uint64_t totalwrite_reqtime;
+
+	/* This is calculated from create time till the entire resp read from wire*/
+	/* Total time(ns) to recv read_IO resp */
+	uint64_t totalread_resptime;
+	/* Total time(ns) to recv write_IO resp */
 	uint64_t totalwrite_resptime;
 	/*
 	 * Following variables should be updated with atomic operation only

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -87,11 +87,11 @@ typedef struct replica_s {
 	int dont_free;
 
 	struct timespec create_time;
-	uint64_t totalreadytime;
-	uint64_t totalwritedonetime;
-	uint64_t totalreadtime;
-	uint64_t totalreaddonetime;
+	uint64_t totalread_reqtime;
+	uint64_t totalread_resptime;
 
+	uint64_t totalwrite_reqtime;
+	uint64_t totalwrite_resptime;
 	/*
 	 * Following variables should be updated with atomic operation only
 	 */

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -676,7 +676,7 @@ mock_repl_io_worker(void *args)
 	snprintf(tinfo, 50, "mockiowork%d", rargs->replica_port);
 	prctl(PR_SET_NAME, tinfo, 0, 0, 0);
 
-	clock_gettime(CLOCK_MONOTONIC, &prev);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &prev);
 	while (1) {
 		MTX_LOCK(&rargs->io_recv_mtx);
 		while (TAILQ_EMPTY(&(rargs->io_recv_list))) {
@@ -712,7 +712,7 @@ mock_repl_io_worker(void *args)
 				break;
 		}
 
-		clock_gettime(CLOCK_MONOTONIC, &now);
+		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 		if (now.tv_sec - prev.tv_sec > 1) {
 			prev = now;
 			REPLICA_LOG("read %d wrote %d sync %d from %s\n",
@@ -1391,7 +1391,7 @@ main(int argc, char **argv)
 	int i;
 	bool do_snap = false;
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
 	replica_poll_time = 5;

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -3360,7 +3360,7 @@ timediff(ISTGT_LU_CMD_Ptr p, char  ch, uint16_t line)
 	}
 	if ((_n->tv_nsec - _s->tv_nsec) < 0) {
 		_r->tv_sec  = _n->tv_sec - _s->tv_sec-1;
-		_r->tv_nsec = 1000000000 + _n->tv_nsec - _s->tv_nsec;
+		_r->tv_nsec = SEC_IN_NS + _n->tv_nsec - _s->tv_nsec;
 	} else {
 		_r->tv_sec  = _n->tv_sec - _s->tv_sec;
 		_r->tv_nsec = _n->tv_nsec - _s->tv_nsec;
@@ -5459,7 +5459,7 @@ prof_log(ISTGT_LU_CMD_Ptr p, const char *caller)
 
 	if ((_n->tv_nsec - _s->tv_nsec) < 0) {
 		_r.tv_sec  = _n->tv_sec - _s->tv_sec-1;
-		_r.tv_nsec = 1000000000 + _n->tv_nsec - _s->tv_nsec;
+		_r.tv_nsec = SEC_IN_NS + _n->tv_nsec - _s->tv_nsec;
 	} else {
 		_r.tv_sec  = _n->tv_sec - _s->tv_sec;
 		_r.tv_nsec = _n->tv_nsec - _s->tv_nsec;
@@ -5561,8 +5561,8 @@ prof_log(ISTGT_LU_CMD_Ptr p, const char *caller)
 				spec->avgs[i].count++;
 				spec->avgs[i].tot_sec += p->tdiff[i].tv_sec;
 				spec->avgs[i].tot_nsec += p->tdiff[i].tv_nsec;
-				secs = spec->avgs[i].tot_nsec/1000000000;
-				nsecs = spec->avgs[i].tot_nsec%1000000000;
+				secs = spec->avgs[i].tot_nsec/SEC_IN_NS;
+				nsecs = spec->avgs[i].tot_nsec%SEC_IN_NS;
 				spec->avgs[i].tot_sec += secs;
 				spec->avgs[i].tot_nsec = nsecs;
 			}
@@ -5570,8 +5570,8 @@ prof_log(ISTGT_LU_CMD_Ptr p, const char *caller)
 			spec->avgs[levels].count++;
 			spec->avgs[levels].tot_sec += (_r.tv_sec);
 			spec->avgs[levels].tot_nsec += (_r.tv_nsec);
-			secs = spec->avgs[levels].tot_nsec/1000000000;
-			nsecs = spec->avgs[levels].tot_nsec%1000000000;
+			secs = spec->avgs[levels].tot_nsec/SEC_IN_NS;
+			nsecs = spec->avgs[levels].tot_nsec%SEC_IN_NS;
 			spec->avgs[levels].tot_sec += secs;
 			spec->avgs[levels].tot_nsec = nsecs;
 		}
@@ -5655,14 +5655,14 @@ update_cummulative_rw_time(ISTGT_LU_TASK_Ptr lu_task)
 				timesdiff(CLOCK_MONOTONIC_RAW,
 					lu_task->lu_cmd.start_rw_time,
 					endtime, diff);
-				ns = diff.tv_sec*1000000000L;
+				ns = diff.tv_sec*SEC_IN_NS;
 				ns += diff.tv_nsec;
 				__sync_fetch_and_add(&spec->totalwritetime, ns);
 				if (lu_task->lu_cmd.lu_start_time.tv_sec) {
 					timesdiff(CLOCK_MONOTONIC_RAW,
 						lu_task->lu_cmd.lu_start_time,
 						endtime, diff);
-					ns = diff.tv_sec*1000000000L;
+					ns = diff.tv_sec*SEC_IN_NS;
 					ns += diff.tv_nsec;
 					__sync_fetch_and_add(&spec->totalwritelutime, ns);
 				}
@@ -5670,7 +5670,7 @@ update_cummulative_rw_time(ISTGT_LU_TASK_Ptr lu_task)
 					timesdiff(CLOCK_MONOTONIC_RAW,
 						lu_task->lu_cmd.repl_start_time,
 						endtime, diff);
-					ns = diff.tv_sec*1000000000L;
+					ns = diff.tv_sec*SEC_IN_NS;
 					ns += diff.tv_nsec;
 					__sync_fetch_and_add(&spec->totalwriterepltime, ns);
 				}
@@ -5685,14 +5685,14 @@ update_cummulative_rw_time(ISTGT_LU_TASK_Ptr lu_task)
 				timesdiff(CLOCK_MONOTONIC_RAW,
 					lu_task->lu_cmd.start_rw_time,
 					endtime, diff);
-				ns = diff.tv_sec*1000000000L;
+				ns = diff.tv_sec*SEC_IN_NS;
 				ns += diff.tv_nsec;
 				__sync_fetch_and_add(&spec->totalreadtime, ns);
 				if (lu_task->lu_cmd.lu_start_time.tv_sec) {
 					timesdiff(CLOCK_MONOTONIC_RAW,
 						lu_task->lu_cmd.lu_start_time,
 						endtime, diff);
-					ns = diff.tv_sec*1000000000L;
+					ns = diff.tv_sec*SEC_IN_NS;
 					ns += diff.tv_nsec;
 					__sync_fetch_and_add(&spec->totalreadlutime, ns);
 				}
@@ -5700,7 +5700,7 @@ update_cummulative_rw_time(ISTGT_LU_TASK_Ptr lu_task)
 					timesdiff(CLOCK_MONOTONIC_RAW,
 						lu_task->lu_cmd.repl_start_time,
 						endtime, diff);
-					ns = diff.tv_sec*1000000000L;
+					ns = diff.tv_sec*SEC_IN_NS;
 					ns += diff.tv_nsec;
 					__sync_fetch_and_add(&spec->totalreadrepltime, ns);
 				}

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -3732,6 +3732,8 @@ istgt_lu_create_task(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd, int lun, ISTGT_LU_D
 	}
 
 #ifdef REPLICATION
+	lu_task->lu_cmd.lu_start_time.tv_sec = 0;
+	lu_task->lu_cmd.repl_start_time.tv_sec = 0;
 	lu_task->lu_cmd.start_rw_time = lu_cmd->start_rw_time;
 #endif
 	lu_task->condwait = 0;
@@ -4506,6 +4508,7 @@ luworker(void *arg)
 			tdiff(second2, third, r);
 #ifdef REPLICATION
 			lu_task->lu_cmd.luworkerindx = tind;
+			clock_gettime(CLOCK_MONOTONIC_RAW, &lu_task->lu_cmd.lu_start_time);
 #endif
 			lu_task->lu_cmd.flags |= ISTGT_WORKER_PICKED;
 			rc = istgt_lu_disk_queue_start(lu, lu_num, tind);

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -4346,7 +4346,7 @@ luworker(void *arg)
 	{	\
 		if ((_n.tv_nsec - _s.tv_nsec) < 0) {        \
 			_r.tv_sec  = _n.tv_sec - _s.tv_sec-1;   \
-			_r.tv_nsec = 1000000000 + _n.tv_nsec - _s.tv_nsec; \
+			_r.tv_nsec = SEC_IN_NS + _n.tv_nsec - _s.tv_nsec; \
 		} else {                                    \
 			_r.tv_sec  = _n.tv_sec - _s.tv_sec;     \
 			_r.tv_nsec = _n.tv_nsec - _s.tv_nsec;   \
@@ -4354,8 +4354,8 @@ luworker(void *arg)
 		spec->avgs[id].count++;	\
 		spec->avgs[id].tot_sec += _r.tv_sec;	\
 		spec->avgs[id].tot_nsec += _r.tv_nsec;	\
-		secs = spec->avgs[id].tot_nsec/1000000000;	\
-		nsecs = spec->avgs[id].tot_nsec%1000000000;	\
+		secs = spec->avgs[id].tot_nsec/SEC_IN_NS;	\
+		nsecs = spec->avgs[id].tot_nsec%SEC_IN_NS;	\
 		spec->avgs[id].tot_sec += secs;	\
 		spec->avgs[id].tot_nsec = nsecs;	\
 	}	\
@@ -4554,7 +4554,7 @@ luscheduler(void *arg)
 	{	\
 		if ((_n.tv_nsec - _s.tv_nsec) < 0) {        \
 			_r.tv_sec  = _n.tv_sec - _s.tv_sec-1;   \
-			_r.tv_nsec = 1000000000 + _n.tv_nsec - _s.tv_nsec; \
+			_r.tv_nsec = SEC_IN_NS + _n.tv_nsec - _s.tv_nsec; \
 		} else {                                    \
 			_r.tv_sec  = _n.tv_sec - _s.tv_sec;     \
 			_r.tv_nsec = _n.tv_nsec - _s.tv_nsec;   \
@@ -4562,8 +4562,8 @@ luscheduler(void *arg)
 		spec->avgs[id].count++;	\
 		spec->avgs[id].tot_sec += _r.tv_sec;	\
 		spec->avgs[id].tot_nsec += _r.tv_nsec;	\
-		secs = spec->avgs[id].tot_nsec/1000000000;	\
-		nsecs = spec->avgs[id].tot_nsec%1000000000;	\
+		secs = spec->avgs[id].tot_nsec/SEC_IN_NS;	\
+		nsecs = spec->avgs[id].tot_nsec%SEC_IN_NS;	\
 		spec->avgs[id].tot_sec += secs;	\
 		spec->avgs[id].tot_nsec = nsecs;	\
 	}	\

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -786,10 +786,10 @@ typedef struct istgt_lu_disk_t {
 	uint64_t writebytes;
 	uint64_t totalreadtime;
 	uint64_t totalwritetime;
-	uint64_t totalreadlutime;
-	uint64_t totalwritelutime;
-	uint64_t totalreadrepltime;
-	uint64_t totalwriterepltime;
+	uint64_t totalreadlutime; /* Time for read IO at LU worker */
+	uint64_t totalwritelutime; /* Similar to above */
+	uint64_t totalreadrepltime; /* Time for read IO at replication module */
+	uint64_t totalwriterepltime; /* Similar to above */
 	uint64_t totalreadblockcount;
 	uint64_t totalwriteblockcount;
 #endif

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -430,6 +430,8 @@ typedef struct istgt_lu_cmd_t {
 #ifdef REPLICATION
 	uint32_t   luworkerindx;
 	struct timespec start_rw_time;
+	struct timespec lu_start_time;
+	struct timespec repl_start_time;
 #endif
 } ISTGT_LU_CMD;
 typedef ISTGT_LU_CMD *ISTGT_LU_CMD_Ptr;
@@ -784,6 +786,10 @@ typedef struct istgt_lu_disk_t {
 	uint64_t writebytes;
 	uint64_t totalreadtime;
 	uint64_t totalwritetime;
+	uint64_t totalreadlutime;
+	uint64_t totalwritelutime;
+	uint64_t totalreadrepltime;
+	uint64_t totalwriterepltime;
 	uint64_t totalreadblockcount;
 	uint64_t totalwriteblockcount;
 #endif

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -3097,7 +3097,7 @@ istgt_uctl_cmd_que(UCTL_Ptr uctl)
 #define	tdiff(_s, _n, _r) {                     \
 	if ((_n.tv_nsec - _s.tv_nsec) < 0) {        \
 		_r.tv_sec  = _n.tv_sec - _s.tv_sec-1;   \
-		_r.tv_nsec = 1000000000 + _n.tv_nsec - _s.tv_nsec; \
+		_r.tv_nsec = SEC_IN_NS + _n.tv_nsec - _s.tv_nsec; \
 	} else {                                    \
 		_r.tv_sec  = _n.tv_sec - _s.tv_sec;     \
 		_r.tv_nsec = _n.tv_nsec - _s.tv_nsec;   \
@@ -3193,7 +3193,7 @@ istgt_uctl_cmd_que(UCTL_Ptr uctl)
 			    (signed long)(spec->avgs[0].tot_nsec))) < 0) {
 				spec->avgs[0].tot_sec  =
 				    now.tv_sec - spec->avgs[0].tot_sec - 1;
-				spec->avgs[0].tot_nsec = 1000000000 +
+				spec->avgs[0].tot_nsec = SEC_IN_NS +
 				    now.tv_nsec - spec->avgs[0].tot_nsec;
 			} else {
 				spec->avgs[0].tot_sec =
@@ -3410,15 +3410,15 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 
 		json_object_object_add(jobj, "TotalReadTime",
 		    json_object_new_uint64(spec->totalreadtime));
-		json_object_object_add(jobj, "TotalReadLUTime",
+		json_object_object_add(jobj, "LUTotalReadTime",
 		    json_object_new_uint64(spec->totalreadlutime));
-		json_object_object_add(jobj, "TotalReadReplTime",
+		json_object_object_add(jobj, "ReplicationTotalReadTime",
 		    json_object_new_uint64(spec->totalreadrepltime));
 		json_object_object_add(jobj, "TotalWriteTime",
 		    json_object_new_uint64(spec->totalwritetime));
-		json_object_object_add(jobj, "TotalWriteLUTime",
+		json_object_object_add(jobj, "LUTotalWriteTime",
 		    json_object_new_uint64(spec->totalwritelutime));
-		json_object_object_add(jobj, "TotalWriteReplTime",
+		json_object_object_add(jobj, "ReplicationTotalWriteTime",
 		    json_object_new_uint64(spec->totalwriterepltime));
 		json_object_object_add(jobj, "TotalReadBlockCount",
 		    json_object_new_uint64(spec->totalreadblockcount));

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -3438,20 +3438,19 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 		MTX_LOCK(&spec->rq_mtx);
 		TAILQ_FOREACH(replica, &spec->rq, r_next) {
 		    MTX_LOCK(&replica->r_mtx);
-		    json_object *jobjarr = json_object_new_object();
-		    json_object_object_add(jobjarr, "Address",
-			json_object_new_string(replica->ip));
-		    json_object_object_add(jobjarr, "Mode",
-			json_object_new_string(((replica->state ==
-			    ZVOL_STATUS_HEALTHY) ? "HEALTHY" : "DEGRADED")));
-		    json_object_object_add(jobjarr, "ReadyTime",
-			json_object_new_uint64(replica->totalreadytime));
-		    json_object_object_add(jobjarr, "WriteDoneTime",
-			json_object_new_uint64(replica->totalwritedonetime));
-		    json_object_object_add(jobjarr, "ReadTime",
-			json_object_new_uint64(replica->totalreadtime));
-		    json_object_object_add(jobjarr, "ReadDoneTime",
-			json_object_new_uint64(replica->totalreaddonetime));
+
+		    struct json_object *jobjarr = NULL;
+		    get_replica_stats_json(replica, &jobjarr);
+
+		    json_object_object_add(jobjarr, "ReadReqTime",
+			json_object_new_uint64(replica->totalread_reqtime));
+		    json_object_object_add(jobjarr, "ReadRespTime",
+			json_object_new_uint64(replica->totalread_resptime));
+
+		    json_object_object_add(jobjarr, "WriteReqTime",
+			json_object_new_uint64(replica->totalwrite_reqtime));
+		    json_object_object_add(jobjarr, "WriteRespTime",
+			json_object_new_uint64(replica->totalwrite_resptime));
 		    MTX_UNLOCK(&replica->r_mtx);
 		    json_object_array_add(jobj_arr, jobjarr);
 		}

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -3410,8 +3410,16 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 
 		json_object_object_add(jobj, "TotalReadTime",
 		    json_object_new_uint64(spec->totalreadtime));
+		json_object_object_add(jobj, "TotalReadLUTime",
+		    json_object_new_uint64(spec->totalreadlutime));
+		json_object_object_add(jobj, "TotalReadReplTime",
+		    json_object_new_uint64(spec->totalreadrepltime));
 		json_object_object_add(jobj, "TotalWriteTime",
 		    json_object_new_uint64(spec->totalwritetime));
+		json_object_object_add(jobj, "TotalWriteLUTime",
+		    json_object_new_uint64(spec->totalwritelutime));
+		json_object_object_add(jobj, "TotalWriteReplTime",
+		    json_object_new_uint64(spec->totalwriterepltime));
 		json_object_object_add(jobj, "TotalReadBlockCount",
 		    json_object_new_uint64(spec->totalreadblockcount));
 		json_object_object_add(jobj, "TotalWriteBlockCount",
@@ -3436,6 +3444,14 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 		    json_object_object_add(jobjarr, "Mode",
 			json_object_new_string(((replica->state ==
 			    ZVOL_STATUS_HEALTHY) ? "HEALTHY" : "DEGRADED")));
+		    json_object_object_add(jobjarr, "ReadyTime",
+			json_object_new_uint64(replica->totalreadytime));
+		    json_object_object_add(jobjarr, "WriteDoneTime",
+			json_object_new_uint64(replica->totalwritedonetime));
+		    json_object_object_add(jobjarr, "ReadTime",
+			json_object_new_uint64(replica->totalreadtime));
+		    json_object_object_add(jobjarr, "ReadDoneTime",
+			json_object_new_uint64(replica->totalreaddonetime));
 		    MTX_UNLOCK(&replica->r_mtx);
 		    json_object_array_add(jobj_arr, jobjarr);
 		}

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -7715,7 +7715,7 @@ istgt_lu_print_q(ISTGT_LU_Ptr lu, int lun)
 #define tdiff(_s, _n, _r) {                     \
 	if ((_n.tv_nsec - _s.tv_nsec) < 0) {        \
 		_r.tv_sec  = _n.tv_sec - _s.tv_sec-1;   \
-		_r.tv_nsec = 1000000000 + _n.tv_nsec - _s.tv_nsec; \
+		_r.tv_nsec = SEC_IN_NS + _n.tv_nsec - _s.tv_nsec; \
 	} else {                                    \
 		_r.tv_sec  = _n.tv_sec - _s.tv_sec;     \
 		_r.tv_nsec = _n.tv_nsec - _s.tv_nsec;   \
@@ -8237,7 +8237,7 @@ istgt_lu_disk_queue(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 	{	\
                 if ((_n.tv_nsec - _s.tv_nsec) < 0) {        \
                         _r.tv_sec  = _n.tv_sec - _s.tv_sec-1;   \
-                        _r.tv_nsec = 1000000000 + _n.tv_nsec - _s.tv_nsec; \
+                        _r.tv_nsec = SEC_IN_NS + _n.tv_nsec - _s.tv_nsec; \
                 } else {                                    \
                         _r.tv_sec  = _n.tv_sec - _s.tv_sec;     \
                         _r.tv_nsec = _n.tv_nsec - _s.tv_nsec;   \
@@ -8245,8 +8245,8 @@ istgt_lu_disk_queue(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 		spec->avgs[id].count++;	\
 		spec->avgs[id].tot_sec += _r.tv_sec;	\
 		spec->avgs[id].tot_nsec += _r.tv_nsec;	\
-		secs = spec->avgs[id].tot_nsec/1000000000;	\
-		nsecs = spec->avgs[id].tot_nsec%1000000000;	\
+		secs = spec->avgs[id].tot_nsec/SEC_IN_NS;	\
+		nsecs = spec->avgs[id].tot_nsec%SEC_IN_NS;	\
 		spec->avgs[id].tot_sec += secs;	\
 		spec->avgs[id].tot_nsec = nsecs;	\
 	}	\

--- a/src/istgt_misc.h
+++ b/src/istgt_misc.h
@@ -217,7 +217,7 @@ int poolprint(char *inbuf, int len);
 	clock_gettime(_clockid, &_now);					\
 	if ((_now.tv_nsec - _st.tv_nsec)<0) {				\
 		_re.tv_sec  = _now.tv_sec - _st.tv_sec - 1;		\
-		_re.tv_nsec = 1000000000 + _now.tv_nsec - _st.tv_nsec;	\
+		_re.tv_nsec = SEC_IN_NS + _now.tv_nsec - _st.tv_nsec;	\
 	} else {							\
 		_re.tv_sec  = _now.tv_sec - _st.tv_sec;			\
 		_re.tv_nsec = _now.tv_nsec - _st.tv_nsec;		\

--- a/src/mock_client.c
+++ b/src/mock_client.c
@@ -109,14 +109,14 @@ writer(void *args)
 	int *cnt = cargs->count;
 	SBC_OPCODE opcode;
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
 	snprintf(tinfo, 50, "mcwrite%d", cargs->workerid);
 	prctl(PR_SET_NAME, tinfo, 0, 0, 0);
 
-	clock_gettime(CLOCK_MONOTONIC, &start);
-	clock_gettime(CLOCK_MONOTONIC, &prev);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &prev);
 
 	lu_cmd  = (ISTGT_LU_CMD_Ptr)malloc(sizeof (ISTGT_LU_CMD));
 	memset(lu_cmd, 0, sizeof (ISTGT_LU_CMD));
@@ -145,7 +145,7 @@ writer(void *args)
 
 		count++;
 
-		clock_gettime(CLOCK_MONOTONIC, &now);
+		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 		if (now.tv_sec - start.tv_sec > 120)
 			break;
 		if (now.tv_sec - prev.tv_sec > 1) {
@@ -188,14 +188,14 @@ reader(void *args)
 	int *cnt = cargs->count;
 	SBC_OPCODE opcode = SBC_READ_16;
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
 	snprintf(tinfo, 50, "mcread%d", cargs->workerid);
 	prctl(PR_SET_NAME, tinfo, 0, 0, 0);
 
-	clock_gettime(CLOCK_MONOTONIC, &start);
-	clock_gettime(CLOCK_MONOTONIC, &prev);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &prev);
 
 	lu_cmd  = malloc(sizeof (ISTGT_LU_CMD));
 	memset(lu_cmd, 0, sizeof (ISTGT_LU_CMD));
@@ -222,7 +222,7 @@ reader(void *args)
 		lu_cmd->data = NULL;
 
 		count++;
-		clock_gettime(CLOCK_MONOTONIC, &now);
+		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 		if (now.tv_sec - start.tv_sec > 10)
 			break;
 		if (now.tv_sec - prev.tv_sec > 1) {
@@ -267,19 +267,19 @@ snapshot_thread(void *args)
 
 	init_snap_resp_list();
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
-	clock_gettime(CLOCK_MONOTONIC, &start);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &start);
 	while (1) {
 		update_snap_resp_list(spec);
 		io_wait_time = random() % 2 + 2;
 		wait_time = random() % 2 + 4;
 
-		clock_gettime(CLOCK_MONOTONIC, &cmd_start);
+		clock_gettime(CLOCK_MONOTONIC_RAW, &cmd_start);
 		ret = istgt_lu_create_snapshot(spec, snapname, io_wait_time,
 		    wait_time);
-		timesdiff(CLOCK_MONOTONIC, cmd_start, now, cmd_time);
+		timesdiff(CLOCK_MONOTONIC_RAW, cmd_start, now, cmd_time);
 
 		VERIFY(cmd_time.tv_sec <= (wait_time + 1));
 
@@ -287,7 +287,7 @@ snapshot_thread(void *args)
 
 		sleep(1);
 		count++;
-		clock_gettime(CLOCK_MONOTONIC, &now);
+		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 		if (now.tv_sec - start.tv_sec > 120)
 			break;
 	}
@@ -326,7 +326,7 @@ create_mock_client(spec_t *spec, bool do_snap)
 
 	count = 0;
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
 	all_cargs = (cargs_t *)malloc(sizeof (cargs_t) *

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -596,7 +596,7 @@ errored_replica(void *arg)
 	io_hdr = malloc(sizeof(zvol_io_hdr_t));
 	mgmtio = malloc(sizeof(zvol_io_hdr_t));
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
 	snprintf(tinfo, 50, "mock_nwrepl%d", replica_port);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1162,7 +1162,7 @@ replica_error:
 	/* Update the volume ready state */
 	update_volstate(spec);
 	MTX_UNLOCK(&spec->rq_mtx);
-	clock_gettime(CLOCK_MONOTONIC, &replica->create_time);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &replica->create_time);
 	return 0;
 }
 
@@ -1379,8 +1379,8 @@ pause_and_timed_wait_for_ongoing_ios(spec_t *spec, int sec)
 	ASSERT(MTX_LOCKED(&spec->rq_mtx));
 	spec->quiesce = 1;
 
-	clock_gettime(CLOCK_MONOTONIC, &last);
-	timesdiff(CLOCK_MONOTONIC, last, now, diff);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &last);
+	timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
 
 	while ((diff.tv_sec < sec) && (can_take_snapshot(spec) == true)) {
 		io_found = false;
@@ -1407,7 +1407,7 @@ pause_and_timed_wait_for_ongoing_ios(spec_t *spec, int sec)
 		 */
 		sleep (1);
 		MTX_LOCK(&spec->rq_mtx);
-		timesdiff(CLOCK_MONOTONIC, last, now, diff);
+		timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
 	}
 
 	if (ret == false)
@@ -1440,7 +1440,7 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 	rcommon_mgmt_cmd_t *rcomm_mgmt;
 	uint64_t io_seq;
 
-	clock_gettime(CLOCK_MONOTONIC, &last);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &last);
 	MTX_LOCK(&spec->rq_mtx);
 
 	/* Wait for any ongoing snapshot commands */
@@ -1474,7 +1474,7 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 
 	uint8_t cf = spec->consistency_factor;
 
-	timesdiff(CLOCK_MONOTONIC, last, now, diff);
+	timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
 	MTX_LOCK(&rcomm_mgmt->mtx);
 
 	while (diff.tv_sec < wait_time) {
@@ -1485,7 +1485,7 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 		sleep(1);
 		MTX_LOCK(&spec->rq_mtx);
 		MTX_LOCK(&rcomm_mgmt->mtx);
-		timesdiff(CLOCK_MONOTONIC, last, now, diff);
+		timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
 	}
 	rcomm_mgmt->caller_gone = 1;
 	if (rcomm_mgmt->cmds_sent == (rcomm_mgmt->cmds_succeeded + rcomm_mgmt->cmds_failed)) {
@@ -1520,7 +1520,7 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 	return r;
 }
 
-static void
+void
 get_replica_stats_json(replica_t *replica, struct json_object **jobj)
 {
 	struct json_object *j_stats;
@@ -1530,7 +1530,10 @@ get_replica_stats_json(replica_t *replica, struct json_object **jobj)
 	json_object_object_add(j_stats, "replicaId",
 	    json_object_new_uint64(replica->zvol_guid));
 
-	json_object_object_add(j_stats, "status",
+	json_object_object_add(j_stats, "Address",
+	    json_object_new_string(replica->ip));
+
+	json_object_object_add(j_stats, "Mode",
 	    json_object_new_string((replica->state == ZVOL_STATUS_HEALTHY) ?
 	    REPLICA_STATUS_HEALTHY : REPLICA_STATUS_DEGRADED));
 
@@ -1546,7 +1549,7 @@ get_replica_stats_json(replica_t *replica, struct json_object **jobj)
 	json_object_object_add(j_stats, "inflightSync",
 	    json_object_new_uint64(replica->replica_inflight_sync_io_cnt));
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
 	json_object_object_add(j_stats, "upTime",
 	    json_object_new_int64(now.tv_sec - replica->create_time.tv_sec));
 
@@ -1823,7 +1826,7 @@ handle_update_spec_stats(spec_t *spec, zvol_io_hdr_t *hdr, void *resp)
 		return;
 	if (strcmp(stats->label, "used") == 0)
 		spec->stats.used = stats->value;
-	clock_gettime(CLOCK_MONOTONIC, &spec->stats.updated_stats_time);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &spec->stats.updated_stats_time);
 	return;
 }
 
@@ -2425,7 +2428,7 @@ respond_with_error_for_all_outstanding_mgmt_ios(replica_t *r)
 		    sizeof(struct zvol_io_rw_hdr));			\
 		rcmd = malloc(sizeof(*rcmd));				\
 		memset(rcmd, 0, sizeof (*rcmd));			\
-		clock_gettime(CLOCK_MONOTONIC, &rcmd->start_time);	\
+		clock_gettime(CLOCK_MONOTONIC_RAW, &rcmd->start_time);	\
 		rcmd->opcode = rcomm_cmd->opcode;			\
 		rcmd->offset = rcomm_cmd->offset;			\
 		rcmd->data_len = rcomm_cmd->data_len;			\
@@ -2596,6 +2599,9 @@ check_for_command_completion(spec_t *spec, rcommon_cmd_t *rcomm_cmd, ISTGT_LU_CM
 	return rc;
 }
 
+#define	ADD_TIMESPEC(var, s, d)	\
+	(var) += (uint64_t)(d.tv_sec - s.tv_sec) * (uint64_t)1000000000L + d.tv_nsec - s.tv_nsec;
+
 int64_t
 replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t nbytes)
 {
@@ -2637,7 +2643,7 @@ again:
 	ASSERT(spec->io_seq);
 	build_rcomm_cmd(rcomm_cmd, cmd, offset, nbytes);
 
-	clock_gettime(CLOCK_MONOTONIC, &io_queue_time[cmd->luworkerindx]);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &io_queue_time[cmd->luworkerindx]);
 	clock_gettime(CLOCK_MONOTONIC_RAW, &cmd->repl_start_time);
 
 retry_read:
@@ -2707,11 +2713,11 @@ retry_read:
 
 	MTX_UNLOCK(&spec->rq_mtx);
 
-	clock_gettime(CLOCK_MONOTONIC, &queued_time);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &queued_time);
 
 	// now wait for command to complete
 	while (1) {
-		timesdiff(CLOCK_MONOTONIC, queued_time, now, diff);
+		timesdiff(CLOCK_MONOTONIC_RAW, queued_time, now, diff);
 		count = 0;
 		for (i = 0; i < rcomm_cmd->copies_sent; i++) {
 			resp_replica = rcomm_cmd->resp_list[i].replica;
@@ -2785,7 +2791,7 @@ retry_read:
 
 wait_for_other_responses:
 		/* wait for 500 ms(500000000 ns) */
-		clock_gettime(CLOCK_REALTIME, &now);
+		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 		nsec = 1000000000 - now.tv_nsec;
 		if (nsec > 500000000) {
 			abstime.tv_sec = now.tv_sec;
@@ -3029,7 +3035,7 @@ init_replication(void *arg __attribute__((__unused__)))
 
 	events = calloc(MAXEVENTS, sizeof(event));
 	timeout = replica_poll_time * 1000;
-	clock_gettime(CLOCK_MONOTONIC, &last);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &last);
 
 #ifdef	DEBUG
 	/*
@@ -3120,7 +3126,7 @@ init_replication(void *arg __attribute__((__unused__)))
 		}
 
 		// send replica_status query to degraded replicas at max interval of '2*replica_poll_time' seconds
-		timesdiff(CLOCK_MONOTONIC, last, now, diff);
+		timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
 		if (diff.tv_sec >= replica_poll_time) {
 			spec_t *spec = NULL;
 			MTX_LOCK(&specq_mtx);
@@ -3129,7 +3135,7 @@ init_replication(void *arg __attribute__((__unused__)))
 				get_replica_stats(spec);
 			}
 			MTX_UNLOCK(&specq_mtx);
-			clock_gettime(CLOCK_MONOTONIC, &last);
+			clock_gettime(CLOCK_MONOTONIC_COARSE, &last);
 		}
 	}
 
@@ -3153,7 +3159,7 @@ initialize_replication()
 		REPLICA_ERRLOG("Failed to init specq_mtx err(%d)\n", rc);
 		return -1;
 	}
-	clock_gettime(CLOCK_MONOTONIC_RAW, &istgt_start_time);
+	clock_gettime(CLOCK_MONOTONIC_COARSE, &istgt_start_time);
 	return 0;
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2602,7 +2602,7 @@ check_for_command_completion(spec_t *spec, rcommon_cmd_t *rcomm_cmd, ISTGT_LU_CM
 }
 
 #define	ADD_TIMESPEC(var, s, d)	\
-	(var) += (uint64_t)(d.tv_sec - s.tv_sec) * (uint64_t)1000000000L + d.tv_nsec - s.tv_nsec;
+	(var) += (uint64_t)(d.tv_sec - s.tv_sec) * (uint64_t)SEC_IN_NS + d.tv_nsec - s.tv_nsec;
 
 int64_t
 replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t nbytes)
@@ -2794,7 +2794,7 @@ retry_read:
 wait_for_other_responses:
 		/* wait for 500 ms(500000000 ns) */
 		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
-		nsec = 1000000000 - now.tv_nsec;
+		nsec = SEC_IN_NS - now.tv_nsec;
 		if (nsec > 500000000) {
 			abstime.tv_sec = now.tv_sec;
 			abstime.tv_nsec = now.tv_nsec + 500000000;

--- a/src/replication.c
+++ b/src/replication.c
@@ -581,13 +581,15 @@ trigger_rebuild(spec_t *spec)
 	if (spec->rebuild_info.rebuild_in_progress == true) {
 		assert(spec->ready == true);
 		REPLICA_NOTICELOG("Rebuild is already in progress "
-		    "on volume(%s)\n", spec->volname);
+		    "on volume(%s) for replica (%lu)\n", spec->volname,
+		    spec->rebuild_info.dw_replica->zvol_guid);
 		return;
 	}
 
 	if (!spec->degraded_rcount) {
-		REPLICA_NOTICELOG("No downgraded replica on volume(%s) "
-		", rebuild will not be attempted\n", spec->volname);
+		REPLICA_NOTICELOG("No downgraded replica on volume(%s),"
+		    "healthy: %d degraded: %d, rebuild will not be attempted\n",
+		    spec->volname, spec->healthy_rcount, spec->degraded_rcount);
 		return;
 	}
 
@@ -1452,7 +1454,7 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 
 	if (can_take_snapshot(spec) == false) {
 		MTX_UNLOCK(&spec->rq_mtx);
-		REPLICA_ERRLOG("volume is not healthy..\n");
+		REPLICA_ERRLOG("volume is not healthy to take snapshots..\n");
 		return false;
 	}
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -113,7 +113,10 @@ typedef struct rcmd_s {
 	uint64_t offset;
 	uint64_t data_len;
 	struct iovec iov[41];
-	struct timespec queued_time;
+	struct timespec start_time;
+	struct timespec ready_time;
+	struct timespec read_time;
+	struct timespec write_done;
 } rcmd_t;
 
 typedef struct replica_s replica_t;

--- a/src/replication.h
+++ b/src/replication.h
@@ -16,6 +16,7 @@
 #include <syslog.h>
 #include <stdbool.h>
 #include "replication_log.h"
+#include <json-c/json_object.h>
 #include "zrepl_prot.h"
 
 #define	MAXREPLICA 5
@@ -115,8 +116,6 @@ typedef struct rcmd_s {
 	struct iovec iov[41];
 	struct timespec start_time;
 	struct timespec ready_time;
-	struct timespec read_time;
-	struct timespec write_done;
 } rcmd_t;
 
 typedef struct replica_s replica_t;
@@ -197,6 +196,7 @@ int initialize_volume(spec_t *spec, int, int);
 void destroy_volume(spec_t *spec);
 void inform_mgmt_conn(replica_t *r);
 extern const char * get_cv_status(spec_t *spec, int replica_cnt, int healthy_replica_cnt);
+extern void get_replica_stats_json(replica_t *replica, struct json_object **jobj);
 
 /* Replica default timeout is 200 seconds */
 #define	REPLICA_DEFAULT_TIMEOUT	200

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -500,7 +500,7 @@ main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
 	data = NULL;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -417,7 +417,7 @@ main(int argc, char **argv)
 	int iofd = -1, mgmtfd, sfd, rc, epfd, event_count, i;
 	int64_t count;
 	struct epoll_event event, *events;
-	uint8_t *data, *data_ptr_cpy;
+	uint8_t *data, *mgmt_data;
 	uint64_t nbytes = 0;
 	int vol_fd;
 	zvol_op_code_t opcode;
@@ -585,8 +585,8 @@ again:
 				}
 
 				if(mgmtio->len) {
-					data = data_ptr_cpy = malloc(mgmtio->len);
-					count = test_read_data(events[i].data.fd, (uint8_t *)data, mgmtio->len);
+					mgmt_data = malloc(mgmtio->len);
+					count = test_read_data(events[i].data.fd, (uint8_t *)mgmt_data, mgmtio->len);
 					if (count < 0) {
 						rc = -1;
 						goto error;
@@ -598,7 +598,7 @@ again:
 					}
 				}
 				opcode = mgmtio->opcode;
-				send_mgmt_ack(mgmtfd, opcode, data, replica_ip, replica_port, zrepl_status, &zrepl_status_msg_cnt);
+				send_mgmt_ack(mgmtfd, opcode, mgmt_data, replica_ip, replica_port, zrepl_status, &zrepl_status_msg_cnt);
 			} else if (events[i].data.fd == sfd) {
 				struct sockaddr saddr;
 				socklen_t slen;
@@ -808,7 +808,7 @@ execute_io:
 
 error:
 	REPLICA_ERRLOG("shutting down replica(%s:%d) IOs(read:%lu write:%lu)\n",
-	    ctrl_ip, ctrl_port, read_ios, write_ios);
+	    replica_ip, replica_port, read_ios, write_ios);
 	if (data)
 		free(data);
 	close(vol_fd);


### PR DESCRIPTION
This PR is to add replication module related latency details to `istgtcontrol -q iostats` command.
`.Replicas[*].ReadReqTime` gives the time taken to send read IO request to replica in replication module.
Similarly, `.Replicas[*].WriteReqTime` is related to write IO request.
`.Replicas[*].ReadRespTime` gives the time taken to receive read IO response sent to replica in replication module. Similarly, `Replicas[*].WriteRespTime` is related to write IO request.

This also changes the clock_id from CLOCK_MONOTONIC to CLOCK_MONOTONIC_RAW, and uses CLOCK_MONOTONIC_COARSE in timer related functions.

Fixes an issue with replication_test regarding the scenario when mgmt opcode (for ex, STATUS opcode) is received when partial data IO is read.

`istgtcontrol -q REPLICA` output is also changed to use same API for iostats and replica options. Change is `.volumeStatus.replicaStatus[*].status` to `.volumeStatus.replicaStatus[*].Mode`. This need changes in litmus repo as well. This needs change in maya repo also.