### PR TITLE
[2502] feat(debug-tools): installing curl/tcpdump/nslookup/ping packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,9 @@
 FROM openebs/cstor-ubuntu:xenial-20181005
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog
-RUN apt-get -y install net-tools iputils-ping
-RUN apt-get -y install libssl-dev libjson-c-dev libjemalloc-dev
-RUN apt -y install apt-file && apt-file update
+RUN apt-get -y install curl tcpdump dnsutils net-tools iputils-ping gdb
+RUN apt-get -y install apt-utils libssl-dev libjson-c-dev libjemalloc-dev
+RUN apt-get -y install apt-file && apt-file update
 
 RUN mkdir -p /usr/local/etc/bkpistgt
 RUN mkdir -p /usr/local/etc/istgt


### PR DESCRIPTION
This PR fixes https://github.com/openebs/openebs/issues/2502.
Installs curl/tcpdump/gdb/ping/nslookup as part of cstor-istgt image

Signed-off-by: Vitta <vitta@mayadata.io>