### PR TITLE
(ephemeral): Allowing non-quorum replicas to connect to istgt target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update -qq
     - sudo apt-get install --yes -qq gcc-6 g++-6 gdb
-    - sudo apt-get install libssl-dev open-iscsi libjson-c-dev ioping
+    - sudo apt-get install libssl-dev open-iscsi libjson-c-dev ioping jq
     # use gcc-6 by default
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -276,6 +276,7 @@ handle_data_conn_error(replica_t *r)
 
 	TAILQ_FOREACH(r1, &(spec->rq), r_next)
 		if (r1 == r) {
+			assert(r->quorum == 1);
 			found_in_list = 1;
 			break;
 		}
@@ -283,6 +284,7 @@ handle_data_conn_error(replica_t *r)
 	if (r1 == NULL)
 		TAILQ_FOREACH(r1, &(spec->non_quorum_rq), r_non_quorum_next)
 			if (r1 == r) {
+				assert(r->quorum == 0);
 				found_in_list = 2;
 				break;
 			}

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -290,14 +290,14 @@ handle_data_conn_error(replica_t *r)
 			}
 
 	if (r1 == NULL) {
-		MTX_LOCK(&r->r_mtx);
 		REPLICA_ERRLOG("replica %s %d not part of rq and non_rq list..\n",
 		    r->ip, r->port);
+		MTX_LOCK(&r->r_mtx);
 		/*
 		 * mgmt thread will check mgmt_eventfd2 fd to see if
 		 * it needs to wait for replica thread or not.
 		 * At this stage, the replica hasn't been added to
-		 * spec's rqlist so we need to update mgmt_eventfd2 to -1
+		 * spec's rqlist and non_rqlist so we need to update mgmt_eventfd2 to -1
 		 * here So that mgmt_thread can skip replica thread check.
 		 */
 		if (r->mgmt_eventfd2 != -1)

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -267,7 +267,7 @@ handle_data_conn_error(replica_t *r)
 	int found_in_list = 0;
 
 	if (r->iofd == -1) {
-		REPLICA_ERRLOG("repl %s %d %p\n", r->ip, r->port, r);
+		REPLICA_ERRLOG("repl %s %d %p data_conn error\n", r->ip, r->port, r);
 		return -1;
 	}
 

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -31,6 +31,7 @@ typedef enum zvol_status replica_state_t;
 
 typedef struct replica_s {
 	TAILQ_ENTRY(replica_s) r_next;
+	TAILQ_ENTRY(replica_s) r_non_quorum_next;
 	TAILQ_ENTRY(replica_s) r_waitnext;
 	/* list of IOs queued from spec to replica */
 	rte_smempool_t cmdq;

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -31,6 +31,7 @@ typedef enum zvol_status replica_state_t;
 
 typedef struct replica_s {
 	TAILQ_ENTRY(replica_s) r_next;
+	/* For Replicas which are connected with the quorum value as 0 */
 	TAILQ_ENTRY(replica_s) r_non_quorum_next;
 	TAILQ_ENTRY(replica_s) r_waitnext;
 	/* list of IOs queued from spec to replica */

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -849,6 +849,7 @@ typedef struct istgt_lu_disk_t {
 	rte_smempool_t rcommon_deadlist;	// Contains completed IOs
 	TAILQ_HEAD(, replica_s) rq; //Queue of replicas connected to this spec(volume)
 	TAILQ_HEAD(, replica_s) rwaitq; //Queue of replicas completed handshake, and yet to have data connection to this spec(volume)
+	TAILQ_HEAD(, replica_s) non_quorum_rq; //Queue of non_quorum replicas connected to this spec
 	TAILQ_HEAD(, known_replica_s) identified_replica;	/* List of replicas known to spec */
 	int replication_factor;
 	int consistency_factor;

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -3431,8 +3431,7 @@ istgt_uctl_cmd_iostats(UCTL_Ptr uctl)
 		json_object_object_add(jobj, "RevisionCounter",
 		    json_object_new_uint64(spec->io_seq));
 		json_object_object_add(jobj, "Status",
-		    json_object_new_string(get_cv_status(spec, replica_cnt,
-                        spec->healthy_rcount)));
+		    json_object_new_string(get_cv_status(spec)));
 
 		json_object *jobj_arr = json_object_new_array();
 		MTX_LOCK(&spec->rq_mtx);

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -433,6 +433,7 @@ send_mgmt_ack(int fd, zvol_io_hdr_t *mgmt_ack_hdr, void *buf, int *zrepl_status_
 			mgmt_ack_data.port = replica_port;
 			mgmt_ack_data.pool_guid = replica_port;
 			mgmt_ack_data.zvol_guid = replica_port;
+			mgmt_ack_data.quorum = 1;
 
 			iovec[3].iov_base = &mgmt_ack_data;
 			iovec[3].iov_len = 50;

--- a/src/replication.h
+++ b/src/replication.h
@@ -196,7 +196,7 @@ int64_t perform_read_write_on_fd(int fd, uint8_t *data, uint64_t len,
 int initialize_volume(spec_t *spec, int, int);
 void destroy_volume(spec_t *spec);
 void inform_mgmt_conn(replica_t *r);
-extern const char * get_cv_status(spec_t *spec, int replica_cnt, int healthy_replica_cnt);
+extern const char * get_cv_status(spec_t *spec);
 extern void get_replica_stats_json(replica_t *replica, struct json_object **jobj);
 
 /* Replica default timeout is 200 seconds */

--- a/src/replication.h
+++ b/src/replication.h
@@ -83,6 +83,7 @@ typedef struct rcommon_cmd_s {
 	TAILQ_ENTRY(rcommon_cmd_s)  wait_cmd_next; /* for rcommon_waitq */
 	int luworker_id;
 	int copies_sent;
+	int non_quorum_copies_sent;
 	uint8_t replication_factor;
 	uint8_t consistency_factor;
 	zvol_op_code_t opcode;

--- a/src/replication.h
+++ b/src/replication.h
@@ -87,7 +87,6 @@ typedef struct rcommon_cmd_s {
 	uint8_t replication_factor;
 	uint8_t consistency_factor;
 	zvol_op_code_t opcode;
-	int healthy_count;	/* number of healthy replica when cmd queued */
 	uint64_t io_seq;
 	uint64_t lun_id;
 	uint64_t offset;
@@ -109,7 +108,6 @@ typedef struct rcmd_s {
 	uint64_t io_seq;
 	void *rcommq_ptr;
 	uint8_t *iov_data;	/* for header to be sent to replica */
-	int healthy_count;	/* number of healthy replica when cmd queued */
 	int idx;		/* index for rcommon_cmd in resp_list */
 	int64_t iovcnt;
 	uint64_t offset;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -36,7 +36,7 @@ __thread char  tinfo[50] =  {0};
 	mgmt_ack_data->pool_guid = replica_port;\
 	mgmt_ack_data->checkpointed_io_seq = 1000;\
 	mgmt_ack_data->zvol_guid = replica_port;\
-	mgmt_ack_data->quorum = *replica_quorum;\
+	mgmt_ack_data->quorum = replica_quorum_state;\
 }
 
 bool degraded_mode = false;
@@ -46,6 +46,7 @@ int mdlist_fd = 0;
 size_t mdlist_size = 0;
 uint64_t read_ios;
 uint64_t write_ios;
+int replica_quorum_state = 0;
 
 static void
 sig_handler(int sig)
@@ -231,7 +232,7 @@ test_read_data(int fd, uint8_t *data, uint64_t len)
 
 static int
 send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
-    int replica_port, int *replica_quorum, int delay,zrepl_status_ack_t *zrepl_status,
+    int replica_port, int delay_connection, zrepl_status_ack_t *zrepl_status,
     int *zrepl_status_msg_cnt)
 {
 	int i, nbytes = 0;
@@ -241,7 +242,6 @@ send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
 	zvol_io_hdr_t *mgmt_ack_hdr = NULL;
 	mgmt_ack_t *mgmt_ack_data = NULL;
 	int ret = -1;
-	bool state_changed_non_quorum=false;
 	zvol_op_stat_t stats;
 
 	/* Init mgmt_ack_hdr */
@@ -266,14 +266,17 @@ send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
 			zrepl_status->state = ZVOL_STATUS_HEALTHY;
 			zrepl_status->rebuild_status = ZVOL_REBUILDING_DONE;
 			(*zrepl_status_msg_cnt) = 0;
-			if(*replica_quorum == 0)
-				state_changed_non_quorum=true;
 		}
 
 		if (zrepl_status->rebuild_status == ZVOL_REBUILDING_SNAP) {
 			(*zrepl_status_msg_cnt) += 1;
 		}
 
+		// Injecting delays while sending acknowledge to target
+		if (delay_connection > 0 )
+			sleep(delay_connection);
+
+		replica_quorum_state = 1;
 		mgmt_ack_hdr->len = sizeof (zrepl_status_ack_t);
 		iovec_count = 2;
 		iovec[1].iov_base = zrepl_status;
@@ -291,8 +294,6 @@ send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
 		iovec_count = 2;
 	} else {
 		build_mgmt_ack_data;
-		if(delay > 0)
-			sleep(5);
 
 		iovec[1].iov_base = mgmt_ack_data;
 		iovec[1].iov_len = sizeof (mgmt_ack_t);
@@ -323,8 +324,7 @@ send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
 			}
 		}
 	}
-	if(state_changed_non_quorum)
-		*replica_quorum=1;
+
 	ret = 0;
 out:
 	if (mgmt_ack_hdr)
@@ -407,6 +407,7 @@ usage(void)
 	printf(" -d run in degraded mode only\n");
 	printf(" -e error frequency (should be <= 10, default is 0)\n");
 	printf(" -t delay in response in seconds\n");
+	printf(" -s delay while forming the management connectioin and Rebuild respone in seconds\n");
 }
 
 
@@ -426,7 +427,7 @@ main(int argc, char **argv)
 	int iofd = -1, mgmtfd, sfd, rc, epfd, event_count, i;
 	int64_t count;
 	struct epoll_event event, *events;
-	uint8_t *data, *data_ptr_cpy;
+	uint8_t *data, *mgmt_data;
 	uint64_t nbytes = 0;
 	int vol_fd;
 	zvol_op_code_t opcode;
@@ -442,10 +443,10 @@ main(int argc, char **argv)
 	int check = 1;
 	struct timespec now;
 	int delay = 0;
+	int delay_connection = 0;
 	bool retry = false;
-	int replica_quorum = 0;
 
-	while ((ch = getopt(argc, argv, "i:p:I:P:V:q:n:e:t:dr")) != -1) {
+	while ((ch = getopt(argc, argv, "i:p:I:P:V:n:e:s:t:drq")) != -1) {
 		switch (ch) {
 			case 'i':
 				strncpy(ctrl_ip, optarg, sizeof(ctrl_ip));
@@ -468,7 +469,7 @@ main(int argc, char **argv)
 				check |= 1 << 5;
 				break;
 			case 'q':
-				replica_quorum = atoi(optarg);
+				replica_quorum_state = 1;
 				break;
 			case 'n':
 				io_cnt = atoi(optarg);
@@ -485,6 +486,9 @@ main(int argc, char **argv)
 				break;
 			case 'r':
 				retry = true;
+				break;
+			case 's':
+				delay_connection = atoi(optarg);
 				break;
 			case 't':
 				delay = atoi(optarg);
@@ -513,7 +517,7 @@ main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &now);
 	srandom(now.tv_sec);
 
 	data = NULL;
@@ -598,8 +602,8 @@ again:
 				}
 
 				if(mgmtio->len) {
-					data = data_ptr_cpy = malloc(mgmtio->len);
-					count = test_read_data(events[i].data.fd, (uint8_t *)data, mgmtio->len);
+					mgmt_data = malloc(mgmtio->len);
+					count = test_read_data(events[i].data.fd, (uint8_t *)mgmt_data, mgmtio->len);
 					if (count < 0) {
 						rc = -1;
 						goto error;
@@ -611,16 +615,16 @@ again:
 					}
 				}
 				opcode = mgmtio->opcode;
-				send_mgmt_ack(mgmtfd, opcode, data, replica_ip, replica_port, &replica_quorum, delay,zrepl_status, &zrepl_status_msg_cnt);
+				send_mgmt_ack(mgmtfd, opcode, mgmt_data, replica_ip, replica_port, delay_connection, zrepl_status, &zrepl_status_msg_cnt);
 			} else if (events[i].data.fd == sfd) {
 				struct sockaddr saddr;
 				socklen_t slen;
 				char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
 				slen = sizeof(saddr);
-				if (delay > 0)
-				{
-					sleep(10);
-				}
+				// Injecting delay while forming data connection to perform test
+				if (delay_connection > 0)
+					sleep(delay_connection);
+
 				iofd = accept(sfd, &saddr, &slen);
 				if (iofd == -1) {
 					if((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
@@ -767,8 +771,10 @@ execute_io:
 						usleep(sleeptime);
 						write_ios++;
 					} else if(io_hdr->opcode == ZVOL_OPCODE_READ) {
-						if ( replica_quorum == 0)
+						if ( replica_quorum_state == 0) {
+							REPLICA_ERRLOG("Received Read IO's request on non-quorum replica \n");
 							goto error;
+						}
 						uint8_t *user_data = NULL;
 						if (delay > 0)
 							sleep(delay);
@@ -827,7 +833,7 @@ execute_io:
 
 error:
 	REPLICA_ERRLOG("shutting down replica(%s:%d) IOs(read:%lu write:%lu)\n",
-	    ctrl_ip, ctrl_port, read_ios, write_ios);
+	    replica_ip, replica_port, read_ios, write_ios);
 	if (data)
 		free(data);
 	close(vol_fd);


### PR DESCRIPTION
This PR is to add replicas to lists (quorum and non-quorum) based on the value of quorum during management connection.

    
- After post rebuild on a non-quorum replica, it will move from non-quorum list to quorum list.
- Write operations are allowed on the non-quorum replicas.
- `istgtcontrol replica` command will show the details of both quorum and non-quorum replica.
output:
```
istgtcontrol -q replica | jq
{
  "volumeStatus": [
    {
      "name": "vol1",
      "status": "Offline",
      "replicaStatus": [
        {
          "replicaId": "6063",
          "Address": "192.168.1.14",
          "Mode": "Degraded",
          "checkpointedIOSeq": "1000",
          "inflightRead": "0",
          "inflightWrite": "0",
          "inflightSync": "0",
          "inQuorum": "1",
          "upTime": 48
        },
        {
          "replicaId": "6062",
          "Address": "192.168.1.14",
          "Mode": "Degraded",
          "checkpointedIOSeq": "1000",
          "inflightRead": "0",
          "inflightWrite": "0",
          "inflightSync": "0",
          "inQuorum": "0",
          "upTime": 28
        }
      ]
    }
  ]
}
```

