### PR TITLE
[WIP] fix(status): set open opcode seq as max of replica's io_seq

### DIFF
--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -139,7 +139,6 @@ int handle_write_resp(spec_t *, replica_t *);
 int handle_read_resp(spec_t *, replica_t *);
 int update_replica_list(int, spec_t *, int);
 replica_t *create_replica_entry(spec_t *, int, int);
-int update_replica_entry(spec_t *, replica_t *, int);
 int handle_read_data_event(replica_t *);
 int handle_write_data_event(replica_t *replica);
 void update_volstate(spec_t *);

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -975,7 +975,7 @@ mock_repl(void *args)
 			32, 0)) < 0) {
 		REPLICA_ERRLOG("conn_listen() failed, errorno:%d", errno);
 		abort();
-		}
+	}
 
 	// Connect to controller to start handshake and connect to epoll
 	while ((rargs->mgmtfd = mgmtfd =
@@ -1481,8 +1481,7 @@ main(int argc, char **argv)
 	wait_for_mock_clients();
 
 	create_mock_replicas(spec->replication_factor, spec->volname);
-	pthread_create(&rebuild_test_thread, NULL,
-	&rebuild_test, (void *)test_args);
+	pthread_create(&rebuild_test_thread, NULL, &rebuild_test, (void *)test_args);
 
 	MTX_LOCK(&test_args->test_mtx);
 	pthread_cond_wait(&test_args->test_state_cv, &test_args->test_mtx);

--- a/src/istgt_queue.h
+++ b/src/istgt_queue.h
@@ -80,6 +80,6 @@ void * istgt_queue_reverse_walk(ISTGT_QUEUE_Ptr head, void ** cookie);
 #ifdef __linux__
 #define	TAILQ_FOREACH_SAFE(var, head, field, tvar)                      \
 	for ((var) = TAILQ_FIRST((head));                               \
-		(var) && ((tvar) = TAILQ_NEXT((var), field), 1);            \
+		(var) && ((tvar) = TAILQ_NEXT((var), field), 1);        \
 		(var) = (tvar))
 #endif

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -709,6 +709,7 @@ try_again:
 					rdata->replica_status = ZVOL_STATUS_HEALTHY;
 			} else if (events[i].data.fd == sfd) {
 				iofd = accept(sfd, NULL, 0);
+				REPLICA_ERRLOG("iofd %d for replica %d", iofd, replica_port);
 				if (iofd == -1) {
 					if((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
 						break;
@@ -879,12 +880,15 @@ error:
 
 	if (mgmtfd != -1) {
 		(void) epoll_ctl(epfd, EPOLL_CTL_DEL, mgmtfd, NULL);
+		shutdown(mgmtfd, SHUT_RDWR);
 		close(mgmtfd);
 		mgmtfd = -1;
 	}
 
 	if (iofd != -1) {
 		(void) epoll_ctl(epfd, EPOLL_CTL_DEL, iofd, NULL);
+		REPLICA_ERRLOG("shutdown iofd of port %d\n", replica_port);
+		shutdown(iofd, SHUT_RDWR);
 		close(iofd);
 		iofd = -1;
 	}

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -232,7 +232,7 @@ verify_replica_removal(int replica_mgmt_sport)
 #ifdef	DEBUG
 	replica_t *r;
 	spec_t *spec = NULL;
-	int retry_count = 10;
+	int retry_count = 60;
 #endif
 
 	if (!replica_mgmt_sport)
@@ -995,7 +995,7 @@ shutdown_errored_replica(void)
 void
 wait_for_spec_ready(void)
 {
-	int count = 10;
+	int count = 15;
 	spec_t *spec = NULL;
 	
 	MTX_LOCK(&specq_mtx);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1131,6 +1131,7 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 	rio_payload->tgt_block_size = spec->blocklen;
 	strncpy(rio_payload->volname, spec->volname,
 	    sizeof (rio_payload->volname));
+	rio_payload->replication_factor = spec->replication_factor;
 
 	REPLICA_LOG("replica(%lu) connected successfully from %s:%d\n",
 	    replica->zvol_guid, replica->ip, replica->port);

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -717,6 +717,7 @@ again:
 							nbytes = 0;
 							count = test_read_data(events[i].data.fd, (uint8_t *)data, io_hdr->len);
 							if (count < 0) {
+								REPLICA_LOG("failed to read for opcode: %d\n", io_hdr->opcode);
 								rc = -1;
 								goto error;
 							} else if ((uint64_t)count < io_hdr->len) {

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1022,7 +1022,7 @@ run_rebuild_time_test_in_single_replica()
 		cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].\"upTime\"'"
 		rt=$(eval $cmd)
 		echo "replica start time $rt"
-		if [ $rt -gt 40 ]; then
+		if [ $rt -gt 20 ]; then
 			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].Mode'"
 			rstatus=$(eval $cmd)
 			echo "replica status $rstatus"

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -642,7 +642,7 @@ check_degraded_quorum()
 	if [ $cnt -ne $expected_degraded_count ]
 	then
 		$ISTGTCONTROL -q REPLICA vol1
-		echo "Degraded replica count is not matched: expected degraded replica count $expected_rep_count and got $cnt"
+		echo "Degraded replica count is not matched: expected degraded replica count $expected_degraded_count and got $cnt"
 		exit 1
 	fi
 


### PR DESCRIPTION
Currently, replicas will be in degraded state even for new volumes. Replicas doesn't know whether the volume is new or is it already having IOs in the volume.
This PR sets io_seq in OPEN opcode. Based on this value, replicas can decide moving them to healthy or degraded state.