### PR TITLE
fix(image): update istgt dockerfile to use ubuntu 18.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # This Dockerfile builds cstor istgt container running istgt from istgt base image
 #
 
-FROM openebs/cstor-ubuntu:xenial-20190515
+FROM openebs/cstor-ubuntu:bionic-20200219
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog
 RUN apt-get -y install curl tcpdump dnsutils net-tools iputils-ping gdb


### PR DESCRIPTION
commit update the Dockerfile to use ubuntu 18.04 as a base
image to fix some of the security vulnerabilities with 16.04
image used earlier.
cherrypick: #312 

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>