### PR TITLE
mitigate(disconnection): slowdown client if any long pending IOs in target

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -119,8 +119,11 @@ int replica_timeout = REPLICA_DEFAULT_TIMEOUT;
 				    (wait_count * polling_timeout)) {	\
 					REPLICA_NOTICELOG("replica(%lu)"\
 					    " hasn't responded in last "\
-					    "%d seconds\n",		\
-					    r->zvol_guid, ms / 1000);	\
+					    "%d seconds for opcode: %d"	\
+					    " with seq: %lu\n",		\
+					    r->zvol_guid, ms / 1000,	\
+					    pending_cmd->opcode,	\
+					    pending_cmd->io_seq);	\
 				}					\
 				if (ms > (wait_count * polling_timeout))\
 					wait_count =			\

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -2848,6 +2848,7 @@ void *timerfn(void
 			MTX_LOCK(&specq_mtx);
 			TAILQ_FOREACH(spec, &spec_q, spec_next) {
 				MTX_LOCK(&spec->complete_queue_mutex);
+				spec->longest_pending_iotime_in_ms = 0;
 				lu_task = (ISTGT_LU_TASK_Ptr)
 				    istgt_queue_first(&spec->complete_queue);
 				if (lu_task) {
@@ -2857,6 +2858,7 @@ void *timerfn(void
 					    lu_cmd->times[0], now, diff);
 					ms = diff.tv_sec * 1000;
 					ms += diff.tv_nsec / 1000000;
+					spec->longest_pending_iotime_in_ms = ms;
 					if (ms > check_interval) {
 						ISTGT_NOTICELOG("LU:%lu "
 						    "CSN:0x%x TT:%x "

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -5685,7 +5685,7 @@ update_cummulative_rw_time(ISTGT_LU_TASK_Ptr lu_task)
 			ISTGT_ERRLOG("Making it sleep for %lus due to long pending IO "
 			    "for > %lus\n", io_max_wait_time/10,
 			    spec->longest_pending_iotime_in_ms / 1000);
-			sleep(io_max_wait_time/10);
+			sleep(io_max_wait_time/20);
 			spec->longest_pending_iotime_in_ms = 0;
 		}
 }

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -590,7 +590,7 @@ istgt_iscsi_write_pdu_queue(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, int req_type, int 
 }
 
 static int
-istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, ISTGT_LU_CMD_Ptr *lu_cmd)
+istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, ISTGT_LU_CMD_Ptr lu_cmd)
 {
 	struct iovec iovec[5]; /* BHS+AHS+HD+DATA+DD */
 	uint8_t *cp;

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -134,6 +134,7 @@ struct istgt_detail {
 #define	ISCSI_ADDVAL(PARAMS, KEY, VAL, LIST, TYPE) \
 	istgt_iscsi_param_add((PARAMS), (KEY), (VAL), (LIST), (TYPE))
 
+extern uint64_t io_max_wait_time;
 static int g_nconns;
 static int g_max_connidx;
 static CONN_Ptr *g_conns;
@@ -394,7 +395,7 @@ istgt_iscsi_read_pdu(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	return (total);
 }
 
-static int istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu);
+static int istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, ISTGT_LU_CMD_Ptr lu_cmd);
 static int istgt_iscsi_write_pdu_queue(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, int req_type, int I_bit);
 
 uint8_t istgt_get_sleep_val(ISTGT_LU_DISK *spec);
@@ -589,7 +590,7 @@ istgt_iscsi_write_pdu_queue(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, int req_type, int 
 }
 
 static int
-istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
+istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, ISTGT_LU_CMD_Ptr *lu_cmd)
 {
 	struct iovec iovec[5]; /* BHS+AHS+HD+DATA+DD */
 	uint8_t *cp;
@@ -680,8 +681,8 @@ istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 		rc = writev(conn->sock, &iovec[0], 5);
 		if (rc < 0) {
 			now = time(NULL);
-			ISTGT_ERRLOG("writev() failed (errno=%d,%s,time=%f)\n",
-				errno, conn->initiator_name, difftime(now, start));
+			ISTGT_ERRLOG("writev() failed (errno=%d,%s,time=%f) for opcode:0x%2.2x CSN:0x%x\n",
+				errno, conn->initiator_name, difftime(now, start), lu_cmd->cdb0, lu_cmd->CmdSN);
 			return (-1);
 		}
 		nbytes -= rc;
@@ -2996,7 +2997,7 @@ istgt_iscsi_transfer_in_internal(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 			DSET32(&rsp[44], 0);
 		}
 
-		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu);
+		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu, lu_cmd);
 		if (rc < 0) {
 			ISTGT_ERRLOG("iscsi_write_pdu() failed\n");
 			return (-1);
@@ -3886,7 +3887,7 @@ istgt_iscsi_task_response(CONN_Ptr conn, ISTGT_LU_TASK_Ptr lu_task)
 	DSET32(&rsp[44], residual_len);
 
 	if (lu_task->lock) {
-		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu);
+		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu, &(lu_task->lu_cmd));
 	} else {
 		rc = istgt_iscsi_write_pdu(conn, &rsp_pdu);
 	}
