### PR TITLE
fix(refresh): refresh cmd handling to parse conf file for storage size

### DIFF
--- a/src/istgt_lu.c
+++ b/src/istgt_lu.c
@@ -2633,10 +2633,20 @@ istgt_lu_update_unit(ISTGT_LU_Ptr lu, CF_SECTION *sp)
 				ISTGT_TRACELOG(ISTGT_TRACE_DEBUG, "Device file=%s\n",
 							    lu->lun[i].u.device.file);
 			} else if (strcasecmp(val, "Storage") == 0) {
+#ifndef	REPLICATION
 				file = istgt_get_nmval(sp, buf, j, 1);
 				size = istgt_get_nmval(sp, buf, j, 2);
 				rsz  = istgt_get_nmval(sp, buf, j, 3);
+#else
+				size = istgt_get_nmval(sp, buf, j, 1);
+				rsz  = istgt_get_nmval(sp, buf, j, 2);
+#endif
+
+#ifndef	REPLICATION
 				if (file == NULL || size == NULL) {
+#else
+				if (size == NULL) {
+#endif
 					ISTGT_ERRLOG("LU%d: LUN%d: format error\n", lu->num, i);
 					goto error_return;
 				}
@@ -2678,9 +2688,15 @@ istgt_lu_update_unit(ISTGT_LU_Ptr lu, CF_SECTION *sp)
 						new_rsize = (uint32_t)vall;
 				}
 
+#ifndef	REPLICATION
 				if (old_size == new_size && new_rsize == old_rsize &&
 					spec != NULL && strcasecmp(file, spec->file) == 0)
 					continue;
+#else
+				if (old_size == new_size && new_rsize == old_rsize &&
+					spec != NULL)
+					continue;
+#endif
 
 				lu->lun[i].u.storage.size = new_size;
 				lu->lun[i].u.storage.rsize = new_rsize;


### PR DESCRIPTION
`istgt` parses istgt.conf file to read storage parameter 'capacity'.
As part of enabling 'replication', few parameters like 'file' has been removed from conf file.

New LUN creation reads the storage parameters correctly.
But, updating istgt LUN using 'istgtcontrol refresh' command has NOT been modified. It still assumes the 'file' parameter. This is causing istgt to assume wrong field as the 'capacity'.

This PR is to fix this issue by making it similar to what has been done for new LUN creation.

Signed-off-by: Vitta <vitta@mayadata.io>