### PR TITLE
feat (Resize): support for resizing volumes via resize command

### DIFF
--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -658,7 +658,6 @@ istgt_uctl_cmd_resize(UCTL_Ptr uctl)
 		r = istgt_lu_resize_volume(spec, new_size);
 
 		if (r == true) {
-			ISTGT_LOG("Successfully resized volume %s to %s size\n", volname, size_str);
 			istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);
 			ret = UCTL_CMD_OK;
 			lu->lun[0].u.storage.size = new_size;

--- a/src/istgt_proto.h
+++ b/src/istgt_proto.h
@@ -107,6 +107,7 @@ ISTGT_LU_Ptr istgt_lu_find_target(ISTGT_Ptr istgt, const char *target_name);
 ISTGT_LU_Ptr istgt_lu_find_target_by_volname(ISTGT_Ptr istgt, const char *target_name);
 #ifdef	REPLICATION
 int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int, int);
+int istgt_lu_resize_volume(spec_t *spec, size_t size);
 int istgt_lu_destroy_snapshot(spec_t *spec, char *snapname);
 void istgt_lu_mempool_stats(char **resp);
 void istgt_lu_replica_stats(char *volname, char **resp);

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -932,11 +932,6 @@ exec_resize(UCTL_Ptr uctl)
 		strupr(result);
 		if (strcmp(result, uctl->cmd) != 0)
 			break;
-		if (uctl->iqn != NULL) {
-			printf("%s\n", arg);
-		} else {
-			printf("%s\n", arg);
-		}
 	}
 	if (strcmp(result, "OK") != 0) {
 		if (is_err_req_auth(uctl, arg))

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -905,6 +905,59 @@ exec_snap(UCTL_Ptr uctl)
 }
 
 static int
