### PR TITLE
Fix the regex to work with GitLab.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ build-istgt:
   stage: build
   only:
     refs:
-      - ^(v[0-9][.][0-9][.]x|replication)?$  
+      - /^(v[0-9][.][0-9][.]x|replication)?$/  
   before_script:
     - echo $HOME
     - whoami
@@ -44,7 +44,7 @@ baseline-image:
   stage: baseline
   only:
     refs:
-      - ^(v[0-9][.][0-9][.]x|replication)?$
+      - /^(v[0-9][.][0-9][.]x|replication)?$/
   image: atulabhi/kops:v10
   script:
      - pwd


### PR DESCRIPTION
- GitLab CI expects a '/' in the front and end of the regular
expression.

Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>