### PR TITLE
fix(snaprebuild) when we are transitioning to

### DIFF
--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -159,6 +159,7 @@ zio_cmd_alloc(zvol_io_hdr_t *hdr)
 	    (hdr->opcode == ZVOL_OPCODE_REPLICA_STATUS) ||
 	    (hdr->opcode == ZVOL_OPCODE_OPEN) ||
 	    (hdr->opcode == ZVOL_OPCODE_SNAP_CREATE) ||
+	    (hdr->opcode == ZVOL_OPCODE_SNAP_PREPARE) ||
 	    (hdr->opcode == ZVOL_OPCODE_SNAP_DESTROY) ||
 	    (hdr->opcode == ZVOL_OPCODE_STATS) ||
 	    (hdr->opcode == ZVOL_OPCODE_START_REBUILD) ||
@@ -315,6 +316,12 @@ handle_snap_opcode(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 		REPLICA_ERRLOG("name mismatch %s %s\n",
 			(char *)zio_cmd->buf, rargs->volname);
 		exit(1);
+	}
+
+	//TODO handle the success/fail resopnse
+	if (hdr->opcode == ZVOL_OPCODE_SNAP_PREPARE) {
+		hdr->status = ZVOL_OP_STATUS_OK;
+		goto send_response;
 	}
 
 	if (hdr->opcode == ZVOL_OPCODE_SNAP_DESTROY) {
@@ -780,6 +787,7 @@ mock_repl_mgmt_worker(void *args)
 				break;
 			case ZVOL_OPCODE_SNAP_CREATE:
 			case ZVOL_OPCODE_SNAP_DESTROY:
+			case ZVOL_OPCODE_SNAP_PREPARE:
 				handle_snap_opcode(rargs, zio_cmd);
 				break;
 			case ZVOL_OPCODE_REPLICA_STATUS:

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -401,6 +401,13 @@ send_mgmt_ack(int fd, zvol_io_hdr_t *mgmt_ack_hdr, void *buf, int *zrepl_status_
 			mgmt_ack_hdr->len = 0;
 			break;
 
+		case ZVOL_OPCODE_SNAP_PREPARE:
+			iovec_count = 3;
+			sleep(random()%3 + 1);
+			mgmt_ack_hdr->status = (random() % 5 == 0) ? ZVOL_OP_STATUS_FAILED : ZVOL_OP_STATUS_OK;
+			mgmt_ack_hdr->len = 0;
+			break;
+
 		case ZVOL_OPCODE_REPLICA_STATUS:
 			zrepl_status.state = ZVOL_STATUS_DEGRADED;
 //			zrepl_status.state = ZVOL_STATUS_HEALTHY;

--- a/src/replication.c
+++ b/src/replication.c
@@ -313,6 +313,7 @@ check_header_sanity(zvol_io_hdr_t *resp_hdr)
 			exp_len = sizeof (zvol_op_stat_t);
 			break;
 		case ZVOL_OPCODE_SNAP_CREATE:
+		case ZVOL_OPCODE_SNAP_PREPARE:
 		case ZVOL_OPCODE_START_REBUILD:
 		case ZVOL_OPCODE_SNAP_DESTROY:
 			exp_len = 0;
@@ -1363,6 +1364,19 @@ handle_snap_create_resp(replica_t *replica, mgmt_cmd_t *mgmt_cmd)
 		free(rcomm_mgmt);
 }
 
+static void
+handle_snap_prepare_resp(replica_t *replica, mgmt_cmd_t *mgmt_cmd)
+{
+	zvol_io_hdr_t *hdr = replica->mgmt_io_resp_hdr;
+	rcommon_mgmt_cmd_t *rcomm_mgmt = mgmt_cmd->rcomm_mgmt;
+	MTX_LOCK(&rcomm_mgmt->mtx);
+	if (hdr->status != ZVOL_OP_STATUS_OK)
+		rcomm_mgmt->cmds_failed++;
+	else
+		rcomm_mgmt->cmds_succeeded++;
+	MTX_UNLOCK(&rcomm_mgmt->mtx);
+}
+
 static int
 send_replica_snapshot(spec_t *spec, replica_t *replica, uint64_t io_seq,
     char *snapname, zvol_op_code_t opcode, rcommon_mgmt_cmd_t *rcomm_mgmt)
@@ -1582,18 +1596,45 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 		return false;
 	}
 