+exec_resize(UCTL_Ptr uctl)
+{
+	const char *delim = ARGS_DELIM;
+	char *arg, *result;
+	int rc = 0, wait_time, io_wait_time;
+	char *name = uctl->setargv[0];
+	char *size = uctl->setargv[1];
+
+	if (uctl->setargcnt >= 3)
+		io_wait_time = atoi(uctl->setargv[2]);
+	else
+		io_wait_time = 10;
+
+	if (uctl->setargcnt >= 4)
+		wait_time = atoi(uctl->setargv[3]);
+	else
+		wait_time = 30;
+
+	uctl_snprintf(uctl, "%s \"%s\" \"%s\" \"%d\" \"%d\"\n",
+		uctl->cmd, name, size, io_wait_time, wait_time);
+
+	rc = uctl_writeline(uctl);
+	if (rc != UCTL_CMD_OK) {
+		return (rc);
+	}
+
+		/* receive result */
+	while (1) {
+		rc = uctl_readline(uctl);
+		if (rc != UCTL_CMD_OK) {
+			return (rc);
+		}
+		arg = trim_string(uctl->recvbuf);
+		result = strsepq(&arg, delim);
+		strupr(result);
+		if (strcmp(result, uctl->cmd) != 0)
+			break;
+		if (uctl->iqn != NULL) {
+			printf("%s\n", arg);
+		} else {
+			printf("%s\n", arg);
+		}
+	}
+	if (strcmp(result, "OK") != 0) {
+		if (is_err_req_auth(uctl, arg))
+			return (UCTL_CMD_REQAUTH);
+		fprintf(stderr, "ERROR %s\n", arg);
+		return (UCTL_CMD_ERR);
+	}
+	return (UCTL_CMD_OK);
+}
+
+static int
 exec_mempool_stats(UCTL_Ptr uctl)
 {
 	const char *delim = ARGS_DELIM;
@@ -1294,6 +1347,7 @@ static EXEC_TABLE exec_table[] =
 #ifdef	REPLICATION
 	{"SNAPCREATE", exec_snap, 2, 0},
 	{"SNAPDESTROY", exec_snap, 2, 0},
+	{"RESIZE", exec_resize, 2, 0},
 	{"REPLICA", exec_replica, 0, 0},
 	{"MAXIOWAIT", exec_max_io_wait, 0, 0},
 #endif
@@ -1783,6 +1837,7 @@ usage(void)
 	printf(" replica    list replica and its stats\n");
 	printf(" mempool    get mempool details\n");
 	printf(" maxiowait  get/set wait time for IO completion in seconds\n");
+	printf(" resize     read the size from command cli and updates the size\n");
 #endif
 	printf(" set        set values for variables:\n");
 	printf("            Syntax: istgtcontrol -t <iqn(ALL to set globally)> \
@@ -2059,7 +2114,8 @@ main(int argc, char *argv[])
 	if ((strcmp(cmd, "SNAPCREATE") == 0) ||
 	(strcmp(cmd, "SNAPDESTROY") == 0) ||
 	    (strcmp(cmd, "REPLICA") == 0) ||
-	    (strcmp(cmd, "MAXIOWAIT") == 0)) {
+	    (strcmp(cmd, "MAXIOWAIT") == 0) ||
+	    (strcmp(cmd, "RESIZE") == 0)) {
 		uctl->setargv = argv;
 		uctl->setargcnt = argc;
 	}

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -909,22 +909,12 @@ exec_resize(UCTL_Ptr uctl)
 {
 	const char *delim = ARGS_DELIM;
 	char *arg, *result;
-	int rc = 0, wait_time, io_wait_time;
+	int rc = 0;
 	char *name = uctl->setargv[0];
 	char *size = uctl->setargv[1];
 
-	if (uctl->setargcnt >= 3)
-		io_wait_time = atoi(uctl->setargv[2]);
-	else
-		io_wait_time = 10;
-
-	if (uctl->setargcnt >= 4)
-		wait_time = atoi(uctl->setargv[3]);
-	else
-		wait_time = 30;
-
-	uctl_snprintf(uctl, "%s \"%s\" \"%s\" \"%d\" \"%d\"\n",
-		uctl->cmd, name, size, io_wait_time, wait_time);
+	uctl_snprintf(uctl, "%s \"%s\" \"%s\" \n",
+		uctl->cmd, name, size);
 
 	rc = uctl_writeline(uctl);
 	if (rc != UCTL_CMD_OK) {

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -317,6 +317,9 @@ send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
 		iovec[1].iov_base = &stats;
 		iovec[1].iov_len = sizeof (zvol_op_stat_t);
 		iovec_count = 2;
+	} else if (opcode == ZVOL_OPCODE_RESIZE) {
+		mgmt_ack_hdr->len = 0;
+		iovec_count = 1;
 	} else {
 		build_mgmt_ack_data;
 

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -57,7 +57,7 @@ logout_of_volume() {
 }
 
 get_scsi_disk() {
-	device_name=$($ISCSIADM -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
+	local device_name=$($ISCSIADM -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
 	i=0
 	while [ -z $device_name ]; do
 		sleep 5
@@ -71,6 +71,7 @@ get_scsi_disk() {
 			continue;
 		fi
 	done
+	echo $device_name
 }
 
 start_istgt() {
@@ -123,7 +124,7 @@ run_istgt_integration()
 
 run_and_verify_iostats() {
 	login_to_volume "$CONTROLLER_IP:3260"
-	get_scsi_disk
+	local device_name=$(get_scsi_disk)
 	if [ "$device_name"!="" ]; then
 		sudo mkfs.ext4 -F /dev/$device_name
 		[[ $? -ne 0 ]] && echo "mkfs failed for $device_name" && exit 1
@@ -169,7 +170,7 @@ run_and_verify_iostats() {
 write_and_verify_data(){
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 5
-	get_scsi_disk
+	local device_name=$(get_scsi_disk)
 	if [ "$device_name"!="" ]; then
 		mkfs.ext4 -F /dev/$device_name
 		[[ $? -ne 0 ]] && echo "mkfs failed for $device_name" && tail -20 $LOGFILE && exit 1
@@ -219,7 +220,8 @@ write_data()
 setup_test_env() {
 	rm -f /tmp/test_vol*
 	mkdir -p /mnt/store
-	truncate -s 5G /tmp/test_vol1 /tmp/test_vol2 /tmp/test_vol3 $1
+	## We are doing resize to 7G
+	truncate -s 7G /tmp/test_vol1 /tmp/test_vol2 /tmp/test_vol3 $1
 	logout_of_volume
 	sudo killall -9 istgt
 	sudo killall -9 replication_test
@@ -369,6 +371,7 @@ run_read_consistency_test ()
 	local file_name="/root/data_file"
 	local device_file="/root/device_file"
 	local w_pid
+	local device_name=""
 
 	# Test to check if replication module is not initialized then
 	# istgtcontrol should return an error
@@ -403,7 +406,7 @@ run_read_consistency_test ()
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 5
 
-	get_scsi_disk
+	device_name=$(get_scsi_disk)
 	if [ "$device_name" == "" ]; then
 		echo "error happened while running read consistency test"
 		pkill -9 -P $replica1_pid
@@ -788,6 +791,7 @@ run_non_quorum_replica_errored_test()
 	local replica1_vdev="/tmp/test_vol1"
 	local replica2_vdev="/tmp/test_vol2"
 	local replica3_vdev="/tmp/test_vol3"
+	local device_name=""
 
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
@@ -808,7 +812,7 @@ run_non_quorum_replica_errored_test()
 
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 5
-	get_scsi_disk
+	device_name=$(get_scsi_disk)
 
 	if [ "$device_name"!="" ]; then
 		mkfs.ext4 -F /dev/$device_name
@@ -892,8 +896,39 @@ kill_non_quorum_replica()
 	echo "Erroring out replica done successfully"
 }
 
+## verify_resize_command will expects the device name to be passed
+verify_resize_command()
+{
+	local disk_name=$1
+	local CONF_FILE="/usr/local/etc/istgt/istgt.conf"
+	old_size=$(lsblk | grep $disk_name |awk -F ' ' '{print $4+0}')
+	new_size=$(( $old_size + 2 ))
+	vol_name=$(cat $CONF_FILE | grep TargetName | awk '{print $2}')
+	$ISTGTCONTROL resize $vol_name "${new_size}G"
+	if [ $? -ne 0 ]
+	then
+		echo "Failed to resize the volume"
+		exit 1
+	else
+		sed -i "s|LUN0 Storage.*|LUN0 Storage ${new_size}G 32k|g" $CONF_FILE
+		sleep 3
+	fi
+	sleep 2
+
+	##Rescan the iscsi session
+	$ISCSIADM -m node -R
+	disk_size=$(lsblk | grep $disk_name |awk -F ' ' '{print $4+0}')
+	if [ $disk_size -ne $new_size ]; then
+		echo "LUN resize failed"
+		exit 1
+	fi
+	echo "Resize passed"
+	sleep 2
+}
+
 data_integrity_with_non_quorum()
 {
+	local device_name=""
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
@@ -924,7 +959,7 @@ data_integrity_with_non_quorum()
 
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 10
-	get_scsi_disk
+	device_name=$(get_scsi_disk)
 
 
 
@@ -966,6 +1001,8 @@ data_integrity_with_non_quorum()
 		sleep 10
 		exit 1
 	fi
+
+	verify_resize_command $device_name
 
 	pkill -9 -P $replica3_pid
 
@@ -1291,6 +1328,7 @@ run_test_env()
 	TEST_ENV=1
 	setup_test_env
 
+	$ISTGTCONTROL dump -a
 	cnt=$(eval $ISTGTCONTROL dump -a | grep "Luworkers:9" | wc -l)
 	if [ $? -ne 0 ] || [ $cnt -ne 1 ]
 	then
@@ -1322,6 +1360,7 @@ run_io_timeout_test()
 	local replica3_ip="127.0.0.1"
 	local replica1_vdev="/tmp/test_vol1"
 	local injected_latency=10
+	local device_name=""
 
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
@@ -1343,7 +1382,7 @@ run_io_timeout_test()
 	sleep 2
 
 	login_to_volume "$CONTROLLER_IP:3260"
-	get_scsi_disk
+	device_name=$(get_scsi_disk)
 	if [ "$device_name"!="" ]; then
 		# Test to verify impact of replica's delay on volume latency
 		sudo kill -9 $replica1_pid

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -974,7 +974,7 @@ data_integrity_with_non_quorum()
 		exit 1
 	fi
 
-	if [ "$device_name"!="" ]; then
+	if [ "$device_name" != "" ]; then
 		sudo dd if=/dev/urandom of=$device_name bs=4k count=1000 oflag=direct
                 var1="$($ISTGTCONTROL -q iostats | jq '.TotalWriteBytes')"
 		sleep 5


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
**What this PR does**:
 This PR supports the volume resize command(with basic working flow).
 
- **Adds volume resize support in target**
Steps to resize the volume:
    1. Execute istgtcontrol resize <vol_name> \<size> command to update TARGET in-memory config and underlying volumes. On error, its returns `ERROR failed RESIZE`.
    2. Update ISTGT config file (istgt.conf) with updated size.

- **To get updated size at client side:**
     1. Execute: `sudo iscsiadm -m node -R`.
     2. Execute: `resize2fs <device_name>`

- **Adds unit test to verify volume resize**