### PR TITLE
feat(logins): allow only one login at a time.

### DIFF
--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -7201,9 +7201,15 @@ istgt_iscsi_drop_old_conns(CONN_Ptr conn)
 			continue;
 		if (xconn == conn)
 			continue;
+#ifdef REPLICATION
+		if (strcasecmp(conn->initiator_name, xconn->initiator_name) == 0) {
+			continue;
+		}
+#else
 		if (strcasecmp(conn->initiator_port, xconn->initiator_port) != 0) {
 			continue;
 		}
+#endif
 		if (strcasecmp(conn->target_name, xconn->target_name) == 0) {
 			if (xconn->sess != NULL) {
 				printf("exiting conn by %s(%s), TSIH=%u, CID=%u\n",

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -7324,7 +7324,7 @@ istgt_iscsi_drop_stale_login(CONN_Ptr conn)
 				continue;
 			if (xconn == conn)
 				continue;
-			if (strcasecmp(conn->initiator_port, xconn->initiator_port) != 0) {
+			if (strcasecmp(conn->initiator_name, xconn->initiator_name) == 0) {
 				continue;
 			}
 			if (strcasecmp(conn->target_name, xconn->target_name) == 0) {

--- a/src/istgt_iscsi.c
+++ b/src/istgt_iscsi.c
@@ -7265,6 +7265,10 @@ istgt_iscsi_drop_old_conns(CONN_Ptr conn)
 	return (0);
 }
 
+/*
+ * logout from the old node as we are
+ * trying to login from the new node.
+*/
 static int
 istgt_iscsi_drop_stale_login(CONN_Ptr conn)
 {


### PR DESCRIPTION
Whenever a new login comes from different node, logout from the old connection so that at a time only one login is present.

this is a temp fix for now, will go ahead with initiator group approach. 

Signed-off-by: Pawan <pawan@mayadata.io>