### PR TITLE
fix(chore):change the repo reference from zfs to cstor

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,7 +8,7 @@ else
 fi
 
 echo "Using zfs branch - ${ZFS_BUILD_BRANCH}"
-echo $(wget -O /tmp/zrepl_prot.h https://raw.githubusercontent.com/openebs/zfs/${ZFS_BUILD_BRANCH}/include/zrepl_prot.h)
+echo $(wget -O /tmp/zrepl_prot.h https://raw.githubusercontent.com/openebs/cstor/${ZFS_BUILD_BRANCH}/include/zrepl_prot.h)
 
 autoreconf -fiv
 rm -Rf autom4te.cache

--- a/fetch-zfs-branch.sh
+++ b/fetch-zfs-branch.sh
@@ -22,6 +22,6 @@ set -e
 #
 #For the moment, we will go with making sure the correct
 # branch name is provided as part of the release process.
-ZFS_BUILD_BRANCH="v0.8.x"
+ZFS_BUILD_BRANCH="v0.8.2"
 export ZFS_BUILD_BRANCH
 


### PR DESCRIPTION
The repo name for cstor code changed from zfs to cstor.
Fixed the code that was downloading a file
file from the cstor repo using the old url.

Also update the branch name to v0.8.2 

Signed-off-by: kmova kiran.mova@openebs.io