### PR TITLE
refactor[gitlab-yaml]: Updated the branch name for packet platform

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ baseline-image:
      - git commit -m "updated $CI_PROJECT_NAME commit:$COMMIT"
      - git push  https://$user:$pass@github.com/openebs/e2e-infrastructure.git --all
      - if [[ "$BRANCH" == "replication" ]] ; then export INFRA="master" ; else export INFRA=$BRANCH ; fi
-     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-13 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
-     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-14 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
-     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-1-15 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-ultimate https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-penultimate https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$INFRA -F token=$PACKET -F ref=k8s-antepenultimate https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
      - curl -X POST -F token=$KONVOY -F ref=$KONVOY_BRANCH https://gitlab.openebs100.io/api/v4/projects/34/trigger/pipeline


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified the Branch names for packet platform. For a every K8s release we were creating a new branch in gitlab repo and we have to modify the branch name in gitlab ci yaml. To avoid this branch name has been changed as a generic name.
```
k8s-ultimate means last newer release version [1.16]
k8s-penultimate - second last [1.15]
k8s-antepenultimate - Third last [1.14]
```