### PR TITLE
[ISS2315]chorus(log): Added more details for delayed IOs logs (#209)

### DIFF
--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -119,8 +119,11 @@ int replica_timeout = REPLICA_DEFAULT_TIMEOUT;
 				    (wait_count * polling_timeout)) {	\
 					REPLICA_NOTICELOG("replica(%lu)"\
 					    " hasn't responded in last "\
-					    "%d seconds\n",		\
-					    r->zvol_guid, ms / 1000);	\
+					    "%d seconds for opcode: %d"	\
+					    " with seq: %lu\n",		\
+					    r->zvol_guid, ms / 1000,	\
+					    pending_cmd->opcode,	\
+					    pending_cmd->io_seq);	\
 				}					\
 				if (ms > (wait_count * polling_timeout))\
 					wait_count =			\

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -394,7 +394,7 @@ istgt_iscsi_read_pdu(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	return (total);
 }
 
-static int istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu);
+static int istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, ISTGT_LU_CMD_Ptr lu_cmd);
 static int istgt_iscsi_write_pdu_queue(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, int req_type, int I_bit);
 
 uint8_t istgt_get_sleep_val(ISTGT_LU_DISK *spec);
@@ -589,7 +589,7 @@ istgt_iscsi_write_pdu_queue(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, int req_type, int 
 }
 
 static int
-istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
+istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu, ISTGT_LU_CMD_Ptr lu_cmd)
 {
 	struct iovec iovec[5]; /* BHS+AHS+HD+DATA+DD */
 	uint8_t *cp;
@@ -680,8 +680,8 @@ istgt_iscsi_write_pdu_internal(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 		rc = writev(conn->sock, &iovec[0], 5);
 		if (rc < 0) {
 			now = time(NULL);
-			ISTGT_ERRLOG("writev() failed (errno=%d,%s,time=%f)\n",
-				errno, conn->initiator_name, difftime(now, start));
+			ISTGT_ERRLOG("writev() failed (errno=%d,%s,time=%f) for opcode:0x%2.2x CSN:0x%x\n",
+				errno, conn->initiator_name, difftime(now, start), lu_cmd->cdb0, lu_cmd->CmdSN);
 			return (-1);
 		}
 		nbytes -= rc;
@@ -2996,7 +2996,7 @@ istgt_iscsi_transfer_in_internal(CONN_Ptr conn, ISTGT_LU_CMD_Ptr lu_cmd)
 			DSET32(&rsp[44], 0);
 		}
 
-		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu);
+		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu, lu_cmd);
 		if (rc < 0) {
 			ISTGT_ERRLOG("iscsi_write_pdu() failed\n");
 			return (-1);
@@ -3886,7 +3886,7 @@ istgt_iscsi_task_response(CONN_Ptr conn, ISTGT_LU_TASK_Ptr lu_task)
 	DSET32(&rsp[44], residual_len);
 
 	if (lu_task->lock) {
-		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu);
+		rc = istgt_iscsi_write_pdu_internal(conn, &rsp_pdu, &(lu_task->lu_cmd));
 	} else {
 		rc = istgt_iscsi_write_pdu(conn, &rsp_pdu);
 	}
@@ -5817,7 +5817,7 @@ sender(void *arg)
 				pdu = lu_task->lu_cmd.pdu;
 				/* send PDU */
 				rc = istgt_iscsi_write_pdu_internal(lu_task->conn,
-					lu_task->lu_cmd.pdu);
+					lu_task->lu_cmd.pdu, &(lu_task->lu_cmd));
 				if (rc < 0) {
 					lu_task->error = 1;
 					ISTGT_ERRLOG(

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -126,7 +126,7 @@ static uint64_t
 fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
     uint8_t **resp_data)
 {
-	uint32_t count = 0;
+	uint32_t count = 1;
 	uint64_t len = io_hdr->len;
 	uint64_t offset = io_hdr->offset;
 	uint64_t start = offset;
@@ -137,6 +137,7 @@ fetch_update_io_buf(zvol_io_hdr_t *io_hdr, uint8_t *user_data,
 	struct zvol_io_rw_hdr *last_io_rw_hdr;
 	uint8_t *resp;
 
+	md_io_num = read_metadata(start);
 	while (start < end) {
 		if (md_io_num != read_metadata(start)) {
 			count++;


### PR DESCRIPTION
This change adds more details to the logs related to latent IOs, and writev errors on the wire.
This is cherry-pick of PR: https://github.com/openebs/istgt/pull/209

Signed-off-by: Vishnu Itta <vitta@mayadata.io>