### PR TITLE
feat(replica scaledown): add support to scaledown replicas

### DIFF
--- a/src/istgt_integration.h
+++ b/src/istgt_integration.h
@@ -64,6 +64,11 @@ typedef struct replica_s {
 	pthread_mutex_t r_mtx;
 	replica_state_t state;
 	spec_t *spec;
+	/* decides whether IOs need to send for the replica
+	 * or not. If it is enabled then don't send IOs for
+	 * this replica.
+	 */
+	int cordon;
 	int iofd;
 	/* management connection descriptor */
 	int mgmt_fd;

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -735,6 +735,7 @@ istgt_uctl_cmd_desired_rf(UCTL_Ptr uctl)
 			    "but requested desired replication factor(%d) are "
 			    "invalid changes\n", spec->desired_replication_factor,
 			    spec->replication_factor, drf);
+			goto error_return;
 		}
 		// In case of scale down read known replica list
 		known_replica_id_list = (char **) xmalloc(sizeof(char *) * drf);

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -741,7 +741,7 @@ istgt_uctl_cmd_desired_rf(UCTL_Ptr uctl)
 		}
 		// In case of scale down read known replica list
 		known_replica_id_list = (char **) xmalloc(sizeof(char *) * drf);
-		memset(known_replica_id_list, 0, sizeof(known_replica_id_list));
+		memset(known_replica_id_list, 0, sizeof(char *) * drf);
 		for (i=0; i < drf; i++) {
 			CHECK_ARG_AND_GOTO_ERROR;
 			known_replica_id_list[i] = strsepq(&arg, delim);

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -744,7 +744,6 @@ istgt_uctl_cmd_desired_rf(UCTL_Ptr uctl)
 			known_replica_id_list[i] = strsepq(&arg, delim);
 		}
 		rc = istgt_lu_remove_unknown_replica(spec, drf, known_replica_id_list);
