### PR TITLE
fix(discovery): restart istgt on 4 continuous send target requests

### DIFF
--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -2059,7 +2059,7 @@ istgt_iscsi_op_login(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 			 * As per the issue https://github.com/openebs/openebs/issues/2382,
 			 * 5 continous discovery requests failure can cause iscsi initiator
 			 * to get into high CPU usage.
-			 * This code checks for this state of 5 continuous discovery failures
+			 * This code checks for this state of 4 continuous discovery failures
 			 * and restarts the process.
 			 */
 			if (discovery_counter > 4) {

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -5363,7 +5363,7 @@ wait_all_task(CONN_Ptr conn)
 		conn->id, conn->running_tasks);
 }
 
-
+#if 0
 static void
 snd_cleanup(void *arg)
 {
@@ -5448,6 +5448,7 @@ worker_cleanup(void *arg)
 	MTX_UNLOCK(&g_conns_mutex);
 	ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "cancel cleanup UNLOCK\n");
 }
+#endif
 
 const char lu_task_typ[4][12] = {
 	"RESPONSE",

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -2055,6 +2055,13 @@ istgt_iscsi_op_login(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 
 			__sync_add_and_fetch(&discovery_counter, 1);
 
+			/*
+			 * As per the issue https://github.com/openebs/openebs/issues/2382,
+			 * 5 continous discovery requests failure can cause iscsi initiator
+			 * to get into high CPU usage.
+			 * This code checks for this state of 5 continuous discovery failures
+			 * and restarts the process.
+			 */
 			if (discovery_counter > 4) {
 				ISTGT_ERRLOG("discovery counter %lu retry limit exceeded\n",
 				    discovery_counter);


### PR DESCRIPTION
fixes https://www.github.com/openebs/openebs/issues/2382
After successful discovery, login request will be received by target.
On continuous 4 discovery failures, high mem usage at kubelet is observed due to this issue https://github.com/open-iscsi/open-iscsi/issues/155.
This PR is to restart istgt to avoid mem consumption at kubelet.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>