### PR TITLE
feat(write_luworkers): set the write LUWorkers using istgtcontrol

### DIFF
--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -754,8 +754,10 @@ typedef struct istgt_lu_disk_t {
 	int persist;
 #ifdef	REPLICATION
 	char *volname;
-	int write_luworkers;
-	int inflight_writes;
+	uint8_t write_luworkers;
+//	uint8_t inflight_writes;
+	uint8_t write_throttle_wait;
+	uint8_t reserved;
 	pthread_mutex_t write_throttle_mtx;
 	pthread_cond_t write_throttle_cv;
 #endif

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -755,11 +755,6 @@ typedef struct istgt_lu_disk_t {
 #ifdef	REPLICATION
 	char *volname;
 	uint8_t write_luworkers;
-//	uint8_t inflight_writes;
-	uint8_t write_throttle_wait;
-	uint8_t reserved;
-	pthread_mutex_t write_throttle_mtx;
-	pthread_cond_t write_throttle_cv;
 #endif
 	int fd;
 	const char *file;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -754,6 +754,10 @@ typedef struct istgt_lu_disk_t {
 	int persist;
 #ifdef	REPLICATION
 	char *volname;
+	int write_luworkers;
+	int inflight_writes;
+	pthread_mutex_t write_throttle_mtx;
+	pthread_cond_t write_throttle_cv;
 #endif
 	int fd;
 	const char *file;

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -689,8 +689,6 @@ istgt_uctl_cmd_max_io_wait(UCTL_Ptr uctl)
 	return (UCTL_CMD_OK);
 }
 
-#endif
-
 static int
 istgt_uctl_set_write_luworkers(ISTGT_LU_DISK *spec, int val)
 {
@@ -715,6 +713,7 @@ istgt_uctl_set_write_luworkers(ISTGT_LU_DISK *spec, int val)
 	}
 	return 0;
 }
+#endif
 
 static int
 istgt_uctl_cmd_set(UCTL_Ptr uctl)
@@ -1051,6 +1050,7 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 
 		break;
 #endif
+#ifdef	REPLICATION
 	case 16:
 		rc = istgt_uctl_set_write_luworkers(spec, setval);
 		if (rc == -1) {
@@ -1058,6 +1058,7 @@ istgt_uctl_cmd_set(UCTL_Ptr uctl)
 			goto error_return;
 		}
 		break;
+#endif
 	default:
 		istgt_uctl_snprintf(uctl, "ERR invalid option %d\n", setopt);
 		goto error_return;

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -922,6 +922,8 @@ istgt_lu_disk_init(ISTGT_Ptr istgt __attribute__((__unused__)), ISTGT_LU_Ptr lu)
 #ifdef	REPLICATION
 		spec->volname = xstrdup(spec->lu->volname);
 		spec->write_luworkers = 0;
+//		spec->inflight_writes = 0;
+		spec->write_throttle_wait = 0;
 #endif
 		spec->num = lu->num;
 		spec->lun = i;

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -922,8 +922,6 @@ istgt_lu_disk_init(ISTGT_Ptr istgt __attribute__((__unused__)), ISTGT_LU_Ptr lu)
 #ifdef	REPLICATION
 		spec->volname = xstrdup(spec->lu->volname);
 		spec->write_luworkers = 0;
-//		spec->inflight_writes = 0;
-		spec->write_throttle_wait = 0;
 #endif
 		spec->num = lu->num;
 		spec->lun = i;
@@ -972,19 +970,6 @@ istgt_lu_disk_init(ISTGT_Ptr istgt __attribute__((__unused__)), ISTGT_LU_Ptr lu)
 		istgt_queue_init(&spec->maint_cmd_queue);
 		istgt_queue_init(&spec->maint_blocked_queue);
 
-#ifdef	REPLICATION
-		rc = pthread_cond_init(&spec->write_throttle_cv, NULL);
-		if (rc != 0) {
-			ISTGT_ERRLOG("LU%d: write_throttle_cv() failed errno:%d\n", lu->num, errno);
-			return -1;
-		}
-
-		rc = pthread_mutex_init(&spec->write_throttle_mtx, &istgt->mutex_attr);
-		if (rc != 0) {
-			ISTGT_ERRLOG("LU%d: write_throttle_mtx() failed errno:%d\n", lu->num, errno);
-			return -1;
-		}
-#endif
 		rc = pthread_mutex_init(&spec->clone_mutex, &istgt->mutex_attr);
 		if (rc != 0) {
 			ISTGT_ERRLOG("LU%d: clone_mutex_init() failed errno:%d\n", lu->num, errno);

--- a/src/replication.c
+++ b/src/replication.c
@@ -2624,20 +2624,6 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 
 	(void) cmd_read;
 	CHECK_IO_TYPE(cmd, cmd_read, cmd_write, cmd_sync);
-#if 0
-	if (cmd_write) {
-		pthread_mutex_lock(&spec->write_throttle_mtx);
-		while ((spec->write_luworkers > 0) &&
-		    (spec->inflight_writes >= spec->write_luworkers)) {
-			spec->write_throttle_wait++;
-			pthread_cond_wait(&spec->write_throttle_cv,
-			    &spec->write_throttle_mtx);
-			spec->write_throttle_wait--;
-		}
-		spec->inflight_writes++;
-		pthread_mutex_unlock(&spec->write_throttle_mtx);
-	}
-#endif
 again:
 	MTX_LOCK(&spec->rq_mtx);
 	if(spec->ready == false) {
@@ -2827,15 +2813,6 @@ wait_for_other_responses:
 	io_queue_time[cmd->luworkerindx].tv_sec =
 	    io_queue_time[cmd->luworkerindx].tv_nsec = 0;
 end:
-#if 0
-	if (cmd_write) {
-		pthread_mutex_lock(&spec->write_throttle_mtx);
-		spec->inflight_writes--;
-		if (spec->write_throttle_wait > 0)
-			pthread_cond_signal(&spec->write_throttle_cv);
-		pthread_mutex_unlock(&spec->write_throttle_mtx);
-	}
-#endif
 	return rc;
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -2624,16 +2624,20 @@ replicate(ISTGT_LU_DISK *spec, ISTGT_LU_CMD_Ptr cmd, uint64_t offset, uint64_t n
 
 	(void) cmd_read;
 	CHECK_IO_TYPE(cmd, cmd_read, cmd_write, cmd_sync);
-
+#if 0
 	if (cmd_write) {
 		pthread_mutex_lock(&spec->write_throttle_mtx);
 		while ((spec->write_luworkers > 0) &&
-		    (spec->inflight_writes >= spec->write_luworkers))
+		    (spec->inflight_writes >= spec->write_luworkers)) {
+			spec->write_throttle_wait++;
 			pthread_cond_wait(&spec->write_throttle_cv,
 			    &spec->write_throttle_mtx);
+			spec->write_throttle_wait--;
+		}
 		spec->inflight_writes++;
 		pthread_mutex_unlock(&spec->write_throttle_mtx);
 	}
+#endif
 again:
 	MTX_LOCK(&spec->rq_mtx);
 	if(spec->ready == false) {
@@ -2823,13 +2827,15 @@ wait_for_other_responses:
 	io_queue_time[cmd->luworkerindx].tv_sec =
 	    io_queue_time[cmd->luworkerindx].tv_nsec = 0;
 end:
+#if 0
 	if (cmd_write) {
 		pthread_mutex_lock(&spec->write_throttle_mtx);
 		spec->inflight_writes--;
-		pthread_cond_signal(&spec->write_throttle_cv);
+		if (spec->write_throttle_wait > 0)
+			pthread_cond_signal(&spec->write_throttle_cv);
 		pthread_mutex_unlock(&spec->write_throttle_mtx);
 	}
-
+#endif
 	return rc;
 }
 

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -124,7 +124,7 @@ static uint64_t
 fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
     uint8_t **resp_data)
 {
-	uint32_t count = 0;
+	uint32_t count = 1;
 	uint64_t len = io_hdr->len;
 	uint64_t offset = io_hdr->offset;
 	uint64_t start = offset;
@@ -135,6 +135,7 @@ fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
 	struct zvol_io_rw_hdr *last_io_rw_hdr;
 	uint8_t *resp;
 
+	md_io_num = read_metadata(start);
 	while (start < end) {
 		if (md_io_num != read_metadata(start)) {
 			count++;
@@ -411,7 +412,6 @@ main(int argc, char **argv)
 	char replica_ip[MAX_IP_LEN];
 	int replica_port = 0;
 	char test_vol[1024];
-	int sleeptime = 0;
 	struct zvol_io_rw_hdr *io_rw_hdr;
 	zvol_op_open_data_t *open_ptr;
 	int iofd = -1, mgmtfd, sfd, rc, epfd, event_count, i;
@@ -747,12 +747,9 @@ execute_io:
 						}
 
 						data -= sizeof(struct zvol_io_rw_hdr);
-						usleep(sleeptime);
 						write_ios++;
 					} else if(io_hdr->opcode == ZVOL_OPCODE_READ) {
 						uint8_t *user_data = NULL;
-						if (delay > 0)
-							sleep(delay);
 
 						if(io_hdr->len) {
 							user_data = malloc(io_hdr->len);

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -335,12 +335,6 @@ run_write_luworkers_test() {
 		exit 1
 	fi
 
-	sudo $ISTGTCONTROL -t vol1 SET 16 -1
-	if [ $? -eq 0 ]; then
-		echo "istgtcontrol set should return error for -1"
-		exit 1
-	fi
-
 	write_and_verify_inflight
 
 	pkill -9 -P $replica1_pid
@@ -1014,12 +1008,12 @@ run_io_timeout_test()
 
 run_lu_rf_test
 run_write_luworkers_test
-#run_data_integrity_test
-#run_mempool_test
-#run_istgt_integration
-#run_read_consistency_test
-#run_replication_factor_test
-#run_io_timeout_test
+run_data_integrity_test
+run_mempool_test
+run_istgt_integration
+run_read_consistency_test
+run_replication_factor_test
+run_io_timeout_test
 tail -20 $LOGFILE
 
 exit 0

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -165,8 +165,8 @@ write_and_verify_inflight(){
 	if [ "$device_name"!="" ]; then
 		sudo $ISTGTCONTROL -t vol1 SET 16 2
 
-		dd if=/dev/urandom of=/dev/$device_name bs=4k count=3 oflag=direct &
-		dd if=/dev/urandom of=/dev/$device_name bs=4k count=3 seek=10 oflag=direct &
+		dd if=/dev/urandom of=/dev/$device_name bs=4k count=4 oflag=direct &
+		dd if=/dev/urandom of=/dev/$device_name bs=4k count=4 seek=10 oflag=direct &
 		dd_pid=$!
 
 		for (( i = 0; i < 5; i++ )) do
@@ -184,7 +184,7 @@ write_and_verify_inflight(){
 		fi
 
 		sudo $ISTGTCONTROL -t vol1 SET 16 1
-		for (( i = 0; i < 13; i++ )) do
+		for (( i = 0; i < 18; i++ )) do
 			sudo $ISTGTCONTROL -q REPLICA | json_pp
 			inflight_cnt=$(sudo $ISTGTCONTROL -q REPLICA | json_pp | grep -w "inflightWrite" | grep "\"1\"" | wc -l)
 			echo $inflight_cnt
@@ -193,7 +193,7 @@ write_and_verify_inflight(){
 			fi
 			sleep 1
 		done
-		if [ $i -eq 13 ]; then
+		if [ $i -eq 18 ]; then
 			sudo $ISTGTCONTROL -q REPLICA | json_pp
 			echo "inflighWrite test2 failed" && tail -20 $LOGFILE && exit 1
 		fi
@@ -201,7 +201,7 @@ write_and_verify_inflight(){
 		sleep 1
 
 		sudo $ISTGTCONTROL -t vol1 SET 16 0
-		for (( i = 0; i < 7; i++ )) do
+		for (( i = 0; i < 12; i++ )) do
 			sudo $ISTGTCONTROL -q REPLICA | json_pp
 			inflight_cnt=$(sudo $ISTGTCONTROL -q REPLICA | json_pp | grep -w "inflightWrite" | grep "\"2\"" | wc -l)
 			echo $inflight_cnt
@@ -210,7 +210,7 @@ write_and_verify_inflight(){
 			fi
 			sleep 1
 		done
-		if [ $i -eq 5 ]; then
+		if [ $i -eq 12 ]; then
 			sudo $ISTGTCONTROL -q REPLICA | json_pp
 			echo "inflighWrite test3 failed" && tail -20 $LOGFILE && exit 1
 		fi
@@ -276,6 +276,7 @@ setup_test_env() {
 	logout_of_volume
 	sudo killall -9 istgt
 	sudo killall -9 replication_test
+	sudo killall -9 istgt_integration
 	touch $INTEGRATION_TEST_LOGFILE
 	start_istgt 5G
 }

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -184,7 +184,7 @@ write_and_verify_inflight(){
 		fi
 
 		sudo $ISTGTCONTROL -t vol1 SET 16 1
-		for (( i = 0; i < 10; i++ )) do
+		for (( i = 0; i < 13; i++ )) do
 			sudo $ISTGTCONTROL -q REPLICA | json_pp
 			inflight_cnt=$(sudo $ISTGTCONTROL -q REPLICA | json_pp | grep -w "inflightWrite" | grep "\"1\"" | wc -l)
 			echo $inflight_cnt
@@ -193,7 +193,7 @@ write_and_verify_inflight(){
 			fi
 			sleep 1
 		done
-		if [ $i -eq 10 ]; then
+		if [ $i -eq 13 ]; then
 			sudo $ISTGTCONTROL -q REPLICA | json_pp
 			echo "inflighWrite test2 failed" && tail -20 $LOGFILE && exit 1
 		fi
@@ -201,7 +201,7 @@ write_and_verify_inflight(){
 		sleep 1
 
 		sudo $ISTGTCONTROL -t vol1 SET 16 0
-		for (( i = 0; i < 5; i++ )) do
+		for (( i = 0; i < 7; i++ )) do
 			sudo $ISTGTCONTROL -q REPLICA | json_pp
 			inflight_cnt=$(sudo $ISTGTCONTROL -q REPLICA | json_pp | grep -w "inflightWrite" | grep "\"2\"" | wc -l)
 			echo $inflight_cnt


### PR DESCRIPTION
This PR is to limit the luworkers that can do simultaneous writes in replication module.
Command to change the setting: istgtcontrol -t vol1 SET 16 <write_luworkers>

luscheduler is modified to pick only initial numbered luworkers for write IOs based on the setting.

Fixed a memory corruption in replication_test binary with read IOs during degraded mode.
Signed-off-by: Vishnu Itta vitta@mayadata.io