### PR TITLE
fix(high_cpu): issue in clock for timedwait

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2793,7 +2793,7 @@ retry_read:
 
 wait_for_other_responses:
 		/* wait for 500 ms(500000000 ns) */
-		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+		clock_gettime(CLOCK_REALTIME, &now);
 		nsec = SEC_IN_NS - now.tv_nsec;
 		if (nsec > 500000000) {
 			abstime.tv_sec = now.tv_sec;


### PR DESCRIPTION
pthread_cond_timedwait expects absolute time at which timeout need to happen in case of no external signals. This absolute time need to be calculated using REALCLOCK clockid. Using other clockids in calculating absolute time can cause high CPU utilization or wrong timeouts.

This PR is to fix an issue in clock setting for timedwait.

This is a regression created with another PR in which latency related stats has been added.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>