+	io_seq = ++spec->io_seq;
+
+	rcommon_mgmt_cmd_t *rmgmt = allocate_rcommon_mgmt_cmd(0);
+	TAILQ_FOREACH(replica, &spec->rq, r_next) {
+		(void) send_replica_snapshot(spec, replica, io_seq, snapname, ZVOL_OPCODE_SNAP_PREPARE, rmgmt);
+	}
+
+	timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
+	MTX_LOCK(&rmgmt->mtx);
+
+	while (diff.tv_sec < wait_time) {
+		if ((rmgmt->cmds_sent == rmgmt->cmds_succeeded) ||
+		    rmgmt->cmds_failed)
+			break;
+		MTX_UNLOCK(&rmgmt->mtx);
+		MTX_UNLOCK(&spec->rq_mtx);
+		sleep(1);
+		MTX_LOCK(&spec->rq_mtx);
+		MTX_LOCK(&rmgmt->mtx);
+		timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
+	}
+	MTX_UNLOCK(&rmgmt->mtx);
+
+	if (rmgmt->cmds_sent != rmgmt->cmds_succeeded) {
+		MTX_UNLOCK(&spec->rq_mtx);
+		free(rmgmt);
+		return (false);
+	}
+
 	rcomm_mgmt = allocate_rcommon_mgmt_cmd(0);
 	free_rcomm_mgmt = 0;
 
 	r = false;
-	io_seq = ++spec->io_seq;
 	TAILQ_FOREACH(replica, &spec->rq, r_next) {
 		(void) send_replica_snapshot(spec, replica, io_seq, snapname, ZVOL_OPCODE_SNAP_CREATE, rcomm_mgmt);
 	}
 
 	uint8_t cf = spec->consistency_factor;
 
-	timesdiff(CLOCK_MONOTONIC_COARSE, last, now, diff);
 	MTX_LOCK(&rcomm_mgmt->mtx);
 
 	while (diff.tv_sec < wait_time) {
@@ -1636,6 +1677,7 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 		REPLICA_ERRLOG("snap create ioseq: %lu resp: %d\n", io_seq, r);
 	if (free_rcomm_mgmt == 1)
 		free(rcomm_mgmt);
+	free(rmgmt);
 	return r;
 }
 
@@ -2371,6 +2413,15 @@ read_io_resp_hdr:
 					handle_snap_create_resp(replica, mgmt_cmd);
 					break;
 
+				case ZVOL_OPCODE_SNAP_PREPARE:
+					/*
+					 * snap create response must come from
+					 * mgmt connection
+					 */
+					assert(fd != replica->iofd);
+					handle_snap_prepare_resp(replica, mgmt_cmd);
+					break;
+
 				case ZVOL_OPCODE_START_REBUILD:
 					assert(fd != replica->iofd);
 					handle_start_rebuild_resp(spec, resp_hdr);
@@ -2517,6 +2568,9 @@ empty_mgmt_q_of_replica(replica_t *r)
 			switch (mgmt_cmd->io_hdr->opcode) {
 				case ZVOL_OPCODE_SNAP_CREATE:
 					handle_snap_create_resp(r, mgmt_cmd);
+					break;
+				case ZVOL_OPCODE_SNAP_PREPARE:
+					handle_snap_prepare_resp(r, mgmt_cmd);
 					break;
 				case ZVOL_OPCODE_PREPARE_FOR_REBUILD:
 					handle_prepare_for_rebuild_resp(r->spec,

--- a/src/replication.c
+++ b/src/replication.c
@@ -1659,6 +1659,16 @@ int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int io_wait_time, int
 	} else if (success < sent) {
 		REPLICA_ERRLOG("snap prep partial failure, success=%d sent=%d rf=%d\n",
 		    success, sent, spec->replication_factor);
+		/*
+		 * If there is partial failure of SNAP_PREP opcode, there will be
+		 * some replica on which SNAP_PREP is successful and if we try to
+		 * do SNAP_PREP for other snapshot command then it will fail.
+		 * Aborting it here as when replica will connect again, SNAP_PREP
+		 * will be reset.
+		 * Ideally we have to disconnect the replicas where this
+		 * command is successful, since we lack that info as of now, so
+		 * aborting is OK as SNAP_PREP will fail rarely.
+		 */
 		abort();
 	}
 

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -270,7 +270,8 @@ send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
 		iovec_count = 1;
 		mgmt_ack_hdr->status = (random() % 2) ? ZVOL_OP_STATUS_FAILED : ZVOL_OP_STATUS_OK;
 		mgmt_ack_hdr->len = 0;
-	} else if (opcode == ZVOL_OPCODE_SNAP_CREATE) {
+	} else if (opcode == ZVOL_OPCODE_SNAP_CREATE ||
+	    opcode == ZVOL_OPCODE_SNAP_PREPARE) {
 		iovec_count = 1;
 		sleep(random()%3 + 1);
 		mgmt_ack_hdr->status = (random() % 5 == 0) ? ZVOL_OP_STATUS_FAILED : ZVOL_OP_STATUS_OK;


### PR DESCRIPTION
AFS mode and we get a snpashot request from the user,
there is a race that if snapshot command is received
after we decided to do AFS transition, we will miss or
have the inconsistant snapshot.

Here traget it self will send prepare snapshot comand to make
each replica ready to receive the snapshot command and then it will
send the command.

Signed-off-by: Pawan <pawan@mayadata.io>