### PR TITLE
change(discovery): dont increment cmdsn for op_text [Test automation]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,17 @@ install:
     - make clean
     - ./configure --enable-debug --enable-replication
     - make
+
+    # compile libiscsi and iscsi based test tools
+    - cd test-tools/login-test
+    - git clone https://github.com/openebs/libiscsi
+    - cd libiscsi
+    - ./autogen.sh
+    - ./configure
+    - make
+    - cd ..
+    - LIBISCSI=./libiscsi make clean
+    - LIBISCSI=./libiscsi make
 script:
     # run ztest and test supported zio backends
     - sudo bash ./print_debug_info.sh &

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
     - make
 
     # compile libiscsi and iscsi based test tools
+    - pushd .
     - cd test-tools/login-test
     - git clone https://github.com/openebs/libiscsi
     - cd libiscsi
@@ -34,6 +35,7 @@ install:
     - cd ..
     - LIBISCSI=./libiscsi make clean
     - LIBISCSI=./libiscsi make
+    - popd
 script:
     # run ztest and test supported zio backends
     - sudo bash ./print_debug_info.sh &

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -2673,11 +2673,11 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	SESS_MTX_LOCK(conn);
 	DSET32(&rsp[24], conn->StatSN);
 	conn->StatSN++;
-	if (I_bit == 0) {
-		conn->sess->ExpCmdSN++;
-		conn->sess->MaxCmdSN++;
-		conn->sess->MaxCmdSN_local++;
-	}
+//	if (I_bit == 0) {
+//		conn->sess->ExpCmdSN++;
+//		conn->sess->MaxCmdSN++;
+//		conn->sess->MaxCmdSN_local++;
+//	}
 	DSET32(&rsp[28], conn->sess->ExpCmdSN);
 	DSET32(&rsp[32], conn->sess->MaxCmdSN);
 	SESS_MTX_UNLOCK(conn);
