### PR TITLE
feat(replication): add support to scale up replicas

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -61,7 +61,7 @@ ctl_header = istgt_ver.h istgt_conf.h istgt_log.h istgt_sock.h istgt_misc.h \
 	istgt_md5.h
 
 istgt_integration_source  = istgt_integration_test.c mock_client.c replication.c replication_misc.c rte_ring.c \
-	ring_mempool.c data_conn.c istgt_misc.c mock_errored_replica.c
+	ring_mempool.c data_conn.c istgt_misc.c mock_errored_replica.c istgt_sock.c
 
 replication_test_source   = replication_test.c replication_misc.c
 replication_test_header   = replication.h istgt_integration.h

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -308,7 +308,7 @@ handle_data_conn_error(replica_t *r)
 			}
 
 	if (r1 == NULL) {
-		REPLICA_ERRLOG("replica %s %d not part of rq and non_rq list..\n",
+		REPLICA_ERRLOG("replica(%s:%d) not part of rq and non_rq list..\n",
 		    r->ip, r->port);
 		MTX_LOCK(&r->r_mtx);
 		/*

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -303,7 +303,6 @@ handle_data_conn_error(replica_t *r)
 	if (r1 == NULL)
 		TAILQ_FOREACH(r1, &(spec->non_quorum_rq), r_non_quorum_next)
 			if (r1 == r) {
-				assert(r->quorum == 0);
 				found_in_list = 2;
 				break;
 			}

--- a/src/init.sh
+++ b/src/init.sh
@@ -15,13 +15,14 @@ do
 	VALUE=$(echo $ARGUMENT | cut -f2 -d=)
 
 	case "$KEY" in
-		volname)		volname=${VALUE} ;;
-		portal)			portal=${VALUE} ;;
-		size)			size=${VALUE} ;;
-		externalIP)		externalIP=${VALUE} ;;
-		replication_factor)	replication_factor=${VALUE} ;;
-		consistency_factor)	consistency_factor=${VALUE} ;;
-		test_env)		test_env=${VALUE} ;;
+		volname)			volname=${VALUE} ;;
+		portal)				portal=${VALUE} ;;
+		size)				size=${VALUE} ;;
+		externalIP)			externalIP=${VALUE} ;;
+		desired_replication_factor)	desired_replication_factor=${VALUE} ;;
+		replication_factor)		replication_factor=${VALUE} ;;
+		consistency_factor)		consistency_factor=${VALUE} ;;
+		test_env)			test_env=${VALUE} ;;
 		*)
 	esac
 done
@@ -54,6 +55,7 @@ fi
 sed -i "s|TargetName.*|TargetName $volname|g" $CONF_FILE
 sed -i "s|ReplicationFactor.*|ReplicationFactor $replication_factor|g" $CONF_FILE
 sed -i "s|ConsistencyFactor.*|ConsistencyFactor $consistency_factor|g" $CONF_FILE
+sed -i "s|DesiredReplicationFactor.*|DesiredReplicationFactor $desired_replication_factor|g" $CONF_FILE
 sed -i "s|TargetAlias.*|TargetAlias nicknamefor-$volname|g" $CONF_FILE
 sed -i "s|Portal UC1.*|Portal UC1 $portal:3261|g" $CONF_FILE
 sed -i "s|Portal DA1.*|Portal DA1 $portal:3260|g" $CONF_FILE

--- a/src/istgt.conf
+++ b/src/istgt.conf
@@ -50,6 +50,7 @@
   ReadOnly No
   ReplicationFactor 3
   ConsistencyFactor 2
+  DesiredReplicationFactor 3
   UnitType Disk
   UnitOnline Yes
   BlockLength 4096

--- a/src/istgt.h
+++ b/src/istgt.h
@@ -165,6 +165,9 @@
 
 #define ISTGT_UCTL_UNXPATH "/var/run/istgt_ctl_sock"
 
+/* Update sock file path */
+#define ISTGT_SEND_UNXPATH "/tmp/temp.sock"
+
 #define MTX_LOCK(MTX) \
 	do {								\
 		int _rc_;							\

--- a/src/istgt.h
+++ b/src/istgt.h
@@ -165,7 +165,7 @@
 
 #define ISTGT_UCTL_UNXPATH "/var/run/istgt_ctl_sock"
 
-/* Update sock file path */
+// Sock file used to communicate from target to side car
 #define ISTGT_SEND_UNXPATH "/var/run/volume_mgmt_sock"
 
 #define MTX_LOCK(MTX) \

--- a/src/istgt.h
+++ b/src/istgt.h
@@ -166,7 +166,7 @@
 #define ISTGT_UCTL_UNXPATH "/var/run/istgt_ctl_sock"
 
 // Sock file used to communicate from target to side car
-#define ISTGT_SEND_UNXPATH "/var/run/volume_mgmt_sock"
+#define ISTGT_MGMT_UNXPATH "/var/run/volume_mgmt_sock"
 
 #define MTX_LOCK(MTX) \
 	do {								\

--- a/src/istgt.h
+++ b/src/istgt.h
@@ -166,7 +166,7 @@
 #define ISTGT_UCTL_UNXPATH "/var/run/istgt_ctl_sock"
 
 /* Update sock file path */
-#define ISTGT_SEND_UNXPATH "/tmp/temp.sock"
+#define ISTGT_SEND_UNXPATH "/var/run/volume_mgmt_sock"
 
 #define MTX_LOCK(MTX) \
 	do {								\

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -75,7 +75,8 @@ typedef struct replica_s {
 	char *ip;
 	uint64_t pool_guid;
 	uint64_t zvol_guid;
-	char replica_id[REPLICA_ID_LEN]; //UID to identify replica
+	/* extra byte for printing and strlen functions */
+	char replica_id[REPLICA_ID_LEN + 1]; //UID to identify replica
 
 	/* payload for current IO response for a replica */
 	void *ongoing_io_buf;

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -104,6 +104,9 @@ typedef struct replica_s {
 
 	int dont_free;
 
+	/* Information to know whether update is success or not */
+	int update_as_known_replica;
+
 	struct timespec create_time;
 
 	/* This is calculated from create time till the queued time into readyQ */

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -105,7 +105,7 @@ typedef struct replica_s {
 	int dont_free;
 
 	/* Information to know whether update is success or not */
-	int update_as_known_replica;
+	bool updated_as_known_replica;
 
 	struct timespec create_time;
 

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -75,6 +75,7 @@ typedef struct replica_s {
 	char *ip;
 	uint64_t pool_guid;
 	uint64_t zvol_guid;
+	char *replica_id; //UID to identify replica
 
 	/* payload for current IO response for a replica */
 	void *ongoing_io_buf;

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -104,9 +104,6 @@ typedef struct replica_s {
 
 	int dont_free;
 
-	/* Information to know whether update is success or not */
-	bool updated_as_known_replica;
-
 	struct timespec create_time;
 
 	/* This is calculated from create time till the queued time into readyQ */

--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -75,7 +75,7 @@ typedef struct replica_s {
 	char *ip;
 	uint64_t pool_guid;
 	uint64_t zvol_guid;
-	char *replica_id; //UID to identify replica
+	char replica_id[REPLICA_ID_LEN]; //UID to identify replica
 
 	/* payload for current IO response for a replica */
 	void *ongoing_io_buf;

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -78,7 +78,7 @@ typedef struct rargs_s {
 	char replica_ip[MAX_IP_LEN];
 	uint16_t replica_port;
 	uint64_t zvol_guid;
-	char replica_id[MAX_NAME_LEN];
+	char replica_id[REPLICA_ID_LEN];
 
 	/* IP:Port on which controller is listening */
 	char ctrl_ip[MAX_IP_LEN];

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -37,6 +37,7 @@
 __thread char tinfo[50] = {0};
 int g_trace_flag = 0;
 pthread_t new_replica[10] = { 0 };
+int desired_replication_factor = 3;
 int replication_factor = 3, consistency_factor = 2;
 int new_replica_count = 3;	/* Assign same number as replication factor */
 
@@ -1490,7 +1491,7 @@ main(int argc, char **argv)
 		return (1);
 	}
 
-	initialize_volume(spec, replication_factor, consistency_factor);
+	initialize_volume(spec, replication_factor, consistency_factor, desired_replication_factor);
 
 	pthread_create(&replica_thread, NULL, &init_replication, (void *)NULL);
 

--- a/src/istgt_integration_test.c
+++ b/src/istgt_integration_test.c
@@ -239,10 +239,10 @@ static void
 handle_replica_start_rebuild(rargs_t *rargs, zvol_io_cmd_t *zio_cmd)
 {
 	zvol_io_hdr_t *hdr = &(zio_cmd->hdr);
-	mgmt_ack_t *mgmt_ack_data = (mgmt_ack_t *)zio_cmd->buf;
+	rebuild_req_t *rebuild_req = (rebuild_req_t *)zio_cmd->buf;
 
 	/* Mark rebuild is in progress */
-	if ((strcmp(mgmt_ack_data->volname, "")) == 0) {
+	if ((strcmp(rebuild_req->volname, "")) == 0) {
 		rargs->zrepl_status = ZVOL_STATUS_HEALTHY;
 		rargs->zrepl_rebuild_status = ZVOL_REBUILDING_DONE;
 	} else {

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -1772,9 +1772,9 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 	/* Read trusty replica details from conf file and maintain in memory structure*/
 	val = istgt_get_val(sp, "Replica");
 	if (val == NULL) {
-		TAILQ_INIT(&lu->trusty_replica);
+		TAILQ_INIT(&lu->trusty_replicas);
 	} else {
-		TAILQ_INIT(&lu->trusty_replica);
+		TAILQ_INIT(&lu->trusty_replicas);
 		for (i=0; ; i++) {
 			key = istgt_get_nmval(sp, "Replica", i, 0);
 			if (key == NULL) {
@@ -1787,21 +1787,21 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 			trusty_replica->replica_id = (char *)malloc(sizeof(char)*len);
 			if (trusty_replica->replica_id == NULL) {
 				ISTGT_ERRLOG("failed to allocate memory"
-				    " for known replicaId %s\n", key);
+				    " for trusty replica %s\n", key);
 			}
 			memset(trusty_replica->replica_id, 0, len);
 			strncpy(trusty_replica->replica_id, key, len-1);
 			trusty_replica->zvol_guid = (uint64_t) strtol(val, NULL, 10);
-			TAILQ_INSERT_TAIL(&lu->trusty_replica, trusty_replica, next);
-			ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "known replica key {%s} and"
+			TAILQ_INSERT_TAIL(&lu->trusty_replicas, trusty_replica, next);
+			ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "trusty replica key {%s} and"
 			    " zvol guid {%lu}\n",trusty_replica->replica_id, trusty_replica->zvol_guid);
 		}
 	}
 	// It is useful in case where multiple copies of data
-	// is lost and to reconstruct the data into other replicas
+	// is lost and to reconstruct the data from other replicas
 	// RF and CF will be updated to correspondig values
 	if (i > lu->desired_replication_factor) {
-		ISTGT_ERRLOG("known replica count %d is greater than desired replication factor %d\n",
+		ISTGT_ERRLOG("trusty replica count %d is greater than desired replication factor %d\n",
 		    i, lu->replication_factor);
 		goto error_return;
 	}
@@ -2381,9 +2381,9 @@ error_return:
 	}
 #ifdef REPLICATION
 	/* Releasing in memory details */
-	while (trusty_replica = TAILQ_FIRST(&lu->trusty_replica)) {
+	while (trusty_replica = TAILQ_FIRST(&lu->trusty_replicas)) {
 		xfree(trusty_replica->replica_id);
-                TAILQ_REMOVE(&lu->trusty_replica, trusty_replica, next);
+                TAILQ_REMOVE(&lu->trusty_replicas, trusty_replica, next);
                 xfree(trusty_replica);
         }
 #endif

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -1769,11 +1769,15 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 		goto error_return;
 	}
 	/* Read trusty replica details from conf file and maintain in memory structure*/
+	/* Replica configuration in istgt conf file looks like
+	 * Replica 6061 6061
+	 * Replica 6062 6062
+	 * Replica 6063 6063
+	 */
 	val = istgt_get_val(sp, "Replica");
-	if (val == NULL) {
-		TAILQ_INIT(&lu->trusty_replicas);
-	} else {
-		TAILQ_INIT(&lu->trusty_replicas);
+	i = 0;
+	TAILQ_INIT(&lu->trusty_replicas);
+	if (val != NULL) {
 		for (i=0; ; i++) {
 			key = istgt_get_nmval(sp, "Replica", i, 0);
 			if (key == NULL) {

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -1783,14 +1783,15 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 			trusty_replica = xmalloc(sizeof (trusty_replica_t));
 			memset(trusty_replica, 0, sizeof(trusty_replica_t));
 			val = istgt_get_nmval(sp, "Replica", i, 1);
-			len = strlen(key) + 1;
-			trusty_replica->replica_id = (char *)malloc(sizeof(char)*len);
+			len = strlen(key);
+			trusty_replica->replica_id = xmalloc(len + 1);
 			if (trusty_replica->replica_id == NULL) {
 				ISTGT_ERRLOG("failed to allocate memory"
 				    " for trusty replica %s\n", key);
+				goto error_return;
 			}
-			memset(trusty_replica->replica_id, 0, len);
-			strncpy(trusty_replica->replica_id, key, len-1);
+			memset(trusty_replica->replica_id, 0, len + 1);
+			strncpy(trusty_replica->replica_id, key, len);
 			trusty_replica->zvol_guid = (uint64_t) strtol(val, NULL, 10);
 			TAILQ_INSERT_TAIL(&lu->trusty_replicas, trusty_replica, next);
 			ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "trusty replica key {%s} and"

--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -1466,7 +1466,6 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 	int nbs;
 	int i, j, k;
 	int rc;
-	int len;
 	int gotstorage = 0;
 #ifdef REPLICATION
 	trusty_replica_t *trusty_replica;
@@ -1783,15 +1782,7 @@ istgt_lu_add_unit(ISTGT_Ptr istgt, CF_SECTION *sp)
 			trusty_replica = xmalloc(sizeof (trusty_replica_t));
 			memset(trusty_replica, 0, sizeof(trusty_replica_t));
 			val = istgt_get_nmval(sp, "Replica", i, 1);
-			len = strlen(key);
-			trusty_replica->replica_id = xmalloc(len + 1);
-			if (trusty_replica->replica_id == NULL) {
-				ISTGT_ERRLOG("failed to allocate memory"
-				    " for trusty replica %s\n", key);
-				goto error_return;
-			}
-			memset(trusty_replica->replica_id, 0, len + 1);
-			strncpy(trusty_replica->replica_id, key, len);
+			strncpy(trusty_replica->replica_id, key, REPLICA_ID_LEN);
 			trusty_replica->zvol_guid = (uint64_t) strtol(val, NULL, 10);
 			TAILQ_INSERT_TAIL(&lu->trusty_replicas, trusty_replica, next);
 			ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "trusty replica key {%s} and"
@@ -2383,7 +2374,6 @@ error_return:
 #ifdef REPLICATION
 	/* Releasing in memory details */
 	while (trusty_replica = TAILQ_FIRST(&lu->trusty_replicas)) {
-		xfree(trusty_replica->replica_id);
                 TAILQ_REMOVE(&lu->trusty_replicas, trusty_replica, next);
                 xfree(trusty_replica);
         }

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -353,7 +353,7 @@ typedef struct istgt_lu_t {
 typedef ISTGT_LU *ISTGT_LU_Ptr;
 
 typedef struct trusty_replica_s {
-	char *replica_id;
+	char replica_id[REPLICA_ID_LEN];
 	uint64_t zvol_guid;
 	TAILQ_ENTRY(trusty_replica_s) next;
 } trusty_replica_t;
@@ -887,7 +887,10 @@ typedef struct istgt_lu_disk_t {
 		bool rebuild_in_progress;
 	} rebuild_info;
 
-	struct replica_s *transition_replica;
+	/* scaleup_replica will set during scaleup replica cases
+	 * when consistency changes
+	 */
+	struct replica_s *scaleup_replica;
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/
 	pthread_mutex_t rq_mtx; 

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -347,9 +347,16 @@ typedef struct istgt_lu_t {
 	uint8_t replication_factor;
 	uint8_t desired_replication_factor;
 	uint8_t consistency_factor;
+	TAILQ_HEAD(, trusty_replica_s) known_replica_head; //Contains list of known replicas
 #endif
 } ISTGT_LU;
 typedef ISTGT_LU *ISTGT_LU_Ptr;
+
+typedef struct trusty_replica_s {
+	char *replica_id;
+	uint64_t zvol_guid;
+	TAILQ_ENTRY(trusty_replica_s) next;
+} trusty_replica_t;
 
 typedef enum {
 	ISTGT_TAG_UNTAGGED,
@@ -892,8 +899,6 @@ typedef struct istgt_lu_disk_t {
 		uint64_t	used;
 		struct timespec	updated_stats_time;
 	} stats;
-	/* To maintain in memory replica uid's */
-	uint64_t known_replicas_uid[MAXREPLICA];
 #endif
 
 	/*Queue containing all the tasks. Instead of going to separate 

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -892,6 +892,8 @@ typedef struct istgt_lu_disk_t {
 		uint64_t	used;
 		struct timespec	updated_stats_time;
 	} stats;
+	/* To maintain in memory replica uid's */
+	uint64_t known_replicas_uid[MAXREPLICA];
 #endif
 
 	/*Queue containing all the tasks. Instead of going to separate 

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -347,7 +347,7 @@ typedef struct istgt_lu_t {
 	uint8_t replication_factor;
 	uint8_t desired_replication_factor;
 	uint8_t consistency_factor;
-	TAILQ_HEAD(, trusty_replica_s) trusty_replica; //Contains list of trusty replicas
+	TAILQ_HEAD(, trusty_replica_s) trusty_replicas; //Contains list of trusty replicas
 #endif
 } ISTGT_LU;
 typedef ISTGT_LU *ISTGT_LU_Ptr;
@@ -887,6 +887,7 @@ typedef struct istgt_lu_disk_t {
 		bool rebuild_in_progress;
 	} rebuild_info;
 
+	struct replica_s *transition_replica;
 	/*Common for both the above queues,
 	Since same cmd is part of both the queues*/
 	pthread_mutex_t rq_mtx; 

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -354,7 +354,7 @@ typedef ISTGT_LU *ISTGT_LU_Ptr;
 
 #ifdef REPLICATION
 typedef struct trusty_replica_s {
-	char replica_id[REPLICA_ID_LEN];
+	char replica_id[REPLICA_ID_LEN + 1];
 	uint64_t zvol_guid;
 	TAILQ_ENTRY(trusty_replica_s) next;
 } trusty_replica_t;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -347,7 +347,7 @@ typedef struct istgt_lu_t {
 	uint8_t replication_factor;
 	uint8_t desired_replication_factor;
 	uint8_t consistency_factor;
-	TAILQ_HEAD(, trusty_replica_s) known_replica; //Contains list of known replicas
+	TAILQ_HEAD(, trusty_replica_s) trusty_replica; //Contains list of trusty replicas
 #endif
 } ISTGT_LU;
 typedef ISTGT_LU *ISTGT_LU_Ptr;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -347,7 +347,7 @@ typedef struct istgt_lu_t {
 	uint8_t replication_factor;
 	uint8_t desired_replication_factor;
 	uint8_t consistency_factor;
-	TAILQ_HEAD(, trusty_replica_s) known_replica_head; //Contains list of known replicas
+	TAILQ_HEAD(, trusty_replica_s) known_replica; //Contains list of known replicas
 #endif
 } ISTGT_LU;
 typedef ISTGT_LU *ISTGT_LU_Ptr;

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -352,11 +352,13 @@ typedef struct istgt_lu_t {
 } ISTGT_LU;
 typedef ISTGT_LU *ISTGT_LU_Ptr;
 
+#ifdef REPLICATION
 typedef struct trusty_replica_s {
 	char replica_id[REPLICA_ID_LEN];
 	uint64_t zvol_guid;
 	TAILQ_ENTRY(trusty_replica_s) next;
 } trusty_replica_t;
+#endif
 
 typedef enum {
 	ISTGT_TAG_UNTAGGED,

--- a/src/istgt_lu.h
+++ b/src/istgt_lu.h
@@ -345,6 +345,7 @@ typedef struct istgt_lu_t {
 	int conns;
 #ifdef REPLICATION
 	uint8_t replication_factor;
+	uint8_t desired_replication_factor;
 	uint8_t consistency_factor;
 #endif
 } ISTGT_LU;
@@ -867,6 +868,7 @@ typedef struct istgt_lu_disk_t {
 	TAILQ_HEAD(, replica_s) rwaitq; //Queue of replicas completed handshake, and yet to have data connection to this spec(volume)
 	TAILQ_HEAD(, replica_s) non_quorum_rq; //Queue of non_quorum replicas connected to this spec
 	TAILQ_HEAD(, known_replica_s) identified_replica;	/* List of replicas known to spec */
+	int desired_replication_factor;
 	int replication_factor;
 	int consistency_factor;
 	int healthy_rcount;

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -730,7 +730,7 @@ istgt_uctl_cmd_desired_rf(UCTL_Ptr uctl)
 	}
 	if (drf == spec->desired_replication_factor) {
 		ISTGT_LOG("desired replication factor is already equal to "
-		    "requested desired replication factor\n", volname);
+		    "requested desired replication factor\n");
 		istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);
 	} else {
 		MTX_LOCK(&spec->rq_mtx);

--- a/src/istgt_lu_disk.c
+++ b/src/istgt_lu_disk.c
@@ -1067,7 +1067,8 @@ istgt_lu_disk_init(ISTGT_Ptr istgt __attribute__((__unused__)), ISTGT_LU_Ptr lu)
 		}
 		istgt_queue_init(&spec->blocked_queue);
 #ifdef REPLICATION
-		rc = initialize_volume(spec, spec->lu->replication_factor, spec->lu->consistency_factor);
+		rc = initialize_volume(spec, spec->lu->replication_factor,
+			spec->lu->consistency_factor, spec->lu->desired_replication_factor);
 		if (rc != 0) {
 			ISTGT_ERRLOG("LU%d: persistent reservation mutex_init() failed errno:%d\n", lu->num, errno);
 			return -1;

--- a/src/istgt_proto.h
+++ b/src/istgt_proto.h
@@ -310,7 +310,7 @@ istgt_lu_set_state(ISTGT_LU_Ptr lu, ISTGT_STATE state)
 }
 
 #ifdef REPLICATION
-//int initialize_volume(spec_t *, int, int);
+//int initialize_volume(spec_t *, int, int, int);
 #endif
 
 #endif /* USE_ATOMIC */

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -905,54 +905,16 @@ exec_snap(UCTL_Ptr uctl)
 }
 
 static int
-exec_resize(UCTL_Ptr uctl)
+exec_command(UCTL_Ptr uctl)
 {
 	const char *delim = ARGS_DELIM;
 	char *arg, *result;
 	int rc = 0;
 	char *name = uctl->setargv[0];
-	char *s_drf = uctl->setargv[1];
+	char *value = uctl->setargv[1];
 
 	uctl_snprintf(uctl, "%s \"%s\" \"%s\" \n",
-		uctl->cmd, name, s_drf);
-
-	rc = uctl_writeline(uctl);
-	if (rc != UCTL_CMD_OK) {
-		return (rc);
-	}
-
-		/* receive result */
-	while (1) {
-		rc = uctl_readline(uctl);
-		if (rc != UCTL_CMD_OK) {
-			return (rc);
-		}
-		arg = trim_string(uctl->recvbuf);
-		result = strsepq(&arg, delim);
-		strupr(result);
-		if (strcmp(result, uctl->cmd) != 0)
-			break;
-	}
-	if (strcmp(result, "OK") != 0) {
-		if (is_err_req_auth(uctl, arg))
-			return (UCTL_CMD_REQAUTH);
-		fprintf(stderr, "ERROR %s\n", arg);
-		return (UCTL_CMD_ERR);
-	}
-	return (UCTL_CMD_OK);
-}
-
-static int
-exec_desired_rf(UCTL_Ptr uctl)
-{
-	const char *delim = ARGS_DELIM;
-	char *arg, *result;
-	int rc = 0;
-	char *name = uctl->setargv[0];
-	char *size = uctl->setargv[1];
-
-	uctl_snprintf(uctl, "%s \"%s\" \"%s\" \n",
-		uctl->cmd, name, size);
+		uctl->cmd, name, value);
 
 	rc = uctl_writeline(uctl);
 	if (rc != UCTL_CMD_OK) {
@@ -1370,8 +1332,8 @@ static EXEC_TABLE exec_table[] =
 #ifdef	REPLICATION
 	{"SNAPCREATE", exec_snap, 2, 0},
 	{"SNAPDESTROY", exec_snap, 2, 0},
-	{"RESIZE", exec_resize, 2, 0},
-	{"DRF", exec_desired_rf, 2, 0},
+	{"RESIZE", exec_command, 2, 0},
+	{"DRF", exec_command, 2, 0},
 	{"REPLICA", exec_replica, 0, 0},
 	{"MAXIOWAIT", exec_max_io_wait, 0, 0},
 #endif

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -911,6 +911,44 @@ exec_resize(UCTL_Ptr uctl)
 	char *arg, *result;
 	int rc = 0;
 	char *name = uctl->setargv[0];
+	char *s_drf = uctl->setargv[1];
+
+	uctl_snprintf(uctl, "%s \"%s\" \"%s\" \n",
+		uctl->cmd, name, s_drf);
+
+	rc = uctl_writeline(uctl);
+	if (rc != UCTL_CMD_OK) {
+		return (rc);
+	}
+
+		/* receive result */
+	while (1) {
+		rc = uctl_readline(uctl);
+		if (rc != UCTL_CMD_OK) {
+			return (rc);
+		}
+		arg = trim_string(uctl->recvbuf);
+		result = strsepq(&arg, delim);
+		strupr(result);
+		if (strcmp(result, uctl->cmd) != 0)
+			break;
+	}
+	if (strcmp(result, "OK") != 0) {
+		if (is_err_req_auth(uctl, arg))
+			return (UCTL_CMD_REQAUTH);
+		fprintf(stderr, "ERROR %s\n", arg);
+		return (UCTL_CMD_ERR);
+	}
+	return (UCTL_CMD_OK);
+}
+
+static int
+exec_desired_rf(UCTL_Ptr uctl)
+{
+	const char *delim = ARGS_DELIM;
+	char *arg, *result;
+	int rc = 0;
+	char *name = uctl->setargv[0];
 	char *size = uctl->setargv[1];
 
 	uctl_snprintf(uctl, "%s \"%s\" \"%s\" \n",
@@ -1333,6 +1371,7 @@ static EXEC_TABLE exec_table[] =
 	{"SNAPCREATE", exec_snap, 2, 0},
 	{"SNAPDESTROY", exec_snap, 2, 0},
 	{"RESIZE", exec_resize, 2, 0},
+	{"DRF", exec_desired_rf, 2, 0},
 	{"REPLICA", exec_replica, 0, 0},
 	{"MAXIOWAIT", exec_max_io_wait, 0, 0},
 #endif
@@ -1823,6 +1862,7 @@ usage(void)
 	printf(" mempool    get mempool details\n");
 	printf(" maxiowait  get/set wait time for IO completion in seconds\n");
 	printf(" resize     read the size from command cli and updates the size\n");
+	printf(" drf        read the desired replication factor from command cli and update in memory\n");
 #endif
 	printf(" set        set values for variables:\n");
 	printf("            Syntax: istgtcontrol -t <iqn(ALL to set globally)> \
@@ -2100,7 +2140,8 @@ main(int argc, char *argv[])
 	(strcmp(cmd, "SNAPDESTROY") == 0) ||
 	    (strcmp(cmd, "REPLICA") == 0) ||
 	    (strcmp(cmd, "MAXIOWAIT") == 0) ||
-	    (strcmp(cmd, "RESIZE") == 0)) {
+	    (strcmp(cmd, "RESIZE") == 0) ||
+	    (strcmp(cmd, "DRF") == 0)) {
 		uctl->setargv = argv;
 		uctl->setargcnt = argc;
 	}

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -453,6 +453,7 @@ send_mgmt_ack(int fd, zvol_io_hdr_t *mgmt_ack_hdr, void *buf, int *zrepl_status_
 		case ZVOL_OPCODE_HANDSHAKE:
 			strcpy(mgmt_ack_data.ip, replica_ip);
 			strcpy(mgmt_ack_data.volname, buf);
+			memset(mgmt_ack_data.replica_id, 0, REPLICA_ID_LEN);
 			sprintf(mgmt_ack_data.replica_id, "%d", replica_port);
 			mgmt_ack_data.port = replica_port;
 			mgmt_ack_data.pool_guid = replica_port;

--- a/src/mock_errored_replica.c
+++ b/src/mock_errored_replica.c
@@ -453,6 +453,7 @@ send_mgmt_ack(int fd, zvol_io_hdr_t *mgmt_ack_hdr, void *buf, int *zrepl_status_
 		case ZVOL_OPCODE_HANDSHAKE:
 			strcpy(mgmt_ack_data.ip, replica_ip);
 			strcpy(mgmt_ack_data.volname, buf);
+			sprintf(mgmt_ack_data.replica_id, "%d", replica_port);
 			mgmt_ack_data.port = replica_port;
 			mgmt_ack_data.pool_guid = replica_port;
 			mgmt_ack_data.zvol_guid = replica_port;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1449,6 +1449,13 @@ update_replica_entry(spec_t *spec, replica_t *replica, int iofd)
 	replica->zvol_guid = ack_data->zvol_guid;
 	strncpy(replica->replica_id, ack_data->replica_id, REPLICA_ID_LEN);
 
+	if (strlen(replica->replica_id) == 0) {
+		REPLICA_ERRLOG("replicas(ip:%s port:%d "
+		    "guid:%lu) replica_id is empty so not permitted to connect\n",
+		    replica->ip, replica->port,
+		    replica->zvol_guid);
+		goto replica_error;
+	}
 	MTX_LOCK(&spec->rq_mtx);
 	if (!is_replica_newly_connected(spec, replica)) {
 		MTX_UNLOCK(&spec->rq_mtx);
@@ -2727,7 +2734,7 @@ update_replica_status(spec_t *spec, zvol_io_hdr_t *hdr, replica_t *replica)
 				}
 
 				ISTGT_LOG("successfully transformed replica(%s:%lu) from "
-				    " unkown to trusty replication factor %d consistency "
+				    " unkown to trusty replica replication factor %d consistency "
 				    " factor %d desired replication factor %d\n",
 				    replica->replica_id, replica->zvol_guid,
 				    spec->replication_factor, spec->consistency_factor,

--- a/src/replication.c
+++ b/src/replication.c
@@ -3684,6 +3684,7 @@ retry_read:
 			if (rcomm_cmd->opcode == ZVOL_OPCODE_WRITE &&
 			    cf == spec->consistency_factor && success_count >= cf) {
 				rc = -1;
+				goto wait_for_other_responses;
 			}
 			TAILQ_REMOVE(&spec->rcommon_waitq, rcomm_cmd, wait_cmd_next);
 			UPDATE_INFLIGHT_SPEC_IO_CNT(spec, cmd, -1);

--- a/src/replication.c
+++ b/src/replication.c
@@ -412,7 +412,7 @@ send_prepare_for_rebuild_or_trigger_rebuild(spec_t *spec,
 	int replica_cnt;
 	uint64_t size;
 	uint64_t data_len;
-	mgmt_ack_t *mgmt_data;
+	rebuild_req_t *rebuild_req;
 	replica_t *replica;
 	struct rcommon_mgmt_cmd *rcomm_mgmt;
 
@@ -436,12 +436,12 @@ send_prepare_for_rebuild_or_trigger_rebuild(spec_t *spec,
 		assert(spec->ready == true);
 
 		data_len = strlen(spec->volname) + 1;
-		mgmt_data = (mgmt_ack_t *)malloc(sizeof (*mgmt_data));
-		memset(mgmt_data, 0, sizeof (*mgmt_data));
-		snprintf(mgmt_data->dw_volname, data_len, "%s",
+		rebuild_req = (rebuild_req_t *)malloc(sizeof (*rebuild_req));
+		memset(rebuild_req, 0, sizeof (*rebuild_req));
+		snprintf(rebuild_req->dw_volname, data_len, "%s",
 		    spec->volname);
-		ret = start_rebuild(mgmt_data,
-		    spec->rebuild_info.dw_replica, sizeof (*mgmt_data));
+		ret = start_rebuild(rebuild_req,
+		    spec->rebuild_info.dw_replica, sizeof (*rebuild_req));
 		if (ret == -1) {
 			spec->rebuild_info.dw_replica = NULL;
 			spec->rebuild_info.healthy_replica = NULL;
@@ -2378,7 +2378,7 @@ handle_prepare_for_rebuild_resp(spec_t *spec, zvol_io_hdr_t *hdr,
 	int ret = 0;
 	size_t data_len;
 	rcommon_mgmt_cmd_t *rcomm_mgmt = mgmt_cmd->rcomm_mgmt;
-	mgmt_ack_t *buf = (mgmt_ack_t *)rcomm_mgmt->buf;
+	rebuild_req_t *buf = (rebuild_req_t *)rcomm_mgmt->buf;
 	
 	if (hdr->status != ZVOL_OP_STATUS_OK) {
 		rcomm_mgmt->cmds_failed++;

--- a/src/replication.c
+++ b/src/replication.c
@@ -3478,6 +3478,7 @@ check_for_command_completion(spec_t *spec, rcommon_cmd_t *rcomm_cmd, ISTGT_LU_CM
 	} else if ((rcomm_cmd->opcode == ZVOL_OPCODE_WRITE) ||
 		   (rcomm_cmd->opcode == ZVOL_OPCODE_SYNC)) {
 		rf = rcomm_cmd->replication_factor;
+		cf = rcomm_cmd->consistency_factor;
 		copies_sent = rcomm_cmd->copies_sent;
 		/* If scaleup replica is not null and to meet new
 		 * consistency model
@@ -3503,8 +3504,9 @@ check_for_command_completion(spec_t *spec, rcommon_cmd_t *rcomm_cmd, ISTGT_LU_CM
 					break;
 				}
 			}
+			cf = (rf / 2) + 1;
+			min_response = MAX_OF(rf - cf + 1, cf);
 		}
-		cf = (rf / 2) + 1;
 		if (healthy_response >= cf) {
 			/*
 			 * We got the successful response from required healthy

--- a/src/replication.h
+++ b/src/replication.h
@@ -52,6 +52,8 @@
 
 #define	MAX_OF(a, b) (((a) > (b))?(a):(b))
 
+#define CONSISTENCY_FACTOR(a) (((a)/2) + 1)
+
 typedef enum zvol_cmd_type_e {
 	CMD_IO = 1,
 	CND_MGMT,

--- a/src/replication.h
+++ b/src/replication.h
@@ -207,7 +207,7 @@ extern int do_drainfd(int);
 void close_fd(int epollfd, int fd);
 int64_t perform_read_write_on_fd(int fd, uint8_t *data, uint64_t len,
     int state);
-int initialize_volume(spec_t *spec, int, int);
+int initialize_volume(spec_t *spec, int, int, int);
 void destroy_volume(spec_t *spec);
 void inform_mgmt_conn(replica_t *r);
 extern const char * get_cv_status(spec_t *spec);

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -480,6 +480,8 @@ main(int argc, char **argv)
 	int delay_connection = 0;
 	bool retry = false;
 
+	memset(replica_id, 0, REPLICA_ID_LEN);
+
 	while ((ch = getopt(argc, argv, "i:p:I:P:V:n:e:s:t:drq")) != -1) {
 		switch (ch) {
 			case 'i':
@@ -495,7 +497,7 @@ main(int argc, char **argv)
 				check |= 1 << 3;
 				break;
 			case 'P':
-				strncpy(replica_id, optarg, sizeof(replica_id));
+				strcpy(replica_id, optarg);
 				replica_port = atoi(optarg);
 				check |= 1 << 4;
 				break;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -64,7 +64,7 @@ size_t mdlist_size = 0;
 uint64_t read_ios;
 uint64_t write_ios;
 int replica_quorum_state = 0;
-char replica_id[MAX_IP_LEN];
+char replica_id[REPLICA_ID_LEN];
 
 static void
 sig_handler(int sig)

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -52,6 +52,7 @@ __thread char  tinfo[50] =  {0};
 	mgmt_ack_data->pool_guid = replica_port;\
 	mgmt_ack_data->checkpointed_io_seq = 1000;\
 	mgmt_ack_data->zvol_guid = replica_port;\
+	strcpy(mgmt_ack_data->replica_id, replica_id);\
 	mgmt_ack_data->quorum = replica_quorum_state;\
 }
 
@@ -64,6 +65,7 @@ uint64_t read_ios;
 uint64_t write_ios;
 int replica_quorum_state = 0;
 int initial_quorum_state;
+char replica_id[MAX_IP_LEN];
 
 static void
 sig_handler(int sig)
@@ -500,6 +502,7 @@ main(int argc, char **argv)
 				check |= 1 << 3;
 				break;
 			case 'P':
+				strncpy(replica_id, optarg, sizeof(replica_id));
 				replica_port = atoi(optarg);
 				check |= 1 << 4;
 				break;

--- a/src/replication_test.c
+++ b/src/replication_test.c
@@ -276,6 +276,10 @@ send_mgmt_ack(int fd, zvol_op_code_t opcode, void *buf, char *replica_ip,
 		iovec_count = 1;
 		sleep(random()%2);
 		mgmt_ack_hdr->status = (random() % 5 == 0) ? ZVOL_OP_STATUS_FAILED : ZVOL_OP_STATUS_OK;
+		if ( mgmt_ack_hdr->status == ZVOL_OP_STATUS_FAILED) {
+			REPLICA_ERRLOG("Random failure on replica(%s:%d) for SNAP_CREATE "
+			    "opcode\n", replica_ip, replica_port);
+		}
 		mgmt_ack_hdr->len = 0;
 	} else if (opcode == ZVOL_OPCODE_SNAP_PREPARE) {
 		iovec_count = 1;

--- a/src/setup_istgt.sh
+++ b/src/setup_istgt.sh
@@ -5,6 +5,7 @@ run_istgt ()
 	local volume_size
 	local rf
 	local cf
+	local drf
 
 	if [ $# -eq 1 ]; then
 		volume_size=$1
@@ -12,6 +13,7 @@ run_istgt ()
 		volume_size=10g
 	fi
 
+	[ ! -z $DESIRED_REPLICATION_FACTOR ] && drf=$DESIRED_REPLICATION_FACTOR || drf=3
 	[ ! -z $REPLICATION_FACTOR ] && rf=$REPLICATION_FACTOR || rf=3
 	[ ! -z $CONSISTENCY_FACTOR ] && cf=$CONSISTENCY_FACTOR || cf=2
 
@@ -24,7 +26,7 @@ run_istgt ()
 	cp istgt /usr/local/bin/istgt
 	cp istgtcontrol /usr/local/bin/istgtcontrol
 	ps -aux | grep "\./istgt" | grep -v grep | sudo kill -9 `awk '{print $2}'`
-	./init.sh volname=vol1 portal=127.0.0.1 size=$volume_size externalIP=127.0.0.1 replication_factor=$rf consistency_factor=$cf test_env=$TEST_ENV
+	./init.sh volname=vol1 portal=127.0.0.1 size=$volume_size externalIP=127.0.0.1 desired_replication_factor=$drf replication_factor=$rf consistency_factor=$cf test_env=$TEST_ENV
 }
 
 parent_file=$( basename $0 )

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -845,12 +845,26 @@ run_non_quorum_replica_errored_test()
 	local replica2_vdev="/tmp/test_vol2"
 	local replica3_vdev="/tmp/test_vol3"
 	local device_name=""
+	local retry_count=5
 
 	DESIRED_REPLICATION_FACTOR=3
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
 
 	setup_test_env
+
+	##Wait for istgt to up
+	while [ $retry_count -gt 0 ]; do
+		value=$(netstat -nap | grep 6060 | grep -w LISTEN | wc -l)
+		if [ $value == "1" ]; then
+			break
+		fi
+		sleep 1
+		retry_count=$((retry_count - 1))
+		if [ $retry_count == 1 ]; then
+			exit 1
+		fi
+	done
 
 	## Below Test will connect 1 QUORUM REPLICA and 5 NON-QUORUM Replica
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica1_ip" -P "$replica1_port" -V $replica1_vdev -q  &

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1472,17 +1472,17 @@ run_io_timeout_test()
 	rm -rf ${replica1_vdev::-1}*
 }
 
-run_lu_rf_test
-run_quorum_test
-data_integrity_with_non_quorum
-run_non_quorum_replica_errored_test
+#run_lu_rf_test
+#run_quorum_test
+#data_integrity_with_non_quorum
+#run_non_quorum_replica_errored_test
 run_data_integrity_test
-run_mempool_test
-run_istgt_integration
-run_read_consistency_test
-run_replication_factor_test
-run_io_timeout_test
-run_test_env
+#run_mempool_test
+#run_istgt_integration
+#run_read_consistency_test
+#run_replication_factor_test
+#run_io_timeout_test
+#run_test_env
 echo "===============All Tests are passed ==============="
 tail -20 $LOGFILE
 

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1472,17 +1472,17 @@ run_io_timeout_test()
 	rm -rf ${replica1_vdev::-1}*
 }
 
-#run_lu_rf_test
-#run_quorum_test
-#data_integrity_with_non_quorum
-#run_non_quorum_replica_errored_test
+run_lu_rf_test
+run_quorum_test
+data_integrity_with_non_quorum
+run_non_quorum_replica_errored_test
 run_data_integrity_test
-#run_mempool_test
-#run_istgt_integration
-#run_read_consistency_test
-#run_replication_factor_test
-#run_io_timeout_test
-#run_test_env
+run_mempool_test
+run_istgt_integration
+run_read_consistency_test
+run_replication_factor_test
+run_io_timeout_test
+run_test_env
 echo "===============All Tests are passed ==============="
 tail -20 $LOGFILE
 

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -509,6 +509,7 @@ run_lu_rf_test ()
   ReadOnly No
   ReplicationFactor 3
   ConsistencyFactor 2
+  DesiredReplicationFactor 3
   UnitType Disk
   UnitOnline Yes
   BlockLength 512
@@ -538,6 +539,8 @@ run_lu_rf_test ()
 	sleep 5
 
 	pkill -9 -P $replica3_pid
+	## Below will be allowed to connect as unkown replica but it will never become healthy
+	## since we are storing RF number replica details in memory
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica3_ip" -P "$(($replica3_port + 10))" -V $replica3_vdev -q &
 	replica3_pid=$!
         sleep 5
@@ -545,9 +548,25 @@ run_lu_rf_test ()
 	## Checking whether process exist or not
 	if ps -p $replica3_pid > /dev/null 2>&1
 	then
-		echo "Replica identification test passed"
-	else
 		echo "Replica identification test failed"
+		cat $LOGFILE
+		exit 1
+	else
+		echo "Replica identification test passed"
+	fi
+
+	## Check whether old replica i.e(6163) allowed to connect or not
+	## since 6173 is new replica it will be addded as part of unknown
+	## quorum list since 6163 is in known list we should allow it to connect
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica3_ip" -P "$replica3_port" -V $replica3_vdev -q &
+	old_replica3_pid=$!
+	sleep 3
+	## checking whether process exist or not
+	if ps -p $old_replica3_pid > /dev/null 2>&1
+	then
+		echo "Trusty Replica identification test passed"
+	else
+		echo "Trusty Replica identification test failed"
 		cat $LOGFILE
 		exit 1
 	fi
@@ -558,11 +577,11 @@ run_lu_rf_test ()
 
 	if ps -p $replica4_pid > /dev/null 2>&1
 	then
-		echo "Non-quorum-replica connection test failed(3 quorum + 1 non-quorum)"
+		echo "Unknown replica connection test failed(3 quorum + 1 non-quorum)"
 		cat $LOGFILE
 		exit 1
 	else
-		echo "Non-quorum-replica connection test passed(3 quorum + 1 non-quorum)"
+		echo "Unknown replica connection test passed(3 quorum + 1 non-quorum)"
 	fi
 
 	pkill -9 -P $replica1_pid
@@ -614,7 +633,7 @@ wait_for_healthy_replicas()
 check_degraded_quorum()
 {
 	local expected_degraded_count=$1
-	local expected_quorum_count=$2
+	local expected_non_quorum_count=$2
 	local cnt=0
 
 	## Check the no.of degraded replicas
@@ -631,7 +650,7 @@ check_degraded_quorum()
 	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[].quorum'"
 	cnt=$(eval $cmd | grep -w 0 | wc -l)
 
-	if [ $cnt -ne $expected_quorum_count ]
+	if [ $cnt -ne $expected_non_quorum_count ]
 	then
 		echo "Quorum test failed: expected quorum count is $expected_quorum_count and got $cnt"
 		exit 1
@@ -657,6 +676,7 @@ run_quorum_test()
 	local replica6_ip="127.0.0.1"
 	local replica1_vdev="/tmp/test_vol1"
 
+	DESIRED_REPLICATION_FACTOR=3
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
 
@@ -677,6 +697,33 @@ run_quorum_test()
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica3_ip" -P "$replica3_port" -V $replica1_vdev &
 	replica3_pid=$!
 	sleep 2
+
+	# As long as we are not running any IOs we can use the same vdev file
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica4_ip" -P "$replica4_port" -V $replica1_vdev &
+	replica4_pid=$!
+	sleep 3
+
+	if ps -p $replica4_pid > /dev/null 2>&1
+	then
+		echo "Non-quorum-replica connection test failed desired replication factor: $DESIRED_REPLICATION_FACTOR"
+		cat $LOGFILE
+		exit 1
+	fi
+
+	## Increasing desired replication factor
+	istgtcontrol drf vol3 5
+	rc=$?
+	if [ $rc == 0 ]; then
+		echo "Updated the desired replication factor using istgtcontrol with invalid volume vol1 returns success"
+		exit 1
+	fi
+
+	istgtcontrol drf vol1 5
+	rc=$?
+	if [ $rc != 0 ]; then
+		echo "Failed to update desired replication factor"
+		exit 1
+	fi
 
 	# As long as we are not running any IOs we can use the same vdev file
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica4_ip" -P "$replica4_port" -V $replica1_vdev &
@@ -730,7 +777,7 @@ run_quorum_test()
 	fi
 
 	# Pass the expected healthy replica count
-	wait_for_healthy_replicas 3
+	wait_for_healthy_replicas 5
 
 	pkill -9 -P $replica1_pid
 	pkill -9 -P $replica2_pid
@@ -741,6 +788,11 @@ run_quorum_test()
 	rm -rf ${replica1_vdev::-1}*
 }
 
+## check_order_of_rebuilding make sure that rebuilding
+## on quorum replicas should be done and later it should
+## be done on unkown replicas
+## $1 -- no.of replicas connected
+## $2 -- no.of unkown or non quorum replicas
 check_order_of_rebuilding()
 {
 
@@ -748,9 +800,10 @@ check_order_of_rebuilding()
 	local cmd1=""
 	local cmd2=""
 	local done_status=0
+	local no_of_replicas=$1
 	while [ 1 ]; do
 		cnt=0
-		for (( i = 0; i < 3; i++ )) do
+		for (( i = 0; i < $no_of_replicas; i++ )) do
 			cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"["$i"].Mode'"
 			rt=$(eval $cmd)
 			if [ ${rt} == "\"Healthy\"" ]; then
@@ -793,6 +846,7 @@ run_non_quorum_replica_errored_test()
 	local replica3_vdev="/tmp/test_vol3"
 	local device_name=""
 
+	DESIRED_REPLICATION_FACTOR=3
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
 
@@ -949,25 +1003,28 @@ verify_resize_command()
 	sleep 2
 }
 
-data_integrity_with_non_quorum()
+data_integrity_with_unknown_replica()
 {
 	local device_name=""
 	local replica1_port="6161"
 	local replica2_port="6162"
 	local replica3_port="6163"
+	local replica4_port="6164"
 	local replica1_ip="127.0.0.1"
 	local replica2_ip="127.0.0.1"
 	local replica3_ip="127.0.0.1"
+	local replica4_ip="127.0.0.1"
 	local replica1_vdev="/tmp/test_vol1"
 	local replica2_vdev="/tmp/test_vol2"
 	local replica3_vdev="/tmp/test_vol3"
+	local replica4_vdev="/tmp/test_vol4"
 
+	DESIRED_REPLICATION_FACTOR=3
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
 
-	setup_test_env
+	setup_test_env $replica4_vdev
 
-	## Below Test will connect 1 QUORUM REPLICA and 5 NON-QUORUM Replica
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica1_ip" -P "$replica1_port" -V $replica1_vdev -q &
 	replica1_pid=$!
 	sleep 2	#Replica will take some time to make successful connection to target
@@ -980,10 +1037,21 @@ data_integrity_with_non_quorum()
 	replica2_pid=$!
 	sleep 2
 
+	## Verify data integrity in scaleup case
+	istgtcontrol drf vol1 4
+	rc=$?
+	if [ $rc != 0 ]; then
+		echo "Failed to update desired replication factor to 4"
+		exit 1
+	fi
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica4_ip" -P "$replica4_port" -V $replica4_vdev &
+	replica4_pid=$!
+	sleep 2
+
+
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 10
 	device_name=$(get_scsi_disk)
-
 
 
 	## Cross check non-quorum replica shuould be in degraded state
@@ -998,21 +1066,28 @@ data_integrity_with_non_quorum()
 	fi
 
 	if [ "$device_name" != "" ]; then
-		sudo dd if=/dev/urandom of=$device_name bs=4k count=1000 oflag=direct
+		sudo dd if=/dev/urandom of=/dev/$device_name bs=4k count=1000 oflag=direct
                 var1="$($ISTGTCONTROL -q iostats | jq '.TotalWriteBytes')"
 		sleep 5
 
 		hash1=$(md5sum $replica1_vdev | awk '{print $1}')
 		hash2=$(md5sum $replica3_vdev | awk '{print $1}')
+		hash3=$(md5sum $replica4_vdev | awk '{print $1}')
 		if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
 		else
 			echo "DI Test: FAILED Hash of quorum is $hash1 and non-quorum is $hash2 with writebytes $var1";
 			tail -20 $LOGFILE
 			exit 1
 		fi
+		if [ $hash1 == $hash3 ]; then echo "DI Test: PASSED on scale up replica"
+		else
+			echo "DI Test: FAILED Hash of known replica is $hash1 and unknown replica is $hash2 with writebytes $var1";
+			tail -20 $LOGFILE
+			exit 1
+		fi
 	fi
 
-	check_order_of_rebuilding
+	check_order_of_rebuilding 4
 
 	## Checking the read IO's with quorum and non-quorum replicas
 	sudo dd if=$device_name of=/dev/null bs=4k count=100
@@ -1034,17 +1109,18 @@ data_integrity_with_non_quorum()
 	date_log=$(eval date +%Y-%m-%d/%H:%M:%S.%s)
 
 	$ISTGTCONTROL -q replica | jq
-	wait_for_healthy_replicas 3
+	wait_for_healthy_replicas 4
 
 	logout_of_volume
 	pkill -9 -P $replica1_pid
 	pkill -9 -P $replica2_pid
 	pkill -9 -P $replica3_pid
+	pkill -9 -P $replica4_pid
 	stop_istgt
 	rm -f /tmp/check_sum*
 	rm -rf ${replica1_vdev::-1}*
-
 }
+
 run_rebuild_time_test_in_single_replica()
 {
 	local replica1_port="6161"
@@ -1053,6 +1129,7 @@ run_rebuild_time_test_in_single_replica()
 	local ret=0
 
 	echo "run rebuild time test in single replica"
+	DESIRED_REPLICATION_FACTOR=1
 	REPLICATION_FACTOR=1
 	CONSISTENCY_FACTOR=1
 	setup_test_env
@@ -1132,6 +1209,7 @@ run_rebuild_time_test_in_multiple_replicas()
 	local done_test=0
 
 	echo "run rebuild time test in multiple replica, param1: $1"
+	DESIRED_REPLICATION_FACTOR=3
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
 	setup_test_env
@@ -1300,6 +1378,7 @@ run_replication_factor_test()
 
 	export non_zero_inflight_replica_cnt=0
 	sleep 1
+	DESIRED_REPLICATION_FACTOR=3
 	REPLICATION_FACTOR=3
 	CONSISTENCY_FACTOR=2
 
@@ -1474,7 +1553,7 @@ run_io_timeout_test()
 
 run_lu_rf_test
 run_quorum_test
-data_integrity_with_non_quorum
+data_integrity_with_unknown_replica
 run_non_quorum_replica_errored_test
 run_data_integrity_test
 run_mempool_test


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR does the following things
1. Adds support to scaleup replicas, replica movement across the pool and
replica replacement scenarios. 
2. Adds support to change drf(desired replication factor) on fly using istgtcontrol commads

To support above features below changes are made to existing code
**Internals**
As part of this PR, we are introducing a new configuration called desiredReplicationFactor
which means that maximum no.of replicas are that are allowed to connect to the target.
1. During handshake time we are checking whether the replica is in known replica list or not.
     If the replica is in known replica list then we are adding to spec->rq list else into spec- 
     >non_quorum_rq list.
2. Replicas are which are added to non_quorum_rq list will reconstruct the data from healthy replicas and move to spec->rq list after successfully updating in etcd(inform to cstor-volume-mgmt about) the replica.
**Note:**
If known replica list is less than the current replication factor then update the replica details(replica_id, replica_zvol_guid) in etcd on success move replica into a known replica list.
For more details: https://github.com/openebs/openebs/pull/2739
     
