### PR TITLE
fix(discovery): read immediate flag from correct bit

### DIFF
--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -2508,6 +2508,8 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	uint32_t sMaxCmdSN = 0;
 	uint32_t cStatSN = 0;
 	int  step = 0;
+	int8_t sendtargets_discovery = 0;
+
 	if (!conn->full_feature) {
 		ISTGT_ERRLOG("before Full Feature\n");
 		return (-1);
@@ -2519,7 +2521,7 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 	memset(data, 0, alloc_len);
 
 	cp = (uint8_t *) &pdu->bhs;
-	I_bit = BGET8(&cp[0], 7);
+	I_bit = BGET8(&cp[0], 6);
 	F_bit = BGET8(&cp[1], 7);
 	C_bit = BGET8(&cp[1], 6);
 
@@ -2623,6 +2625,7 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 				conn->initiator_name,
 				conn->initiator_addr,
 				val, data, alloc_len, data_len);
+			sendtargets_discovery = 1;
 			SESS_MTX_LOCK(conn);
 		} else {
 			if (strcasecmp(val, "ALL") == 0) {
@@ -2635,6 +2638,7 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 					conn->initiator_name,
 					conn->initiator_addr,
 					val, data, alloc_len, data_len);
+				sendtargets_discovery = 2;
 				SESS_MTX_LOCK(conn);
 			}
 		}
@@ -2689,6 +2693,8 @@ istgt_iscsi_op_text(CONN_Ptr conn, ISCSI_PDU_Ptr pdu)
 		return (-1);
 	}
 
+	ISTGT_NOTICELOG("queued op_text response: %s", (sendtargets_discovery == 1) ? "sendtargets_discovery" :
+	    ((sendtargets_discovery == 2) ? "sendtargets_nondiscovery" : ""));
 	/* update internal variables */
 	istgt_iscsi_copy_param2var(conn);
 	/* check value */


### PR DESCRIPTION
For discovery related request, istgt is not reading immediate flag from correct bits.
This PR fixes the same, and is part of cherry-pick of PR#231

Signedoff-by: Vitta <vitta@mayadata.io>