@@ -5673,6 +5674,19 @@ update_cummulative_rw_time(ISTGT_LU_TASK_Ptr lu_task)
 				ns += diff.tv_nsec;
 				__sync_fetch_and_add(&spec->totalreadtime, ns);
 				break;
+		default:
+				return;
+	}
+	/* Only for read/write IOs, if longest pending IO is io_max_wait_time/4,
+	   delay in responding to client by io_max_wait_time/10 for replica to catch up */
+	if (spec != NULL)
+		if ((spec->longest_pending_iotime_in_ms >> 10) >
+		    (io_max_wait_time >> 2)) {
+			ISTGT_ERRLOG("Making it sleep for %lus due to long pending IO "
+			    "for > %lus\n", io_max_wait_time/10,
+			    spec->longest_pending_iotime_in_ms / 1000);
+			sleep(io_max_wait_time/10);
+			spec->longest_pending_iotime_in_ms = 0;
 		}
 }
 #endif
@@ -5783,7 +5797,7 @@ sender(void *arg)
 				pdu = lu_task->lu_cmd.pdu;
 				/* send PDU */
 				rc = istgt_iscsi_write_pdu_internal(lu_task->conn,
-					lu_task->lu_cmd.pdu);
+					lu_task->lu_cmd.pdu, &(lu_task->lu_cmd));
 				if (rc < 0) {
 					lu_task->error = 1;
 					ISTGT_ERRLOG(

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -867,6 +867,7 @@ typedef struct istgt_lu_disk_t {
 		uint64_t	used;
 		struct timespec	updated_stats_time;
 	} stats;
+	uint64_t longest_pending_iotime_in_ms;
 #endif
 
 	/*Queue containing all the tasks. Instead of going to separate 

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -867,6 +867,8 @@ typedef struct istgt_lu_disk_t {
 		uint64_t	used;
 		struct timespec	updated_stats_time;
 	} stats;
+
+	/* time since oldest existing IO is added to queue */
 	uint64_t longest_pending_iotime_in_ms;
 #endif
 

--- a/src/replication.h
+++ b/src/replication.h
@@ -196,7 +196,7 @@ void inform_mgmt_conn(replica_t *r);
 extern const char * get_cv_status(spec_t *spec, int replica_cnt, int healthy_replica_cnt);
 
 /* Replica default timeout is 200 seconds */
-#define	REPLICA_DEFAULT_TIMEOUT	200
+#define	REPLICA_DEFAULT_TIMEOUT	100
 
 // Volume status
 #define VOL_STATUS_OFFLINE "Offline"

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -386,7 +386,8 @@ run_read_consistency_test ()
 	get_scsi_disk
 	if [ "$device_name" == "" ]; then
 		echo "error happened while running read consistency test"
-		kill -9 $replica1_pid $replica2_pid $replica3_pid
+		pkill -9 -P $replica1_pid $replica2_pid $replica3_pid
+		kill -SIGKILL $replica1_pid $replica2_pid $replica3_pid
 		return
 	fi
 
@@ -396,7 +397,8 @@ run_read_consistency_test ()
 	write_data 0 10485760 4096 "/dev/$device_name" $file_name &
 	w_pid=$!
 	sleep 1
-	kill -9 $replica1_pid
+	pkill -9 -P $replica1_pid
+	kill -SIGKILL $replica1_pid
 	wait $w_pid
 	sync
 
@@ -406,7 +408,8 @@ run_read_consistency_test ()
 	write_data 13631488 10485760 4096 "/dev/$device_name" $file_name &
 	w_pid=$!
 	sleep 1
-	kill -9 $replica2_pid
+	pkill -9 -P $replica2_pid
+	kill -SIGKILL $replica2_pid
 	wait $w_pid
 	sync
 
@@ -416,7 +419,8 @@ run_read_consistency_test ()
 	write_data 31457280 10485760 4096 "/dev/$device_name" $file_name &
 	w_pid=$!
 	sleep 1
-	kill -9 $replica3_pid
+	pkill -9 -P $replica3_pid
+	kill -SIGKILL $replica3_pid
 	wait $w_pid
 	sync
 
@@ -435,7 +439,8 @@ run_read_consistency_test ()
 	fi
 
 	logout_of_volume
-	kill -9 $replica1_pid $replica2_pid $replica3_pid
+	pkill -9 -P $replica1_pid $replica2_pid $replica3_pid
+	kill -SIGKILL $replica1_pid $replica2_pid $replica3_pid
 	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
 	rm -rf $file_name $device_file
 	stop_istgt
@@ -507,7 +512,9 @@ run_lu_rf_test ()
 
 	sleep 5
 
-	kill -9 $replica3_pid
+
+	pkill -9 -P $replica3_pid
+	kill -SIGKILL $replica3_pid
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica3_ip" -P "$(($replica3_port + 10))" -V $replica3_vdev &
 	replica3_pid=$!
 	sleep 5
@@ -521,7 +528,8 @@ run_lu_rf_test ()
 		echo "Replica identification test passed"
 	fi
 
-	kill -9 $replica1_pid $replica2_pid $replica3_pid
+	pkill -9 -P $replica1_pid $replica2_pid $replica3_pid
+	kill -SIGKILL $replica1_pid $replica2_pid $replica3_pid
 	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
 	stop_istgt
 }

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -591,7 +591,8 @@ run_rebuild_time_test_in_single_replica()
 		fi
 		sleep 10
 	done
-	kill -9 $replica1_pid
+	pkill -9 -P $replica1_pid
+	kill -SIGKILL $replica1_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
 }
