### PR TITLE
fix(resize): add resize test cases when replicas are in different states

### DIFF
--- a/src/setup_istgt.sh
+++ b/src/setup_istgt.sh
@@ -8,16 +8,11 @@ run_istgt ()
 	local drf
 	local known_replica1_details
 
-	if [ $# -eq 1 ]; then
-		volume_size=$1
-	else
-		volume_size=10g
-	fi
-
 	[ ! -z $DESIRED_REPLICATION_FACTOR ] && drf=$DESIRED_REPLICATION_FACTOR || drf=3
 	[ ! -z $REPLICATION_FACTOR ] && rf=$REPLICATION_FACTOR || rf=3
 	[ ! -z $CONSISTENCY_FACTOR ] && cf=$CONSISTENCY_FACTOR || cf=2
 	[ ! -z "$KNOWN_REPLICA1_DETAILS" ] && known_replica1_details="$KNOWN_REPLICA1_DETAILS" || known_replica1_details=""
+	[ ! -z "$VOLUME_SIZE" ] && volume_size="$VOLUME_SIZE" || volume_size=5G
 
 	ulimit -c unlimited
 	rm -rf core

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -239,13 +239,13 @@ write_data()
 setup_test_env() {
 	rm -f /tmp/test_vol*
 	mkdir -p /mnt/store
-	## We are doing resize to 7G
-	truncate -s 7G /tmp/test_vol1 /tmp/test_vol2 /tmp/test_vol3 $1
+	## We are doing multiple resizes
+	truncate -s 10G /tmp/test_vol1 /tmp/test_vol2 /tmp/test_vol3 $1
 	logout_of_volume
 	sudo killall -9 istgt
 	sudo killall -9 replication_test
 	touch $INTEGRATION_TEST_LOGFILE
-	start_istgt 5G
+	start_istgt
 }
 
 cleanup_test_env() {
@@ -981,6 +981,139 @@ run_replica_connection_test ()
 	pkill -9 -P $replica2_pid
 	pkill -9 -P $replica3_pid
 	pkill -9 -P $new_replica3_pid
+	stop_istgt
+	rm -rf ${replica1_vdev::-1}*
+}
+
+## wait_for_no_of_replicas will wait and return if specified no.of replias are
+## connected to it or else it returns error. It accepts replica_count as first
+## argument
+wait_for_no_of_replicas ()
+{
+	local replica_count=$1
+	local retry_cnt=5
+
+	for (( i = 0; i < $retry_cnt; i++ )) do
+		connected_replica_cnt=$(get_connected_replica_count)
+		if [ $connected_replica_cnt -eq $replica_count ]; then
+			break
+		fi
+		sleep 1
+	done
+	if [ $connected_replica_cnt -ne $replica_count ]; then
+		echo "Disconnected the replica: $replica3_id but still connected replica count is $connected_replica_cnt"
+		exit 1
+	fi
+}
+
+# run_resize_test will test the resize functionality when replicas are in different state
+run_resize_test ()
+{
+	local replica1_port="6161"
+	local replica2_port="6162"
+	local replica3_port="6163"
+	local replica1_id="6161"
+	local replica2_id="6162"
+	local replica3_id="6163"
+	local replica_ip="127.0.0.1"
+	local replica1_vdev="/tmp/test_vol1"
+	local replica2_vdev="/tmp/test_vol2"
+	local replica3_vdev="/tmp/test_vol3"
+	local CONF_FILE="/usr/local/etc/istgt/istgt.conf"
+	local current_size=""
+
+
+	DESIRED_REPLICATION_FACTOR=3
+	REPLICATION_FACTOR=3
+	CONSISTENCY_FACTOR=2
+	VOLUME_SIZE=1G
+
+	setup_test_env
+
+	local vol_name=$(cat $CONF_FILE | grep TargetName | awk '{print $2}')
+	local new_size=2
+	echo "Resize of volume when replicas are in different state"
+	$ISTGTCONTROL resize $vol_name "${new_size}G"
+	if [ $? -ne 0 ]
+	then
+		echo "Failed to resize the volume from ${VOLUME_SIZE} to  ${new_size}G"
+		exit 1
+	fi
+
+	echo "Test resize when all the replicas are in Degraded state"
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica1_port" -V $replica1_vdev -u "$replica1_id" -q &
+	replica1_pid=$!
+	sleep 2	#Replica will take some time to make successful connection to target
+
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica2_port" -V $replica2_vdev -u "$replica2_id" -q &
+	replica2_pid=$!
+	sleep 2
+
+	# As long as we are not running any IOs we can use the same vdev file
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica3_port" -V $replica3_vdev -u "$replica3_id" -q &
+	replica3_pid=$!
+	sleep 2
+
+	login_to_volume "$CONTROLLER_IP:3260"
+	sleep 10
+	device_name=$(get_scsi_disk)
+
+	## Verify updated size
+	disk_size=$(lsblk | grep $device_name |awk -F ' ' '{print $4+0}')
+	if [ $disk_size -ne $new_size ]; then
+		echo "LUN resize failed"
+		echo "Failed to resize the volume from ${VOLUME_SIZE} to  ${new_size}G"
+		exit 1
+	fi
+
+	## Check whether all replicas are in degraded state or not
+	cmd="$ISTGTCONTROL -q REPLICA vol1 | jq '.\"volumeStatus\"[0].\"replicaStatus\"[].Mode' | grep -w Degraded"
+	cnt=$(eval $cmd | wc -l)
+	if [ $cnt -ne $REPLICATION_FACTOR ]; then
+		echo "run_resize_test: Replicas are just now connected and all should be in degraded state"
+		exit 1
+	fi
+
+	## When all the replicas are in degraded state
+	verify_resize_command $device_name
+
+	## Disconnect one replica and trigger resize. Resize should succeed
+	pkill -9 -P $replica3_pid
+	wait_for_no_of_replicas 2
+
+	## When only two replicas are connected out of 3
+	verify_resize_command $device_name
+
+	## verify resize only when 1 replica is connected
+	pkill -9 -P $replica2_pid
+	wait_for_no_of_replicas 1
+
+	current_size=$(lsblk | grep $device_name |awk -F ' ' '{print $4+0}')
+	new_size=$(( $current_size + 1 ))
+
+	## Resize only when one replica is connected
+	$ISTGTCONTROL resize $vol_name "${new_size}G"
+	if [ $? -ne 0 ]
+	then
+		echo "Failed to resize the volume from ${current_size}G to  ${new_size}G"
+		exit 1
+	fi
+
+	start_replica -i "$CONTROLLER_IP" -p "$CONTROLLER_PORT" -I "$replica_ip" -P "$replica2_port" -V $replica2_vdev -u "$replica2_id" -q &
+	replica2_pid=$!
+	sleep 2
+
+	sudo iscsiadm -m node -R
+	current_size=$(lsblk | grep $device_name |awk -F ' ' '{print $4+0}')
+	if [ $current_size -ne $new_size ]; then
+		echo "Resize failed when one replica is connected"
+	fi
+
+	logout_of_volume
+	echo "run_resize_test is completed"
+
+	pkill -9 -P $replica1_pid
+	pkill -9 -P $replica2_pid
 	stop_istgt
 	rm -rf ${replica1_vdev::-1}*
 }
@@ -1912,6 +2045,7 @@ run_lu_rf_test
 run_replica_connection_test
 run_scaleup_scaledown_test
 run_quorum_test
+run_resize_test
 data_integrity_with_unknown_replica
 run_non_quorum_replica_errored_test
 run_data_integrity_test

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1112,6 +1112,8 @@ run_resize_test ()
 	logout_of_volume
 	echo "run_resize_test is completed"
 
+	## Unset the volume size
+	VOLUME_SIZE=""
 	pkill -9 -P $replica1_pid
 	pkill -9 -P $replica2_pid
 	stop_istgt

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1441,19 +1441,19 @@ verify_resize_command()
 	vol_name=$(cat $CONF_FILE | grep TargetName | awk '{print $2}')
 
 	$ISTGTCONTROL resize "${vol_name}invalid" "${new_size}G"
-	if [ $? -eq 0 ]; then echo"resize should fail due to invalid volume name"; exit 1; fi
+	if [ $? -eq 0 ]; then echo "resize should fail due to invalid volume name"; exit 1; fi
 
 	$ISTGTCONTROL resize ${vol_name} "${lower_size}G"
-	if [ $? -eq 0 ]; then echo"resize should fail due to lower size than current"; exit 1; fi
+	if [ $? -eq 0 ]; then echo "resize should fail due to lower size than current"; exit 1; fi
 
 	$ISTGTCONTROL resize ${vol_name} ${invalid_bs}
-	if [ $? -eq 0 ]; then echo"resize should fail due to invalid block size"; exit 1; fi
+	if [ $? -eq 0 ]; then echo "resize should fail due to invalid block size"; exit 1; fi
 
 	$ISTGTCONTROL resize ${vol_name}
-	if [ $? -eq 0 ]; then echo"resize should fail due to invalid arguments"; exit 1; fi
+	if [ $? -eq 0 ]; then echo "resize should fail due to invalid arguments"; exit 1; fi
 
 	$ISTGTCONTROL resize ${vol_name} "${old_size}G"
-	if [ $? -ne 0 ]; then echo"Failed to resize volume with same size"; exit 1; fi
+	if [ $? -ne 0 ]; then echo "Failed to resize volume with same size"; exit 1; fi
 
 	$ISTGTCONTROL resize $vol_name "${new_size}G"
 	if [ $? -ne 0 ]
@@ -1570,7 +1570,7 @@ data_integrity_with_unknown_replica()
 	fi
 
 	## Checking the read IO's with quorum and non-quorum replicas
-	sudo dd if=$device_name of=/dev/null bs=4k count=100
+	sudo dd if=/dev/$device_name of=/dev/null bs=4k count=100
 	if ps -p $replica3_pid > /dev/null 2>&1
 	then
 		echo "Passed the read IO test on non-quorum"

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -1006,7 +1006,7 @@ wait_for_no_of_replicas ()
 	fi
 }
 
