### PR TITLE
fix(core): dump cores on persistent location based on env

### DIFF
--- a/docker/entrypoint-istgtimage.sh
+++ b/docker/entrypoint-istgtimage.sh
@@ -20,6 +20,17 @@ touch /usr/local/etc/istgt/logfile
 export externalIP=0.0.0.0
 service rsyslog start
 
+# Disabling coredumps by default in the shell where istgt runs
+if [ -z "$ENABLE_COREDUMP" ]; then
+	echo "Disabling dumping core"
+	ulimit -c 0
+else
+	echo "Enabling coredumps"
+	ulimit -c unlimited
+        ## Remove hardcoded value. Take it via ENV
+	cd /var/openebs/sparse || exit
+fi
+
 ARCH=$(uname -m)
 export LD_PRELOAD=/usr/lib/${ARCH}-linux-gnu/libjemalloc.so
 exec /usr/local/bin/istgt

--- a/docker/entrypoint-istgtimage.sh
+++ b/docker/entrypoint-istgtimage.sh
@@ -27,8 +27,9 @@ if [ -z "$ENABLE_COREDUMP" ]; then
 else
 	echo "Enabling coredumps"
 	ulimit -c unlimited
-        ## Remove hardcoded value. Take it via ENV
-	cd /var/openebs/sparse || exit
+        ## make PWD as $PERSISTENT_PATH. So container will dump the
+	## core in persistent path
+	cd $PERSISTENT_STORAGE_PATH || exit
 fi
 
 ARCH=$(uname -m)

--- a/docker/entrypoint-istgtimage.sh
+++ b/docker/entrypoint-istgtimage.sh
@@ -5,9 +5,9 @@ trap 'call_exit $LINE_NO' EXIT
 
 call_exit()
 {
-echo "at call_exit.."     
+echo "at call_exit.."
 echo  "exit code:" $?
-echo "reference: "  $0 
+echo "reference: "  $0
 }
 
 if [ ! -f "/usr/local/etc/istgt/istgt.conf" ];then
@@ -27,9 +27,11 @@ if [ -z "$ENABLE_COREDUMP" ]; then
 else
 	echo "Enabling coredumps"
 	ulimit -c unlimited
-        ## make PWD as $PERSISTENT_PATH. So container will dump the
-	## core in persistent path
-	cd $PERSISTENT_STORAGE_PATH || exit
+	## /var/openebs is mounted as persistent directory on
+	## host machine
+	cd /var/openebs || exit
+	mkdir -p core
+	cd core
 fi
 
 ARCH=$(uname -m)


### PR DESCRIPTION
This PR dumps the core on persistent location i.e /var/openebs/core which is mounted on
host path(OPENEBS_BASE_DIR/cstor-target/<volume_name>).

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>