### PR TITLE
fix(OPEN_OPCODE): send replication_factor

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1131,6 +1131,7 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 	rio_payload->tgt_block_size = spec->blocklen;
 	strncpy(rio_payload->volname, spec->volname,
 	    sizeof (rio_payload->volname));
+	rio_payload->replication_factor = spec->replication_factor;
 
 	REPLICA_LOG("replica(%lu) connected successfully from %s:%d\n",
 	    replica->zvol_guid, replica->ip, replica->port);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1966,7 +1966,7 @@ update_replica_status(spec_t *spec, replica_t *replica)
 			}
 
 			assert(r1 != NULL);
-			assert(spec->rebuild_info.dw_replica == replica);
+			assert((spec->rebuild_info.dw_replica == replica) || (spec->replication_factor == 1));
 			spec->rebuild_info.dw_replica = NULL;
 			spec->rebuild_info.healthy_replica = NULL;
 			spec->rebuild_info.rebuild_in_progress = false;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -610,6 +610,8 @@ again:
 					mgmt_data = malloc(mgmtio->len);
 					count = test_read_data(events[i].data.fd, (uint8_t *)mgmt_data, mgmtio->len);
 					if (count < 0) {
+						REPLICA_ERRLOG("Failed to read from %d for len %lu and opcode %d\n",
+						    events[i].data.fd, mgmtio->len, mgmtio->opcode);
 						rc = -1;
 						goto error;
 					} else if ((uint64_t)count != mgmtio->len) {
@@ -666,6 +668,8 @@ again:
 					if (read_rem_data) {
 						count = test_read_data(events[i].data.fd, (uint8_t *)data + recv_len, total_len - recv_len);
 						if (count < 0) {
+							REPLICA_ERRLOG("Failed to read from datafd %d with rem_data for opcode: %d\n",
+							    iofd, io_hdr->opcode);
 							rc = -1;
 							goto error;
 						} else if ((uint64_t)count < (total_len - recv_len)) {
@@ -682,6 +686,7 @@ again:
 					} else if (read_rem_hdr) {
 						count = test_read_data(events[i].data.fd, (uint8_t *)io_hdr + recv_len, total_len - recv_len);
 						if (count < 0) {
+							REPLICA_ERRLOG("Failed to read from datafd %d with rem_hdr\n", iofd);
 							rc = -1;
 							goto error;
 						} else if ((uint64_t)count < (total_len - recv_len)) {
@@ -696,6 +701,7 @@ again:
 					} else {
 						count = test_read_data(events[i].data.fd, (uint8_t *)io_hdr, io_hdr_len);
 						if (count < 0) {
+							REPLICA_ERRLOG("Failed to read from datafd %d\n", iofd);
 							rc = -1;
 							goto error;
 						} else if ((uint64_t)count < io_hdr_len) {
@@ -717,6 +723,8 @@ again:
 							nbytes = 0;
 							count = test_read_data(events[i].data.fd, (uint8_t *)data, io_hdr->len);
 							if (count < 0) {
+								REPLICA_ERRLOG("Failed to read from datafd %d with opcode %d\n",
+								    iofd, io_hdr->opcode);
 								rc = -1;
 								goto error;
 							} else if ((uint64_t)count < io_hdr->len) {

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1036,11 +1036,19 @@ run_rebuild_time_test_in_single_replica()
 					$ISTGTCONTROL -q REPLICA vol1
 					echo "volume status is supposed to be 4"
 					exit 1
+				elif [ ${rt} == "\"Healthy\"" ]; then
+					break
+				else
+					echo "volume status is not proper"
+					exit 1
 				fi
-				break
 			fi
+		elif [ $rt -le 20 ]; then
+			sleep 10
+		else
+			echo "replication factor(4) test failed"
+			exit 1
 		fi
-		sleep 10
 	done
 	pkill -9 -P $replica1_pid
 	stop_istgt
@@ -1137,6 +1145,10 @@ run_rebuild_time_test_in_multiple_replicas()
 						done_test=1
 						break
 					fi
+				elif [ $rt -le 40 ]; then
+				else
+					echo "replication factor(5) test failed"
+					exit 1
 				fi
 			else
 				if [ $rt -le 30 ]; then
@@ -1147,9 +1159,12 @@ run_rebuild_time_test_in_multiple_replicas()
 						echo "replication factor(3) test failed"
 						exit 1
 					fi
-				else
+				elif [ $rt -gt 30 ]; then
 					done_test=1
 					break
+				else
+					echo "replication factor(6) test failed"
+					exit 1
 				fi
 			fi
 		done
@@ -1186,8 +1201,12 @@ run_rebuild_time_test_in_multiple_replicas()
 				$ISTGTCONTROL -q REPLICA vol1
 				echo "volume status is supposed to be 3"
 				exit 1
+			elif [ ${rstatus} == "\"Healthy\"" ]; then
+				break
+			else
+				echo "replication factor(7) test failed"
+				exit 1
 			fi
-			break
 		fi
 	done
 

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1022,7 +1022,7 @@ run_rebuild_time_test_in_single_replica()
 		cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].\"upTime\"'"
 		rt=$(eval $cmd)
 		echo "replica start time $rt"
-		if [ $rt -gt 40 ]; then
+		if [ $rt -gt 20 ]; then
 			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].Mode'"
 			rstatus=$(eval $cmd)
 			echo "replica status $rstatus"

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1146,6 +1146,7 @@ run_rebuild_time_test_in_multiple_replicas()
 						break
 					fi
 				elif [ $rt -le 40 ]; then
+					: # This kind of checks are required when eval cmd fails
 				else
 					echo "replication factor(5) test failed"
 					exit 1


### PR DESCRIPTION
Fixes https://www.github.com/openebs/openebs/issues/2437

Replication factor sent from istgt during OPEN_OPCODE lets zrepl to convert the state to Healthy in case of single replica volumes.

This PR is to send replication factor in OPEN_OPCODE.
Add testcase to convert single replica to healthy

Signed-off-by: Vitta <vitta@mayadata.io>