-# run_resize_test will test the resize functionality when replicas are in different state
+# run_resize_test will test the resize functionality when replicas are not in healthy state
 run_resize_test ()
 {
 	local replica1_port="6161"
@@ -1028,11 +1028,11 @@ run_resize_test ()
 	CONSISTENCY_FACTOR=2
 	VOLUME_SIZE=1G
 
+	echo "[Test Started] Resize of volume when replicas are not in Healthy state"
 	setup_test_env
 
 	local vol_name=$(cat $CONF_FILE | grep TargetName | awk '{print $2}')
 	local new_size=2
-	echo "Resize of volume when replicas are in different state"
 	$ISTGTCONTROL resize $vol_name "${new_size}G"
 	if [ $? -ne 0 ]
 	then
@@ -1110,8 +1110,8 @@ run_resize_test ()
 	fi
 
 	logout_of_volume
-	echo "run_resize_test is completed"
 
+	echo "[Test Completed] Resize of volume when replicas are not in Healthy state"
 	## Unset the volume size
 	VOLUME_SIZE=""
 	pkill -9 -P $replica1_pid


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR adds different test cases to cover resize functionality.

Following are the test cases:
- When replicas are not connected trigger resize and expect iscsi disk of the same size after replicas are connected(offline resize).
- When all the replicas are in degraded state triggering resize.
- When only two replicas are connected out of three replicas then triggering resize.
- When only one replica is connected out of three replicas then triggering resize.