### PR TITLE
fix(random_travis_failures): with single replica tests

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1127,14 +1127,16 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 
 	rio_payload = (zvol_op_open_data_t *) malloc(
 	    sizeof (zvol_op_open_data_t));
+	memset(rio_payload, 0, sizeof (zvol_op_open_data_t));
 	rio_payload->timeout = (3 * replica_timeout);
 	rio_payload->tgt_block_size = spec->blocklen;
 	strncpy(rio_payload->volname, spec->volname,
 	    sizeof (rio_payload->volname));
 	rio_payload->replication_factor = spec->replication_factor;
 
-	REPLICA_LOG("replica(%lu) connected successfully from %s:%d\n",
-	    replica->zvol_guid, replica->ip, replica->port);
+	REPLICA_LOG("replica(%lu) connected successfully from %s:%d rep: %d\n",
+	    replica->zvol_guid, replica->ip, replica->port,
+	    rio_payload->replication_factor);
 
 	if (write(replica->iofd, rio_hdr, sizeof (*rio_hdr)) !=
 	    sizeof (*rio_hdr)) {

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -736,7 +736,7 @@ again:
 							read_rem_data = false;
 						}
 					}
-
+execute_io:
 					if (io_hdr->opcode == ZVOL_OPCODE_OPEN) {
 						open_ptr = (zvol_op_open_data_t *)data;
 						if (open_ptr->replication_factor == 1) {
@@ -744,10 +744,10 @@ again:
 							zrepl_status->rebuild_status = ZVOL_REBUILDING_DONE;
 						}
 						io_hdr->status = ZVOL_OP_STATUS_OK;
-						REPLICA_LOG("Volume name:%s blocksize:%d timeout:%d.. replica(%d)\n",
-						    open_ptr->volname, open_ptr->tgt_block_size, open_ptr->timeout, ctrl_port);
+						REPLICA_LOG("Volume name:%s blocksize:%d timeout:%d.. replica(%d) state: %d\n",
+						    open_ptr->volname, open_ptr->tgt_block_size, open_ptr->timeout, ctrl_port,
+						    zrepl_status->state);
 					}
-execute_io:
 					if ((io_cnt > 0) && (io_hdr->opcode == ZVOL_OPCODE_WRITE ||
 							io_hdr->opcode == ZVOL_OPCODE_READ)) {
 						io_cnt --;

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1209,6 +1209,7 @@ run_rebuild_time_test_in_multiple_replicas()
 				exit 1
 			fi
 		fi
+		sleep 2
 	done
 
 	pkill -9 -P $replica1_pid


### PR DESCRIPTION
When data part of ZVOL_OPCODE_OPEN is read in chunks, test code is not handling in executing the IO.
This PR fixes the testcase related to ZVOL_OPCODE_OPEN.