### PR TITLE
fix(chore):change the repo reference from zfs to cstor

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,7 +8,7 @@ else
 fi
 
 echo "Using zfs branch - ${ZFS_BUILD_BRANCH}"
-echo $(wget -O /tmp/zrepl_prot.h https://raw.githubusercontent.com/openebs/zfs/${ZFS_BUILD_BRANCH}/include/zrepl_prot.h)
+echo $(wget -O /tmp/zrepl_prot.h https://raw.githubusercontent.com/openebs/cstor/${ZFS_BUILD_BRANCH}/include/zrepl_prot.h)
 
 autoreconf -fiv
 rm -Rf autom4te.cache


### PR DESCRIPTION
The repo name for cstor code changed from zfs to cstor.
Fixed the code that was downloading a file
file from the cstor repo using the old url.

Signed-off-by: kmova <kiran.mova@openebs.io>