### PR TITLE
workaround(discovery): restart istgt on consective 4 discovery requests

### DIFF
--- a/fetch-zfs-branch.sh
+++ b/fetch-zfs-branch.sh
@@ -21,6 +21,6 @@ set -e
 #
 #For the moment, we will go with making sure the correct
 # branch name is provided as part of the release process.
-ZFS_BUILD_BRANCH="zfs-0.7-release"
+ZFS_BUILD_BRANCH="0.8.0"
 export ZFS_BUILD_BRANCH
 

--- a/src/istgt.c
+++ b/src/istgt.c
@@ -93,6 +93,7 @@
 #define	PORTNUMLEN    32
 
 ISTGT g_istgt;
+uint64_t discovery_retry_limit = 4;
 #ifdef	REPLICATION
 extern int replica_timeout;
 extern int extraWait;
@@ -3101,6 +3102,13 @@ main(int argc, char **argv)
 #ifndef	REPLICATION
 	poolinit();
 #endif
+
+	const char *s_discovery_retry_limit = getenv("DiscoveryRetryLimit");
+	if (s_discovery_retry_limit) {
+		discovery_retry_limit = (unsigned int)strtol(s_discovery_retry_limit, NULL, 10);
+		ISTGT_NOTICELOG("Setting discovery retry limit at %lu\n", discovery_retry_limit);
+	}
+
 	/* read config files */
 	config = istgt_allocate_config();
 	rc = istgt_read_config(config, config_file);


### PR DESCRIPTION
related to https://www.github.com/openebs/openebs/issues/2382

After successful discovery, login request will be received by target.
On continuous 4 discovery failures, high mem usage at kubelet is observed due to bug in open-iscsi.
This PR is to restart istgt to avoid mem consumption at kubelet.

Signed-off-by: Vitta <vitta@mayadata.io>