### PR TITLE
Updates the variable name from inQuorum to Quorum

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1651,7 +1651,7 @@ get_replica_stats_json(replica_t *replica, struct json_object **jobj)
 	json_object_object_add(j_stats, "inflightSync",
 	    json_object_new_uint64(replica->replica_inflight_sync_io_cnt));
 
-	json_object_object_add(j_stats, "inQuorum",
+	json_object_object_add(j_stats, "quorum",
 	    json_object_new_uint64(replica->quorum));
 
 	clock_gettime(CLOCK_MONOTONIC, &now);


### PR DESCRIPTION
This PR updates the variable name from inQuorum to Quorum and below is the output of `istgtcontrol -q replica | json_pp`
```
{
  "volumeStatus": [
    {
      "name": "vol1",
      "status": "Degraded",
      "replicaStatus": [
        {
          "replicaId": "6061",
          "Address": "127.0.0.1",
          "Mode": "Degraded",
          "checkpointedIOSeq": "1000",
          "inflightRead": "0",
          "inflightWrite": "0",
          "inflightSync": "0",
          "quorum": "1",
          "upTime": 4
        }
      ]
    }
  ]
}

```
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>