-		rc = 0;
 		if (rc == 0) {
 			istgt_uctl_snprintf(uctl, "OK %s\n", uctl->cmd);
 			ret = UCTL_CMD_OK;

--- a/src/istgt_lu_ctl.c
+++ b/src/istgt_lu_ctl.c
@@ -723,6 +723,8 @@ istgt_uctl_cmd_desired_rf(UCTL_Ptr uctl)
 
 	if (drf < spec->desired_replication_factor) {
 
+		// TODO: I think this check is not required(get confirmation during review process)
+		// If user want to remove scalingup replica should we need to allow this process?
 		if ( spec->desired_replication_factor != spec->replication_factor ||
 		    drf != spec->replication_factor - 1) {
 			ISTGT_ERRLOG("current desired replication factor(%d) "

--- a/src/istgt_proto.h
+++ b/src/istgt_proto.h
@@ -108,6 +108,7 @@ ISTGT_LU_Ptr istgt_lu_find_target_by_volname(ISTGT_Ptr istgt, const char *target
 #ifdef	REPLICATION
 int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int, int);
 int istgt_lu_resize_volume(spec_t *spec, size_t size);
+int istgt_lu_remove_replica(spec_t *spec, char **replicas_id);
 int istgt_lu_destroy_snapshot(spec_t *spec, char *snapname);
 void istgt_lu_mempool_stats(char **resp);
 void istgt_lu_replica_stats(char *volname, char **resp);

--- a/src/istgt_proto.h
+++ b/src/istgt_proto.h
@@ -108,7 +108,7 @@ ISTGT_LU_Ptr istgt_lu_find_target_by_volname(ISTGT_Ptr istgt, const char *target
 #ifdef	REPLICATION
 int istgt_lu_create_snapshot(spec_t *spec, char *snapname, int, int);
 int istgt_lu_resize_volume(spec_t *spec, size_t size);
-int istgt_lu_remove_replica(spec_t *spec, char **replicas_id);
+int istgt_lu_remove_unknown_replica(spec_t *spec, int drf, char **replicas_id);
 int istgt_lu_destroy_snapshot(spec_t *spec, char *snapname);
 void istgt_lu_mempool_stats(char **resp);
 void istgt_lu_replica_stats(char *volname, char **resp);

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -65,7 +65,10 @@
 #include "istgt_sock.h"
 #include "istgt_misc.h"
 #include "istgt_md5.h"
+
+#ifdef REPLICATION
 #include "zrepl_prot.h"
+#endif
 
 #if !defined(__GNUC__)
 #undef __attribute__

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -915,14 +915,14 @@ exec_command(UCTL_Ptr uctl)
 	char *name = uctl->setargv[0];
 	char *value = uctl->setargv[1];
 	int i = 0, listcnt;
-	char *id_list;
+	char *id_list = NULL;
 
 	listcnt = uctl->setargcnt - 2;
 	if (listcnt != 0) {
 		// Since list of replicaIds sent via socket
-		// each replicaId should enclosed with in ""
+		// each replicaId should enclosed with in "" and space
 		id_list = (char *) malloc(sizeof(char) * ((listcnt * 
-		    REPLICA_ID_LEN) + (listcnt * 3)));
+		    REPLICA_ID_LEN) + (listcnt * 4)));
 		memset(id_list, 0, sizeof(id_list));
 		for (i=0; i < listcnt; i++) {
 			strcat(id_list, "\"");

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -914,16 +914,16 @@ exec_command(UCTL_Ptr uctl)
 	int rc = 0;
 	char *name = uctl->setargv[0];
 	char *value = uctl->setargv[1];
-	int i = 0, listcnt;
+	int i = 0, listcnt, memory_len;
 	char *id_list = NULL;
 
 	listcnt = uctl->setargcnt - 2;
-	if (listcnt != 0) {
+	if (listcnt > 0) {
 		// Since list of replicaIds sent via socket
 		// each replicaId should enclosed with in "" and space
-		id_list = (char *) malloc(sizeof(char) * ((listcnt * 
-		    REPLICA_ID_LEN) + (listcnt * 4)));
-		memset(id_list, 0, sizeof(id_list));
+		memory_len = ((listcnt * REPLICA_ID_LEN) + (listcnt * 4));
+		id_list = (char *) malloc(sizeof(char) * memory_len);
+		memset(id_list, 0, sizeof(sizeof(char) * memory_len));
 		for (i=0; i < listcnt; i++) {
 			strcat(id_list, "\"");
 			strncat(id_list, uctl->setargv[i+2], REPLICA_ID_LEN);
@@ -931,7 +931,7 @@ exec_command(UCTL_Ptr uctl)
 		}
 	}
 	//Release the momory
-	if (listcnt != 0) {
+	if (listcnt > 0) {
 		uctl_snprintf(uctl, "%s \"%s\" \"%s\" %s \n",
 		    uctl->cmd, name, value, id_list);
 		free(id_list);

--- a/src/istgtcontrol.c
+++ b/src/istgtcontrol.c
@@ -65,6 +65,7 @@
 #include "istgt_sock.h"
 #include "istgt_misc.h"
 #include "istgt_md5.h"
+#include "zrepl_prot.h"
 
 #if !defined(__GNUC__)
 #undef __attribute__
@@ -84,7 +85,6 @@
 
 #define	MAX_LINEBUF 4096
 #define	UCTL_CHAP_CHALLENGE_LEN 1024
-#define REPLICA_ID_LEN 32
 
 typedef struct istgt_uctl_auth_t {
 	char *user;

--- a/src/replication.c
+++ b/src/replication.c
@@ -2262,13 +2262,11 @@ istgt_lu_remove_unknown_replica(spec_t *spec, int drf, char **known_replica_id_l
 	MTX_LOCK(&spec->rq_mtx);
 	ASSERT(drf == spec->replication_factor - 1);
 
-#ifdef REPLICATION
 	if (is_valid_known_replica_list(spec, drf, known_replica_id_list) == false) {
 		MTX_UNLOCK(&spec->rq_mtx);
 		ISTGT_ERRLOG("invalid known replicaid list\n");
 		return rc;
 	}
-#endif
 
 	// Find the replica who's replicaID is not exist in known_replica_id_list
 	TAILQ_FOREACH(replica, &spec->rq, r_next) {

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -88,6 +88,25 @@ start_replica() {
 	$REPLICATION_TEST $* >> $LOGFILE 2>&1
 }
 
+## wait_for_istgt_process verifies whether istgt is running or not
+## $1 - retry count
+wait_for_istgt_process() {
+	local retry_count=$1
+
+	##Wait for istgt to up
+	while [ $retry_count -gt 0 ]; do
+		value=$(netstat -nap | grep $CONTROLLER_PORT | grep -w LISTEN | wc -l)
+		if [ $value == "1" ]; then
+			break
+		fi
+		sleep 1
+		retry_count=$((retry_count - 1))
+		if [ $retry_count == 1 ]; then
+			exit 1
+		fi
+	done
+}
+
 stop_istgt() {
 	if [ $SETUP_PID -ne -1 ]; then
 		pkill -9 -P $(list_descendants $SETUP_PID)
@@ -684,7 +703,7 @@ is_replica_connected ()
 	fi
 }
 
-run_scaleup_test ()
+run_scaleup_scaledown_test ()
 {
 	local replica1_port="6161"
 	local replica2_port="6162"
@@ -708,11 +727,11 @@ run_scaleup_test ()
 	## Replica2, Replica3 will be part of unknown replicas
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica2_port" -V $replica2_vdev -u "$replica2_id" &
 	replica2_pid=$!
-	sleep 2
+	sleep 3
 
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica3_port" -V $replica3_vdev -u "$replica3_id" &
 	replica3_pid=$!
-	sleep 2
+	sleep 3
 
 	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
 	rt=$(eval $cmd)
@@ -737,6 +756,54 @@ run_scaleup_test ()
 
 	## Wait for replcaed replica to become healthy
 	wait_for_healthy_replicas 3
+
+	## disconnect one replica and trigger scaledown
+	pkill -9 -P $replica1_pid
+
+	## remove replica1
+	istgtcontrol drf vol1 2 $replica2_id $replica3_id
+	rc=$?
+	if [ $rc != 0 ]; then
+		echo "Replica Scaledown should be succeed"
+		exit 1
+	fi
+	## wait for few seconds to disconnect the replica
+	sleep 3
+
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica1_port" -V $replica1_vdev -u "$replica1_id" -q &
+	replica1_pid=$!
+	## checking whether process exist or not
+	if ps -p $replica1_pid > /dev/null 2>&1
+	then
+		echo "Target should disconnect the replica ($replica1_id:$replica1_port) removed during scale down"
+		cat $LOGFILE
+		exit 1
+	fi
+
+	## Remove replica2
+	istgtcontrol drf vol1 1 $replica3_id
+	rc=$?
+	if [ $rc != 0 ]; then
+		echo "Replica Scaledown should be succeed"
+		exit 1
+	fi
+	## Wait for few seconds after disconnecting the replica
+	sleep 3
+
+	## pass zvol_guid as argument
+	replica_status=$(is_replica_connected "$replica2_port")
+	if [ "$replica_status" == 0 ]; then
+		echo "Replica($replica2_port) should be disconnected from the target as part of scaledown"
+		exit -1
+	fi
+
+	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
+	rt=$(eval $cmd)
+	if [ ${rt} != "\"Healthy\"" ]; then
+		$ISTGTCONTROL -q REPLICA vol1
+		echo "volume status is supposed to be Healthy since it is single replica case after scale down, but, $rt"
+		exit 1
+	fi
 
 	## Remove known replica from conf file
 	sed -i "$ d" /usr/local/istgt/istgt.conf
@@ -767,6 +834,8 @@ run_replica_connection_test ()
 	CONSISTENCY_FACTOR=1
 
 	setup_test_env $replica4_vdev
+
+	wait_for_istgt_process 3
 
 	# We didn't passed the replicaId so target should disconnect this replica
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica1_port" -V $replica1_vdev -q &
@@ -823,6 +892,14 @@ run_replica_connection_test ()
 	replica3_pid=$!
 	sleep 2
 
+	## Scaling down replica shouldn't be allowed when scaleup is in progress
+	istgtcontrol drf vol1 2 $replica1_id $replica2_id
+	rc=$?
+	if [ $rc == 0 ]; then
+		echo "Replica Scaledown should be failed due to ongoing scaleup process"
+		exit 1
+	fi
+
 	# wait till unknown replicas become healthy and known replicas
 	wait_for_healthy_replicas 3
 
@@ -856,9 +933,35 @@ run_replica_connection_test ()
 	## Wait for replcaed replica to become healthy
 	wait_for_healthy_replicas 3
 
+	## scale down the replicas to 2 (provided corrupted replica list)
+	istgtcontrol drf vol1 2 $replica1_id $new_replica_port
+	rc=$?
+	if [ $rc == 0 ]; then
+		echo "Replica Scaledown should be failed due to invalid replica id list"
+		exit 1
+	fi
+
+	## Scaledown replica2
+	istgtcontrol drf vol1 2 $replica1_id $replica3_id
+	rc=$?
+	if [ $rc != 0 ]; then
+		echo "Replica Scaledown should be succeed"
+		exit 1
+	fi
+	## Wait for few seconds after scaledown
+	sleep 3
+
+	## pass zvol_guid as argument
+	replica_status=$(is_replica_connected "$replica2_id")
+	if [ "$replica_status" == 0 ]; then
+		echo "Replica($replica2_id) should be disconnected from the target as we performed scaledown"
+		exit -1
+	fi
+
 	pkill -9 -P $replica1_pid
 	pkill -9 -P $replica2_pid
 	pkill -9 -P $replica3_pid
+	pkill -9 -P $new_replica3_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
 }
@@ -1058,7 +1161,6 @@ run_non_quorum_replica_errored_test()
 	local replica2_vdev="/tmp/test_vol2"
 	local replica3_vdev="/tmp/test_vol3"
 	local device_name=""
-	local retry_count=5
 
 	DESIRED_REPLICATION_FACTOR=3
 	REPLICATION_FACTOR=3
@@ -1066,18 +1168,8 @@ run_non_quorum_replica_errored_test()
 
 	setup_test_env
 
-	##Wait for istgt to up
-	while [ $retry_count -gt 0 ]; do
-		value=$(netstat -nap | grep 6060 | grep -w LISTEN | wc -l)
-		if [ $value == "1" ]; then
-			break
-		fi
-		sleep 1
-		retry_count=$((retry_count - 1))
-		if [ $retry_count == 1 ]; then
-			exit 1
-		fi
-	done
+	## Wait for istgt to up
+	wait_for_istgt_process 5
 
 	## Below Test will connect 1 QUORUM REPLICA and 5 NON-QUORUM Replica
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica1_ip" -P "$replica1_port" -V $replica1_vdev -u "$replica1_id" -q  &
@@ -1797,19 +1889,19 @@ run_io_timeout_test()
 	rm -rf ${replica1_vdev::-1}*
 }
 
-run_lu_rf_test
+#run_lu_rf_test
 run_replica_connection_test
-run_scaleup_test
-run_quorum_test
-data_integrity_with_unknown_replica
-run_non_quorum_replica_errored_test
-run_data_integrity_test
-run_mempool_test
-run_istgt_integration
-run_read_consistency_test
-run_replication_factor_test
-run_io_timeout_test
-run_test_env
+run_scaleup_scaledown_test
+#run_quorum_test
+#data_integrity_with_unknown_replica
+#run_non_quorum_replica_errored_test
+#run_data_integrity_test
+#run_mempool_test
+#run_istgt_integration
+#run_read_consistency_test
+#run_replication_factor_test
+#run_io_timeout_test
+#run_test_env
 echo "===============All Tests are passed ==============="
 tail -20 $LOGFILE
 

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -744,7 +744,7 @@ run_scaleup_scaledown_test ()
 	## Below replica is connecting as known replica
 	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica1_port" -V $replica1_vdev -u "$replica1_id" -q &
 	replica1_pid=$!
-	sleep 15 #Replica will take some time to make successful connection to target
+	sleep 20 #Replica will take some time to make successful connection to target
 
 	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].status'"
 	rt=$(eval $cmd)
@@ -1889,19 +1889,19 @@ run_io_timeout_test()
 	rm -rf ${replica1_vdev::-1}*
 }
 
-#run_lu_rf_test
+run_lu_rf_test
 run_replica_connection_test
 run_scaleup_scaledown_test
-#run_quorum_test
-#data_integrity_with_unknown_replica
-#run_non_quorum_replica_errored_test
-#run_data_integrity_test
-#run_mempool_test
-#run_istgt_integration
-#run_read_consistency_test
-#run_replication_factor_test
-#run_io_timeout_test
-#run_test_env
+run_quorum_test
+data_integrity_with_unknown_replica
+run_non_quorum_replica_errored_test
+run_data_integrity_test
+run_mempool_test
+run_istgt_integration
+run_read_consistency_test
+run_replication_factor_test
+run_io_timeout_test
+run_test_env
 echo "===============All Tests are passed ==============="
 tail -20 $LOGFILE
 


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

This PR adds support to perform replica scale down (or) remove the replica from a volume without IO disruption.

**Prerequisites to perform replica scale-down:**
All replicas should be in a healthy state before triggering the replica scaledown command. 

**How to trigger scale down**
CMD: istgtcontrol drf <vol_name> <drf_value> <drf_value_no_known_replica_ids>
Ex: istgtcontrol drf vol1 2 6061 6063 (On assumption of 3 replicas 6061, 6062 and 6063 are connected and I need to remove 6062)

**TODO**
1. Move new functions into a new file(other than replication.c).
