### PR TITLE
feat(write_luworkers): set the write LUWorkers using istgtcontrol

### DIFF
--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -754,6 +754,10 @@ typedef struct istgt_lu_disk_t {
 	int persist;
 #ifdef	REPLICATION
 	char *volname;
+	int write_luworkers;
+	int inflight_writes;
+	pthread_mutex_t write_throttle_mtx;
+	pthread_cond_t write_throttle_cv;
 #endif
 	int fd;
 	const char *file;

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -689,8 +689,6 @@ istgt_uctl_cmd_max_io_wait(UCTL_Ptr uctl)
 	return (UCTL_CMD_OK);
 }
 
-#endif
-
 static int
 istgt_uctl_set_write_luworkers(ISTGT_LU_DISK *spec, int val)
 {
@@ -715,6 +713,7 @@ istgt_uctl_set_write_luworkers(ISTGT_LU_DISK *spec, int val)
 	}
 	return 0;
 }
+#endif
 
 static int
 istgt_uctl_cmd_set(UCTL_Ptr uctl)
@@ -1051,6 +1050,7 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 
 		break;
 #endif
+#ifdef	REPLICATION
 	case 16:
 		rc = istgt_uctl_set_write_luworkers(spec, setval);
 		if (rc == -1) {
@@ -1058,6 +1058,7 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 			goto error_return;
 		}
 		break;
+#endif
 	default:
 		istgt_uctl_snprintf(uctl, "ERR invalid option %d\n", setopt);
 		goto error_return;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -124,7 +124,7 @@ static uint64_t
 fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
     uint8_t **resp_data)
 {
-	uint32_t count = 0;
+	uint32_t count = 1;
 	uint64_t len = io_hdr->len;
 	uint64_t offset = io_hdr->offset;
 	uint64_t start = offset;
@@ -135,6 +135,7 @@ fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
 	struct zvol_io_rw_hdr *last_io_rw_hdr;
 	uint8_t *resp;
 
+	md_io_num = read_metadata(start);
 	while (start < end) {
 		if (md_io_num != read_metadata(start)) {
 			count++;
@@ -411,7 +412,6 @@ main(int argc, char **argv)
 	char replica_ip[MAX_IP_LEN];
 	int replica_port = 0;
 	char test_vol[1024];
-	int sleeptime = 0;
 	struct zvol_io_rw_hdr *io_rw_hdr;
 	zvol_op_open_data_t *open_ptr;
 	int iofd = -1, mgmtfd, sfd, rc, epfd, event_count, i;
@@ -747,12 +747,9 @@ execute_io:
 						}
 
 						data -= sizeof(struct zvol_io_rw_hdr);
-						usleep(sleeptime);
 						write_ios++;
 					} else if(io_hdr->opcode == ZVOL_OPCODE_READ) {
 						uint8_t *user_data = NULL;
-						if (delay > 0)
-							sleep(delay);
 
 						if(io_hdr->len) {
 							user_data = malloc(io_hdr->len);


### PR DESCRIPTION
This PR is to limit the luworkers that can do simultaneous writes in replication module.
Command to change the setting: `istgtcontrol -t vol1 SET 16 <write_luworkers>`

Fixed a memory corruption in replication_test binary with read IOs during degraded mode.
Signed-off-by: Vishnu Itta <vitta@mayadata.io>