@@ -6139,7 +6139,6 @@ worker(void *arg)
 				break;
 			} else if (rc == 1) { // means successful logout ISCSI_OP_LOGOUT
 				ISTGT_TRACELOG(ISTGT_TRACE_ISCSI, "logout received\n");
-				break;
 			}
 
 			if (conn->pdu.ahs != NULL) {

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -2519,7 +2519,7 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	memset(data, 0, alloc_len);
 
 	cp = (uint8_t *) &pdu->bhs;
-	I_bit = BGET8(&cp[0], 7);
+	I_bit = BGET8(&cp[0], 6);
 	F_bit = BGET8(&cp[1], 7);
 	C_bit = BGET8(&cp[1], 6);
 
@@ -2673,11 +2673,11 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	SESS_MTX_LOCK(conn);
 	DSET32(&rsp[24], conn->StatSN);
 	conn->StatSN++;
-//	if (I_bit == 0) {
-//		conn->sess->ExpCmdSN++;
-//		conn->sess->MaxCmdSN++;
-//		conn->sess->MaxCmdSN_local++;
-//	}
+	if (I_bit == 0) {
+		conn->sess->ExpCmdSN++;
+		conn->sess->MaxCmdSN++;
+		conn->sess->MaxCmdSN_local++;
+	}
 	DSET32(&rsp[28], conn->sess->ExpCmdSN);
 	DSET32(&rsp[32], conn->sess->MaxCmdSN);
 	SESS_MTX_UNLOCK(conn);

--- a/test-tools/login-test/Makefile
+++ b/test-tools/login-test/Makefile
@@ -1,0 +1,24 @@
+TARGET = login_test
+LIBS = -liscsi
+CC = gcc
+CFLAGS = -O2 -g -Wall -I /usr/include/iscsi
+
+.PHONY: default all clean
+
+default: $(TARGET)
+all: default
+
+OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
+HEADERS = $(wildcard *.h)
+
+%.o: %.c $(HEADERS)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+.PRECIOUS: $(TARGET) $(OBJECTS)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(OBJECTS) -Wall $(LIBS) -o $@
+
+clean:
+	-rm -f *.o
+	-rm -f $(TARGET)

--- a/test-tools/login-test/Makefile
+++ b/test-tools/login-test/Makefile
@@ -17,7 +17,7 @@ HEADERS = $(wildcard *.h)
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(OBJECTS) -Wall $(LIBS) -o $@
+	$(CC) $(OBJECTS) -L $(LIBISCSI)/lib/.libs -Wall $(LIBS) -o $@
 
 clean:
 	-rm -f *.o

--- a/test-tools/login-test/Makefile
+++ b/test-tools/login-test/Makefile
@@ -1,7 +1,7 @@
 TARGET = login_test
 LIBS = -liscsi
 CC = gcc
-CFLAGS = -O2 -g -Wall -I /usr/include/iscsi
+CFLAGS = -O2 -g -Wall -I $(LIBISCSI)/include
 
 .PHONY: default all clean
 

--- a/test-tools/login-test/login_test.c
+++ b/test-tools/login-test/login_test.c
@@ -1,0 +1,134 @@
+#include <iscsi.h>
+#include <scsi-lowlevel.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <assert.h>
+#include <string.h>
+
+void usage()
+{
+	printf("login_login -h <target, target:port> -t <sec> (default=5)\n");
+	printf("-v for verbose output\n");
+}
+
+int main(int argc, char **argv)
+{
+	int opt;
+	int verbose = 0;
+	int err = 0;
+	int count = 0;
+	int iter_count = 0;
+	int timeout = 5;
+	const char *target = NULL;
+
+	struct iscsi_context *iscsi_ctx;
+	struct iscsi_url *iscsi_url;
+
+	if (argc < 2) {
+		usage();
+	}
+
+	while ((opt = getopt(argc, argv, "vt:h:")) != -1) {
+		switch (opt) {
+		case 'v':
+			verbose = 9;
+			break;
+		case 'h':
+			target = optarg;
+			break;
+		case 't':
+			timeout = atoi(optarg);
+			break;
+		default:
+			printf("unknow option %s\n", optarg);
+			usage();
+			return 1;
+		}
+	}
+
+	if (target == NULL) {
+		usage();
+		return 1;
+	}
+
+
+	printf("Running test against: %s with timeout set to %d seconds\n",
+	       target, timeout);
+
+	while(iter_count < 400) {
+		if ((iscsi_ctx =
+			     iscsi_create_context("iqn.2019-2.io.openebs:test"))
+		    == NULL) {
+			printf("failed to create iscsi context\n");
+			return 1;
+		}
+
+		iscsi_url = iscsi_parse_portal_url(iscsi_ctx, target);
+		if (verbose)
+			printf("target: %s, portal: %s, lu %d\n",
+			       iscsi_url->target, iscsi_url->portal,
+			       iscsi_url->lun);
+
+		iscsi_set_session_type(iscsi_ctx, ISCSI_SESSION_DISCOVERY);
+		iscsi_set_header_digest(iscsi_ctx, ISCSI_HEADER_DIGEST_NONE);
+		iscsi_set_log_level(iscsi_ctx, verbose);
+		iscsi_set_log_fn(iscsi_ctx, iscsi_log_to_stderr);
+		iscsi_set_timeout(iscsi_ctx, timeout);
+
+		if ((err = iscsi_connect_sync(iscsi_ctx, iscsi_url->portal))
+		    != 0) {
+			printf("failed to connect %s\n", target);
+			return 1;
+		}
+
+		if ((err = iscsi_login_sync(iscsi_ctx)) != 0) {
+			printf("failed to login %s\n",
+			       iscsi_get_error(iscsi_ctx));
+			return 1;
+		}
+
+		struct iscsi_discovery_address *addr =
+			iscsi_discovery_sync(iscsi_ctx);
+
+		if (addr == NULL) {
+			printf("discovery failed: %s\n",
+			       iscsi_get_error(iscsi_ctx));
+			return 1;
+		}
+
+		struct iscsi_discovery_address *curr;
+		int target_count = 0;
+		int portal_count = 0;
+
+		do {
+			if (verbose)
+				printf("target name: %s\n", addr->target_name);
+			target_count++;
+			struct iscsi_target_portal *cp;
+			do {
+				if (verbose)
+					printf("target portal %s\n",
+					       addr->portals->portal);
+				portal_count++;
+			} while ((cp = addr->portals->next) != NULL);
+		} while ((curr = addr->next) != NULL);
+
+		if (portal_count == 0 || target_count == 0) {
+			printf("failed to find any target(s) test failed..\n");
+			return 1;
+		}
+
+		assert(iscsi_logout_sync(iscsi_ctx) == 0);
+
+		iscsi_destroy_url(iscsi_url);
+		iscsi_destroy_context(iscsi_ctx);
+		if (verbose)
+			printf("-- iteration count: %d\n", iter_count);
+
+		iter_count++;
+		// make sure we give a sign of life...
+		if ((iter_count % 100 == 0) && verbose == 0)
+			printf("%d  discoveries succesfull\n", iter_count);
+	}
+}

--- a/test-tools/login-test/login_test.c
+++ b/test-tools/login-test/login_test.c
@@ -130,4 +130,5 @@ int main(int argc, char **argv)
 		if ((iter_count % 100 == 0) && verbose == 0)
 			printf("%d  discoveries succesfull\n", iter_count);
 	}
