### PR TITLE
fix(logout): client connection shouldn't be closed on logout conn

### DIFF
--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -5345,14 +5345,13 @@ wait_all_task(CONN_Ptr conn)
 		conn->id, conn->running_tasks);
 }
 
-
+#if 0
 static void
 snd_cleanup(void *arg)
 {
 	ISTGT_WARNLOG("snd:%p thread_exit\n", arg);
 }
 
-#if 0
 static void
 worker_cleanup(void *arg)
 {

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1018,7 +1018,7 @@ run_rebuild_time_test_in_single_replica()
 
 	while [ 1 ]; do
 		# With replica poll timeout as 10, volume should become
-		# healthy in less than 40 seconds.
+		# healthy in less than 20 seconds.
 		cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[0].\"upTime\"'"
 		rt=$(eval $cmd)
 		echo "replica start time $rt"


### PR DESCRIPTION
This PR is cherry-pick of part of PR#231

These changes makes istgt NOT to close the client connection as soon as it receives the logout request. Now, connection will be closed once client closes the connection or on any error.

Signed-off-by: Vitta <vitta@mayadata.io>