### PR TITLE
refact(build): make the docker images configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ jobs:
   include:
     - os: linux
       arch: amd64
+      env:
+        - RELEASE_TAG_DOWNSTREAM=1
     - os: linux
       arch: arm64
+      env:
+        - RELEASE_TAG_DOWNSTREAM=0
 
 before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -46,6 +50,26 @@ script:
       fi
     - pwd
     - ./build_image.sh
+    # If this build is running due to travis release tag, and
+    # this job indicates to push the release downstream, then
+    # go ahead and tag the dependent repo.
+    # This is controlled by ENV RELEASE_TAG_DOWNSTREAM.
+    #
+    # $TRAVIS_BRANCH contains the same value as $TRAVIS_TAG.
+    # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch. 
+    # OpenEBS release are done from branches named as v1.9.x. 
+    # Convert the TRAVIS_TAG to the corresponding release branch.
+    #
+    # Allow for building forked openebs pipelines. 
+    # Tag the downstream repos under current repo org. 
+    - if [ -z $REPO_ORG ]; then
+        REPO_ORG=$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f1);
+        export REPO_ORG;
+      fi
+    - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "$REPO_ORG/istgt" ]; then
+        REL_BRANCH=$(echo v$(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x) ;
+        ./buildscripts/git-release "$REPO_ORG/external-storage" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+      fi
 notifications:
   email:
     recipients:

--- a/build_image.sh
+++ b/build_image.sh
@@ -68,7 +68,7 @@ if [ -z "${DBUILD_SITE_URL}" ]; then
   DBUILD_SITE_URL="https://openebs.io"
 fi
 
-DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
+DBUILD_ARGS="--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}"
 
 if [ "${ARCH}" = "x86_64" ]; then
 	REPO_NAME="$IMAGE_ORG/cstor-istgt"

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2018-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 pwd
@@ -20,19 +34,54 @@ fi
 make clean
 make
 
-BUILD_DATE=$(date +'%Y%m%d%H%M%S')
+# The images can be pushed to any docker/image registeries
+# like docker hub, quay. The registries are specified in 
+# the `build/push` script.
+#
+# The images of a project or company can then be grouped
+# or hosted under a unique organization key like `openebs`
+#
+# Each component (container) will be pushed to a unique 
+# repository under an organization. 
+# Putting all this together, an unique uri for a given 
+# image comprises of:
+#   <registry url>/<image org>/<image repo>:<image-tag>
+#
+# IMAGE_ORG can be used to customize the organization 
+# under which images should be pushed. 
+# By default the organization name is `openebs`. 
+
+if [ -z "${IMAGE_ORG}" ]; then
+  IMAGE_ORG="openebs"
+fi
+
+# Specify the date of build
+DBUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')
+
+# Specify the docker arg for repository url
+if [ -z "${DBUILD_REPO_URL}" ]; then
+  DBUILD_REPO_URL="https://github.com/openebs/istgt"
+fi
+
+# Specify the docker arg for website url
+if [ -z "${DBUILD_SITE_URL}" ]; then
+  DBUILD_SITE_URL="https://openebs.io"
+fi
+
+DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
+
 if [ "${ARCH}" = "x86_64" ]; then
-	REPO_NAME="openebs/cstor-istgt"
+	REPO_NAME="$IMAGE_ORG/cstor-istgt"
 	DOCKERFILE="Dockerfile"
 elif [ "${ARCH}" = "aarch64" ]; then
-	REPO_NAME="openebs/cstor-istgt-arm64"
+	REPO_NAME="$IMAGE_ORG/cstor-istgt-arm64"
 	DOCKERFILE="Dockerfile.arm64"
 else
 	echo "Unusable architecture: ${ARCH}"
 	exit 1
 fi
 
-echo "Build image ${REPO_NAME}:ci with BUILD_DATE=${BUILD_DATE}"
+echo "Build image ${REPO_NAME}:ci with BUILD_DATE=${DBUILD_DATE}"
 
 cp src/istgt ./docker
 cp src/istgtcontrol ./docker
@@ -43,7 +92,7 @@ sudo docker version
 sudo docker build --help
 
 cd docker && \
- sudo docker build -f ${DOCKERFILE} -t ${REPO_NAME}:ci --build-arg BUILD_DATE=${BUILD_DATE} . && \
+ sudo docker build -f ${DOCKERFILE} -t ${REPO_NAME}:ci ${DBUILD_ARGS} . && \
  IMAGE_REPO=${REPO_NAME} ./push && \
  cd ..
 

--- a/buildscripts/git-release
+++ b/buildscripts/git-release
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Error: Unable to create a new release. Missing required input."
+    echo "Usage: $0 <github org/repo> <tag-name> <branch-name>"
+    echo "Example: $0 kmova/bootstrap v1.0.0 master"
+    exit 1
+fi
+
+C_GIT_URL=$(echo "https://api.github.com/repos/$1/releases")
+C_GIT_TAG_NAME=$2
+C_GIT_TAG_BRANCH=$3
+
+if [ -z ${GIT_NAME} ];
+then
+  echo "Error: Environment variable GIT_NAME not found. Please set it to proceed.";
+  echo "GIT_NAME should be a valid GitHub username.";
+  exit 1
+fi
+
+if [ -z ${GIT_TOKEN} ];
+then
+  echo "Error: Environment variable GIT_TOKEN not found. Please set it to proceed.";
+  echo "GIT_TOKEN should be a valid GitHub token associated with GitHub username.";
+  echo "GIT_TOKEN should be configured with required permissions to create new release.";
+  exit 1
+fi
+
+RELEASE_CREATE_JSON=$(echo \
+{ \
+ \"tag_name\":\"${C_GIT_TAG_NAME}\", \
+ \"target_commitish\":\"${C_GIT_TAG_BRANCH}\", \
+ \"name\":\"${C_GIT_TAG_NAME}\", \
+ \"body\":\"Release created via $0\", \
+ \"draft\":false, \
+ \"prerelease\":false \
+} \
+)
+
+#delete the temporary response file that might 
+#have been left around by previous run of the command
+#using a fixed name means that this script 
+#is not thread safe. only one execution is permitted 
+#at a time.
+TEMP_RESP_FILE=temp-curl-response.txt
+rm -rf ${TEMP_RESP_FILE}
+
+response_code=$(curl -u ${GIT_NAME}:${GIT_TOKEN} \
+ -w "%{http_code}" \
+ --silent \
+ --output ${TEMP_RESP_FILE} \
+ --url ${C_GIT_URL} \
+ --request POST --header 'content-type: application/json' \
+ --data "$RELEASE_CREATE_JSON")
+
+#When embedding this script in other scripts like travis, 
+#success responses like 200 can mean error. rc_code maps
+#the responses to either success (0) or error (1)
+rc_code=0
+
+#Github returns 201 Created on successfully creating a new release
+#201 means the request has been fulfilled and has resulted in one 
+#or more new resources being created.
+if [ $response_code != "201" ]; then
+    echo "Error: Unable to create release. See below response for more details"
+    #The GitHub error response is pretty well formatted.
+    #Printing the body gives all the details to fix the errors
+    #Sample response when the branch already exists looks like this:
+    #{
+    #  "message": "Validation Failed",
+    #  "errors": [
+    #    {
+    #      "resource": "Release",
+    #      "code": "already_exists",
+    #      "field": "tag_name"
+    #    }
+    #  ],
+    #  "documentation_url": "https://developer.github.com/v3/repos/releases/#create-a-release"
+    #}
+    rc_code=1
+else
+    #Note. In case of success, lots of details of returned, but just 
+    #knowing that creation worked is all that matters now.
+    echo "Successfully tagged $1 with release tag ${C_GIT_TAG_NAME} on branch ${C_GIT_TAG_BRANCH}"
+fi
+cat ${TEMP_RESP_FILE}
+
+#delete the temporary response file
+rm -rf ${TEMP_RESP_FILE}
+
+exit ${rc_code}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,13 +19,17 @@ RUN touch /usr/local/etc/bkpistgt/logfile
 COPY entrypoint-istgtimage.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
 
-ARG BUILD_DATE
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="istgt"
 LABEL org.label-schema.description="OpenEBS istgt"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/istgt"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT entrypoint-istgtimage.sh
 EXPOSE 3260 6060

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -19,13 +19,17 @@ RUN touch /usr/local/etc/bkpistgt/logfile
 COPY entrypoint-istgtimage.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
 
-ARG BUILD_DATE
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="istgt"
 LABEL org.label-schema.description="OpenEBS istgt"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/istgt"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT entrypoint-istgtimage.sh
 EXPOSE 3260 6060

--- a/docker/push
+++ b/docker/push
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 if [ -z ${IMAGE_REPO} ];
@@ -42,7 +56,10 @@ function TagAndPushImage() {
   REPO="$1"
   TAG="$2"
   
-  IMAGE_URI="${REPO}:${TAG}";
+  #Add an option to specify a custom TAG_SUFFIX 
+  #via environment variable. Default is no tag.
+  #Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the docker images on forked repos push to custom docker orgs.  

This PR will help customizing docker images via environment variables:
- The following ENV help specify custom docker build args
  - DBUILD_SITE_URL ( default: https://openebs.io )
  - DBUILD_REPO_URL ( default: https://github.com/openebs/istgt )
- The following ENV allows Travis to specify custom image org
  - IMAGE_ORG (default: openebs )
- The following ENV will allow specifying an extra tag suffix
  - TAG_SUFFIX ( default: none )

In addition, this PR will also help with automating the tagged releases. 
For releasing cstor code, multiple repo's need to be tagged in a certain order.

This fix will help to trigger the release on the downstream repo. 
In this case, after releasing openebs/istgt, openebs/external-storage needs
to be tagged.

Signed-off-by: kmova <kiran.mova@mayadata.io>
