### PR TITLE
Enhancements and changes to GitLab CI YAML.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,12 +4,15 @@ stages:
 
 build-istgt:
   stage: build
+  only:
+    refs:
+      - ^(v[0-9][.][0-9][.]x|replication)?$  
   before_script:
     - echo $HOME
     - whoami
     - export BRANCH=${CI_COMMIT_REF_NAME}
     - echo $BRANCH
-    - export COMMIT=${CI_COMMIT_SHA:0:8}
+    - export COMMIT=${CI_COMMIT_SHORT_SHA}
     - apt-get update
     - apt-get install --yes psmisc git-core net-tools rsyslog sudo ioping
     - apt-get install --yes software-properties-common wget autoconf lsof
@@ -39,6 +42,9 @@ build-istgt:
 
 baseline-image:
   stage: baseline
+  only:
+    refs:
+      - ^(v[0-9][.][0-9][.]x|replication)?$
   image: atulabhi/kops:v10
   script:
      - pwd
@@ -48,9 +54,10 @@ baseline-image:
      - git config --global user.email openebscibot@openebs.io
      - export BRANCH=${CI_COMMIT_REF_NAME}
      - echo $BRANCH
-     - export COMMIT=${CI_COMMIT_SHA:0:8}
+     - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - echo $COMMIT
      - git clone https://github.com/openebs/e2e-infrastructure.git
+     - if [[ "$BRANCH" == "replication" ]] ; then git checkout master ; else git checkout $BRANCH ; fi
      - cd e2e-infrastructure/baseline
      - ansible-playbook commit-writer.yml --extra-vars "branch=$BRANCH repo=$CI_PROJECT_NAME commit=$COMMIT"
      - git status
@@ -58,6 +65,7 @@ baseline-image:
      - git status
      - git commit -m "updated $CI_PROJECT_NAME commit:$COMMIT"
      - git push  https://$user:$pass@github.com/openebs/e2e-infrastructure.git --all
-     - curl -X POST -F token=$AZURE -F ref=master https://gitlab.openebs.ci/api/v4/projects/2/trigger/pipeline
-     - curl -X POST -F token=$EKS -F ref=master https://gitlab.openebs.ci/api/v4/projects/3/trigger/pipeline
-     - curl -X POST -F token=$GKE -F ref=master https://gitlab.openebs.ci/api/v4/projects/5/trigger/pipeline
+     - if [[ "$BRANCH" == "replication" ]] ; then export INFRA="master" ; else export INFRA=$BRANCH ; fi
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-11 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-12 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-13 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline


### PR DESCRIPTION
- Check for replication and .x branches for build to trigger by using only:
refs option.
- Use the new CI_COMMIT_SHORT_SHA env to get the short commit SHA.
- Push the commit details to respective branches on e2e-infrastructure.
- Pass the branch details of ISTGT to the platform repos to checkout e2e-infrastructure for that particular branch when the infra-setup stage is run.
- Deprecate GKE, EKS and AKS platforms.
- Run Packet platform, with k8s 1.11, 1.12 and 1.13 for master branch.

Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>