### PR TITLE
revert(workaround): remove code that restarts istgt on continuous dis…

### DIFF
--- a/src/istgt.c
+++ b/src/istgt.c
@@ -93,7 +93,6 @@
 #define	PORTNUMLEN    32
 
 ISTGT g_istgt;
-uint64_t discovery_retry_limit = 4;
 #ifdef	REPLICATION
 extern int replica_timeout;
 extern int extraWait;
@@ -3102,12 +3101,6 @@ main(int argc, char **argv)
 #ifndef	REPLICATION
 	poolinit();
 #endif
-
-	const char *s_discovery_retry_limit = getenv("DiscoveryRetryLimit");
-	if (s_discovery_retry_limit) {
-		discovery_retry_limit = (unsigned int)strtol(s_discovery_retry_limit, NULL, 10);
-		ISTGT_NOTICELOG("Setting discovery retry limit at %lu\n", discovery_retry_limit);
-	}
 
 	/* read config files */
 	config = istgt_allocate_config();


### PR DESCRIPTION
…covery reqs

PR#228 does restart of istgt to capture core on consecutive 4 discovery requests without without a login request after the discovery request.

This PR is to revert the above behavior introduced in PR#228.

Signed-off-by: Vitta <vitta@mayadata.io>