### PR TITLE
feat(env): IO_MAX_WAIT_TIME setting for replica timeout

### DIFF
--- a/changelogs/unreleased/324-vishnuitta
+++ b/changelogs/unreleased/324-vishnuitta
@@ -1,0 +1,1 @@
+feat(env): IO_MAX_WAIT_TIME env setting for replica timeout

--- a/src/init.sh
+++ b/src/init.sh
@@ -76,9 +76,9 @@ service rsyslog start
 
 if [ -z $test_env ]
 then
-	/usr/local/bin/istgt -R 20
+	IO_MAX_WAIT_TIME=120 /usr/local/bin/istgt -R 20
 else
-	QueueDepth=5 Luworkers=9 /usr/local/bin/istgt -R 20
+	IO_MAX_WAIT_TIME=120 QueueDepth=5 Luworkers=9 /usr/local/bin/istgt -R 20
 fi
 
 child=$!

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -2008,15 +2008,13 @@ run_io_timeout_test()
 		$IOPING  -c 3 -B -WWW /dev/$device_name > $iopinglog
 		cmd="grep -ch 'changing IO max wait time from 60 to 120' $LOGFILE"
 		val=$(eval $cmd)
-		if [ $val -ne 1 ]
-		then
+		if [ $val -eq 0 ]; then
 			echo "IO timeout not set as per IO_MAX_WAIT_TIME env setting"
 			exit 1
 		fi
 		cmd="grep -ch 'Max IO wait time updated to 5 seconds from 120 seconds' $LOGFILE"
 		val=$(eval $cmd)
-		if [ $val -ne 1 ]
-		then
+		if [ $val -eq 0 ]; then
 			echo "IO timeout not set as per istgtcontrol maxiowait setting"
 			exit 1
 		fi

--- a/test_istgt.sh
+++ b/test_istgt.sh
@@ -2006,6 +2006,20 @@ run_io_timeout_test()
 		# Test to verify disconnection of replica if delay from replica is more than maxiowait
 		$ISTGTCONTROL maxiowait 5
 		$IOPING  -c 3 -B -WWW /dev/$device_name > $iopinglog
+		cmd="grep -ch 'changing IO max wait time from 60 to 120' $LOGFILE"
+		val=$(eval $cmd)
+		if [ $val -ne 1 ]
+		then
+			echo "IO timeout not set as per IO_MAX_WAIT_TIME env setting"
+			exit 1
+		fi
+		cmd="grep -ch 'Max IO wait time updated to 5 seconds from 120 seconds' $LOGFILE"
+		val=$(eval $cmd)
+		if [ $val -ne 1 ]
+		then
+			echo "IO timeout not set as per istgtcontrol maxiowait setting"
+			exit 1
+		fi
 		wait $replica1_pid
 		if [ $? -eq 0 ]; then
 			echo "IO timeout test failed"


### PR DESCRIPTION
This PR adds an environment variable "IO_MAX_WAIT_TIME" for istgt.
This setting is the maximum time istgt need to wait for response from replica. If replica doesn't respond with in this configured value, istgt will disconnect that replica.

Signed-off-by: Vitta <vitta@mayadata.io>