### PR TITLE
[ISS2315]chorus(log): Added more details for delayed IOs logs

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -119,8 +119,11 @@ int replica_timeout = REPLICA_DEFAULT_TIMEOUT;
 				    (wait_count * polling_timeout)) {	\
 					REPLICA_NOTICELOG("replica(%lu)"\
 					    " hasn't responded in last "\
-					    "%d seconds\n",		\
-					    r->zvol_guid, ms / 1000);	\
+					    "%d seconds for opcode: %d"	\
+					    " with seq: %lu\n",		\
+					    r->zvol_guid, ms / 1000,	\
+					    pending_cmd->opcode,	\
+					    pending_cmd->io_seq);	\
 				}					\
 				if (ms > (wait_count * polling_timeout))\
 					wait_count =			\

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -124,7 +124,7 @@ static uint64_t
 fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
     uint8_t **resp_data)
 {
-	uint32_t count = 0;
+	uint32_t count = 1;
 	uint64_t len = io_hdr->len;
 	uint64_t offset = io_hdr->offset;
 	uint64_t start = offset;
@@ -135,6 +135,7 @@ fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
 	struct zvol_io_rw_hdr *last_io_rw_hdr;
 	uint8_t *resp;
 
+	md_io_num = read_metadata(start);
 	while (start < end) {
 		if (md_io_num != read_metadata(start)) {
 			count++;


### PR DESCRIPTION
This PR adds more details to the logs related to latent IOs, and writev errors on the wire.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>