### PR TITLE
fix(discovery): reading immediate flag from correct bit

### DIFF
--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -2544,7 +2544,7 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	memset(data, 0, alloc_len);
 
 	cp = (uint8_t *) &pdu->bhs;
-	I_bit = BGET8(&cp[0], 7);
+	I_bit = BGET8(&cp[0], 6);
 	F_bit = BGET8(&cp[1], 7);
 	C_bit = BGET8(&cp[1], 6);
 
@@ -6134,7 +6134,6 @@ worker(void *arg)
 				break;
 			} else if (rc == 1) { // means successful logout ISCSI_OP_LOGOUT
 				ISTGT_TRACELOG(ISTGT_TRACE_ISCSI, "logout received\n");
-				break;
 			}
 
 			if (conn->pdu.ahs != NULL) {


### PR DESCRIPTION
This PR addresses the issue at [openebs/openebs#2390](https://github.com/openebs/openebs/issues/2390) and cherry-pick of fixes from PR#226

Signed-off-by: Vitta <vitta@mayadata.io>