+	return 0;
 }

--- a/test-tools/login-test/login_test.c
+++ b/test-tools/login-test/login_test.c
@@ -17,7 +17,6 @@ int main(int argc, char **argv)
 	int opt;
 	int verbose = 0;
 	int err = 0;
-	int count = 0;
 	int iter_count = 0;
 	int timeout = 5;
 	const char *target = NULL;
@@ -56,7 +55,7 @@ int main(int argc, char **argv)
 	printf("Running test against: %s with timeout set to %d seconds\n",
 	       target, timeout);
 
-	while(iter_count < 400) {
+	while (iter_count < 400) {
 		if ((iscsi_ctx =
 			     iscsi_create_context("iqn.2019-2.io.openebs:test"))
 		    == NULL) {

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -104,6 +104,7 @@ run_mempool_test()
 
 run_istgt_integration()
 {
+	echo "===================run_istgt_integration start: " $(date)
 	local pid_istgt=$(sudo lsof -t -i:6060)
 	echo "istgt PID is $pid_istgt"
 	kill -9 $pid_istgt
@@ -116,6 +117,7 @@ run_istgt_integration()
 	[[ $? -ne 0 ]] && echo "istgt integration test failed" && tail -30 $INTEGRATION_TEST_LOGFILE && exit 1
 	rm -f /tmp/test_vol*
 	rm $INTEGRATION_TEST_LOGFILE
+	echo "===================run_istgt_integration end: " $(date)
 	return 0
 }
 
@@ -255,6 +257,7 @@ list_descendants ()
 }
 
 run_data_integrity_test() {
+	echo "===================run_data_integrity_test start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -351,11 +354,12 @@ run_data_integrity_test() {
 
 	ps -auxwww
 	ps -o pid,ppid,command
-
+	echo "===================run_data_integrity_test end: " $(date)
 }
 
 run_read_consistency_test ()
 {
+	echo "===================run_read_consistency_test start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -462,10 +466,12 @@ run_read_consistency_test ()
 	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
 	rm -rf $file_name $device_file
 	stop_istgt
+	echo "===================run_read_consistency_test end: " $(date)
 }
 
 run_lu_rf_test ()
 {
+	echo "===================run_lu_rf_test start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -481,7 +487,7 @@ run_lu_rf_test ()
 
 	>$LOGFILE
 	sed -i -n '/LogicalUnit section/,$!p' src/istgt.conf
-	setup_test_env $replica4_vdev
+	setup_test_env
 
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica1_ip" -P "$replica1_port" -V $replica1_vdev -q -r &
 	replica1_pid=$!
@@ -566,6 +572,7 @@ run_lu_rf_test ()
 	pkill -9 -P $replica3_pid
 	rm -rf ${replica1_vdev}* ${replica2_vdev}* ${replica3_vdev}*
 	stop_istgt
+	echo "====================run_lu_rf_test end: " $(date)
 }
 
 ## wait_for_healthy_replicas will wait for max of 5 minutes for replicas to become healthy
@@ -639,6 +646,7 @@ check_degraded_quorum()
 # run_quorum_test is used to test by connecting n Quorum replicas and m Non Quorum replicas
 run_quorum_test()
 {
+	echo "===================run_quorum_test start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -735,6 +743,7 @@ run_quorum_test()
 	pkill -9 -P $replica5_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
+	echo "===================run_quorum_test end: " $(date)
 }
 
 check_order_of_rebuilding()
@@ -778,6 +787,7 @@ check_order_of_rebuilding()
 ##run_non_quorum_replica_errored_test is used to kill the replica while forming management connection
 run_non_quorum_replica_errored_test()
 {
+	echo "===================run_non_quorum_replica_errored_test start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -836,7 +846,7 @@ run_non_quorum_replica_errored_test()
 	stop_istgt
 	rm -f /tmp/check_sum*
 	rm -rf ${replica1_vdev::-1}*
-
+	echo "===================run_non_quorum_replica_errored_test end: " $(date)
 }
 
 ## kill_non_quorum_replica used to kill the replica during connections
@@ -893,6 +903,7 @@ kill_non_quorum_replica()
 
 data_integrity_with_non_quorum()
 {
+	echo "===================data_integrity_with_non_quorum start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -982,7 +993,7 @@ data_integrity_with_non_quorum()
 	stop_istgt
 	rm -f /tmp/check_sum*
 	rm -rf ${replica1_vdev::-1}*
-
+	echo "===================data_integrity_with_non_quorum end: " $(date)
 }
 run_rebuild_time_test_in_single_replica()
 {
@@ -1199,6 +1210,7 @@ run_rebuild_time_test_in_multiple_replicas()
 
 run_replication_factor_test()
 {
+	echo "===================run_replication_factor_test start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -1257,12 +1269,14 @@ run_replication_factor_test()
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
 
+	echo "===================run_replication_factor_test end: " $(date)
 	if [ $ret == 1 ]; then
 		exit 1
 	fi
 }
 
 run_login_test() {
+	echo "Running login test.." $(date)
 	local replica1_port="6161"
 	local replica1_ip="127.0.0.1"
 	local replica1_vdev="/tmp/test_vol1"
@@ -1271,7 +1285,6 @@ run_login_test() {
 	CONSISTENCY_FACTOR=1
 	setup_test_env
 
-	echo "Running login test.."
 	LIBISCSI=$DIR/test-tools/login-test/libiscsi LD_LIBRARY_PATH=$LIBISCSI/lib/.libs $DIR/test-tools/login-test/login_test -h iscsi://127.0.0.1:3260 -t 5
 	if [ $? -eq 0 ]; then
 		echo "login test passed"
@@ -1286,6 +1299,7 @@ run_login_test() {
 
 run_io_timeout_test()
 {
+	echo "===================run_iotimeout_test start: " $(date)
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -1380,6 +1394,7 @@ run_io_timeout_test()
 	kill -9  $replica3_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
+	echo "===================run_io_timeout_test end: " $(date)
 }
 
 run_lu_rf_test

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1262,6 +1262,28 @@ run_replication_factor_test()
 	fi
 }
 
+run_login_test() {
+	local replica1_port="6161"
+	local replica1_ip="127.0.0.1"
+	local replica1_vdev="/tmp/test_vol1"
+
+	REPLICATION_FACTOR=1
+	CONSISTENCY_FACTOR=1
+	setup_test_env
+
+	echo "Running login test.."
+	LIBISCSI=$DIR/test-tools/login-test/libiscsi LD_LIBRARY_PATH=$LIBISCSI/lib/.libs $DIR/test-tools/login-test/login_test -h iscsi://127.0.0.1:3260 -t 5
+	if [ $? -eq 0 ]; then
+		echo "login test passed"
+	else
+		echo "login test failed"
+		tail -20 $LOGFILE
+		exit 1
+	fi
+
+	stop_istgt
+}
+
 run_io_timeout_test()
 {
 	local replica1_port="6161"
@@ -1370,6 +1392,7 @@ run_istgt_integration
 run_read_consistency_test
 run_replication_factor_test
 run_io_timeout_test
+run_login_test
 echo "===============All Tests are passed ==============="
 tail -20 $LOGFILE
 


### PR DESCRIPTION
This PR addresses the issue at https://github.com/openebs/openebs/issues/2390

Without changes, below is output:
```
root@localhost:/home/prateek/gila# ./login_test -v -h iscsi://127.0.0.1:3260 -t 5
Running test against: iscsi://127.0.0.1:3260 with timeout set to 5 seconds
target: , portal: 127.0.0.1:3260, lu 0
libiscsi:2 connecting to portal 127.0.0.1:3260
libiscsi:3 SO_KEEPALIVE set to 1
libiscsi:3 TCP_KEEPCNT set to 3
libiscsi:3 TCP_KEEPINTVL set to 30
libiscsi:3 TCP_KEEPIDLE set to 30
libiscsi:3 TCP_NODELAY set to 1
libiscsi:2 connection established (127.0.0.1:53028 -> 127.0.0.1:3260)
libiscsi:6 TargetLoginReply: HeaderDigest=None
libiscsi:6 TargetLoginReply: DataDigest=None
libiscsi:6 TargetLoginReply: InitialR2T=Irrelevant
libiscsi:6 TargetLoginReply: ImmediateData=Irrelevant
libiscsi:6 TargetLoginReply: MaxBurstLength=Irrelevant
libiscsi:6 TargetLoginReply: FirstBurstLength=Irrelevant
libiscsi:6 TargetLoginReply: DefaultTime2Wait=2
libiscsi:6 TargetLoginReply: DefaultTime2Retain=0
libiscsi:6 TargetLoginReply: MaxOutstandingR2T=Irrelevant
libiscsi:6 TargetLoginReply: ErrorRecoveryLevel=0
libiscsi:6 TargetLoginReply: IFMarker=No
libiscsi:6 TargetLoginReply: OFMarker=No
libiscsi:6 TargetLoginReply: MaxConnections=Irrelevant
libiscsi:6 TargetLoginReply: MaxRecvDataSegmentLength=262144
libiscsi:6 TargetLoginReply: DataPDUInOrder=Irrelevant
libiscsi:6 TargetLoginReply: DataSequenceInOrder=Irrelevant
libiscsi:2 login successful
target name: iqn.2016-09.com.openebs.cstor:vol1
target portal 127.0.0.1:3260,1
libiscsi:1 iscsi_write_to_socket: outqueue[0]->cmdsn < expcmdsn (3f599ca1 < 3f599ca2) opcode 06
libiscsi:2 reconnect initiated
libiscsi:2 connecting to portal 
libiscsi:1 Invalid target:  Can not resolv into IPv4/v6.
libiscsi:1 reconnect try 1 failed, waiting 1 seconds
^C
```

After changes, below is output:
```
root@localhost:/home/prateek/gila# ./login_test -h iscsi://127.0.0.1:3260 -t 5
Running test against: iscsi://127.0.0.1:3260 with timeout set to 5 seconds
100  discoveries succesfull
200  discoveries succesfull
300  discoveries succesfull
400  discoveries succesfull
500  discoveries succesfull
failed to login iscsi_service failed with : iscsi_service_reconnect_if_loggedin. Can not reconnect right now.
```

As istgt does garbage collection of connection after some time, logins are failing after 500+ continuous tries with error `pipe() failed` at istgt.

Couple of points:
- login_test is expecting target NOT to increment CmdSN as part of SendTargets request.
`libiscsi:1 iscsi_write_to_socket: outqueue[0]->cmdsn < expcmdsn (3f599ca1 < 3f599ca2) opcode 06`
But, istgt is incrementing CmdSN as it was reading Immediate flag from wrong bit.

This PR have the fix for same.

- On receiving logout request, istgt is breaking connection. This can make sometimes NOT to send the response to client.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>