@@ -740,7 +741,8 @@ run_rebuild_time_test_in_multiple_replicas()
 		fi
 	done
 
-	kill -9 $replica1_pid $replica2_pid $replica3_pid
+	pkill -9 -P $replica1_pid $replica2_pid $replica3_pid
+	kill -SIGKILL $replica1_pid $replica2_pid $replica3_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
 }
@@ -793,13 +795,15 @@ run_replication_factor_test()
 	wait $replica4_pid
 	if [ $? == 0 ]; then
 		echo "replica limit test failed"
-		kill -9 $replica4_pid
+		pkill -9 -P $replica4_pid
+		kill -SIGKILL $replica4_pid
 		ret=1
 	else
 		echo "replica limit test passed"
 	fi
 
-	kill -9 $replica1_pid $replica2_pid $replica3_pid
+	pkill -9 -P $replica1_pid $replica2_pid $replica3_pid
+	kill -SIGKILL $replica1_pid $replica2_pid $replica3_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
 
@@ -842,12 +846,15 @@ run_io_timeout_test()
 	get_scsi_disk
 	if [ "$device_name"!="" ]; then
 		# Test to verify impact of replica's delay on volume latency
-		kill -9 $replica1_pid
+		pkill -9 -P $replica1_pid
+		kill -SIGKILL $replica1_pid
 		sleep 2
 
 		$REPLICATION_TEST -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica1_ip" -P "$replica1_port" -V $replica1_vdev -t $injected_latency &
 		replica1_pid=$!
 		sleep 2 #Replica will take some time to make successful connection to target
+
+		$ISTGTCONTROL maxiowait 12
 
 		iopinglog=`mktemp`
 		$IOPING -c 1 -B -WWW /dev/$device_name > $iopinglog
@@ -877,12 +884,14 @@ run_io_timeout_test()
 		replica1_pid=$!
 		sleep 2
 
-		kill -9 $replica2_pid
+		pkill -9 -P $replica2_pid
+		kill -SIGKILL $replica2_pid
 		$REPLICATION_TEST -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica2_ip" -P "$replica2_port" -V $replica1_vdev  -t $injected_latency &
 		replica2_pid=$!
 		sleep 2
 
-		kill -9 $replica3_pid
+		pkill -9 -P $replica3_pid
+		kill -SIGKILL $replica3_pid
 		$REPLICATION_TEST -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica3_ip" -P "$replica3_port" -V $replica1_vdev -t $injected_latency&
 		replica3_pid=$!
 		sleep 2
@@ -897,7 +906,8 @@ run_io_timeout_test()
 		exit 1
 	fi
 
-	kill -9 $replica1_pid $replica2_pid $replica3_pid
+	pkill -9 -P $replica1_pid $replica2_pid $replica3_pid
+	kill -SIGKILL $replica1_pid $replica2_pid $replica3_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
 }


### PR DESCRIPTION
This PR slows down client in sending IOs if target is having long pending IOs in its queue.
This adds to the latency of IOs, but, avoids the client disconnection.
Also, added IO related information when writev fails to client.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>