### PR TITLE
feat(tunings): luworkers and queudepth settings through env

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -21,6 +21,7 @@ do
 		externalIP)		externalIP=${VALUE} ;;
 		replication_factor)	replication_factor=${VALUE} ;;
 		consistency_factor)	consistency_factor=${VALUE} ;;
+		test_env)		test_env=${VALUE} ;;
 		*)
 	esac
 done
@@ -65,7 +66,14 @@ export externalIP=$externalIP
 echo $externalIP
 service rsyslog start
 #setting replica timeout to 20 seconds
-/usr/local/bin/istgt -R 20
+
+if [ -z $test_env ]
+then
+	/usr/local/bin/istgt -R 20
+else
+	QueueDepth=5 Luworkers=9 /usr/local/bin/istgt -R 20
+fi
+
 child=$!
 echo "child PID from init script: "$child
 wait

--- a/src/setup_istgt.sh
+++ b/src/setup_istgt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 run_istgt ()
 {
 	local volume_size
@@ -24,7 +24,7 @@ run_istgt ()
 	cp istgt /usr/local/bin/istgt
 	cp istgtcontrol /usr/local/bin/istgtcontrol
 	ps -aux | grep "\./istgt" | grep -v grep | sudo kill -9 `awk '{print $2}'`
-	./init.sh volname=vol1 portal=127.0.0.1 size=$volume_size externalIP=127.0.0.1 replication_factor=$rf consistency_factor=$cf
+	./init.sh volname=vol1 portal=127.0.0.1 size=$volume_size externalIP=127.0.0.1 replication_factor=$rf consistency_factor=$cf test_env=$TEST_ENV
 }
 
 parent_file=$( basename $0 )

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -90,7 +90,9 @@ start_replica() {
 stop_istgt() {
 	if [ $SETUP_PID -ne -1 ]; then
 		pkill -9 -P $(list_descendants $SETUP_PID)
+		kill -9 $(list_descendants $SETUP_PID)
 		pkill -9 -P $SETUP_PID
+		kill -9 $SETUP_PID
 	fi
 
 }
@@ -1262,6 +1264,34 @@ run_replication_factor_test()
 	fi
 }
 
+run_test_env()
+{
+	REPLICATION_FACTOR=3
+	CONSISTENCY_FACTOR=2
+	TEST_ENV=1
+	setup_test_env
+
+	cnt=$(eval $ISTGTCONTROL dump -a | grep "Luworkers:9" | wc -l)
+	if [ $? -ne 0 ] || [ $cnt -ne 1 ]
+	then
+		echo "test env failed"
+		exit 1
+	fi
+	cleanup_test_env
+
+	unset TEST_ENV
+	setup_test_env
+
+	cnt=$(eval $ISTGTCONTROL dump -a | grep "Luworkers:6" | wc -l)
+	if [ $? -ne 0 ] || [ $cnt -ne 1 ]
+	then
+		echo "test env failed"
+		exit 1
+	fi
+	cleanup_test_env
+}
+
+
 run_io_timeout_test()
 {
 	local replica1_port="6161"
@@ -1370,6 +1400,7 @@ run_istgt_integration
 run_read_consistency_test
 run_replication_factor_test
 run_io_timeout_test
+run_test_env
 echo "===============All Tests are passed ==============="
 tail -20 $LOGFILE
 


### PR DESCRIPTION
related to issue https://github.com/openebs/openebs/issues/2413

This PR makes istgt to take QueueDepth and Luworkers through environment variables.

Env variable for QueueDepth is `QueueDepth`, and,
env variable for Luworkers is `Luworkers`. 

Signed-off-by: Vitta <vitta@mayadata.io>