### PR TITLE
fix(image): update istgt dockerfile to use ubuntu 18.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # This Dockerfile builds cstor istgt container running istgt from istgt base image
 #
 
-FROM openebs/cstor-ubuntu:xenial-20190515
+FROM openebs/cstor-ubuntu:bionic-20200219
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog
 RUN apt-get -y install curl tcpdump dnsutils net-tools iputils-ping gdb


### PR DESCRIPTION
commit update the Dockerfile to use ubuntu 18.04 as a base
image to fix some of the security vulnerabilities with 16.04
image used earlier.

**Tested Changes locally**

```sh
trivy openebs/cstor-istgt:ci
2020-03-11T14:11:43.283+0530	INFO	Detecting Ubuntu vulnerabilities...

openebs/cstor-istgt:ci (ubuntu 18.04)
=====================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

```
**Note**: Pushed the base docker image here https://hub.docker.com/repository/docker/openebs/cstor-ubuntu

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>