### PR TITLE
docs(contributor): add governance and maintainers files

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,2 @@
+This is a OpenEBS sub project and abides by the 
+[OpenEBS Project Governance](https://github.com/openebs/openebs/blob/master/GOVERNANCE.md).

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,16 @@
+# Official list of OpenEBS Maintainers.
+#
+# Names added to this file should be in the following format:
+#     Individual's name,@githubhandle, Company Name
+#
+# Please keep the below list sorted in ascending order.
+#
+#Maintainers
+"Jeffry Molanus",@gila,MayaData
+"Kiran Mova",@kmova,MayaData
+"Vishnu Itta",@vishnuitta,MayaData
+
+#Reviewers
+"Mayank Patel",@mynktl,MayaData
+"Payes Anand",@payes,MayaData
+"Utkarsh Mani Tripathi",@utkarshmani1997,MayaData

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,5 +1,5 @@
-The source code developed by the OpenEBS Authors is licensed under Apache 2.0. 
+The source code developed for the OpenEBS Project is licensed under Apache 2.0. 
 
-However, the project contains unmodified/modified subcomponents from other Open Source Projects with separate copyright notices and license terms. Please refer to the individual source files for further details.
+However, the OpenEBS project contains unmodified/modified subcomponents from other Open Source Projects with separate copyright notices and license terms. 
 
 Your use of the source code for these subcomponents is subject to the terms and conditions as defined by those source projects.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/openebs/istgt.svg?branch=replication)](https://travis-ci.org/openebs/istgt)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fopenebs%2Fistgt.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fopenebs%2Fistgt?ref=badge_shield)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2738/badge)](https://bestpractices.coreinfrastructure.org/projects/2738)
 
 ### Instructions to check cstyle
 ```


### PR DESCRIPTION
This PR adds the current maintainer and reviewer list
for the openebs/maya project. Also links to the Governance
process outlined for the overall openebs projects in openebs/openebs#2547

Signed-off-by: kmova <kiran.mova@openebs.io>