### PR TITLE
cherry-pick(build): fix git-release file to ignore error if tag already exists

### DIFF
--- a/buildscripts/git-release
+++ b/buildscripts/git-release
@@ -60,6 +60,24 @@ RELEASE_CREATE_JSON=$(echo \
 TEMP_RESP_FILE=temp-curl-response.txt
 rm -rf ${TEMP_RESP_FILE}
 
+#is_release_already_exist verifies the output of API for error message
+#return 0 -- if release already exist
+#return 1 -- if release doesn't exist
+is_release_already_exist() {
+	dfile=$1
+
+	msg=$(cat $dfile | jq -r '.message')
+	code=$(cat $dfile | jq -r '.errors[0].code')
+	resource=$(cat $dfile | jq -r '.errors[0].resource')
+	error_len=$(cat $dfile | jq '.errors | length')
+
+	[[ "$msg" == "Validation Failed" ]] && \
+		[[ "$code" == "already_exists" ]] && \
+		[[ "$resource" -eq "Release" ]] && \
+		[[ $error_len -eq 1 ]] && \
+		echo 0 || echo 1
+}
+
 response_code=$(curl -u ${GIT_NAME}:${GIT_TOKEN} \
  -w "%{http_code}" \
  --silent \
@@ -76,7 +94,7 @@ rc_code=0
 #Github returns 201 Created on successfully creating a new release
 #201 means the request has been fulfilled and has resulted in one 
 #or more new resources being created.
-if [ $response_code != "201" ]; then
+if [ $response_code != "201" && [[ $(is_release_already_exist $TEMP_RESP_FILE) -ne 0 ]]; then
     echo "Error: Unable to create release. See below response for more details"
     #The GitHub error response is pretty well formatted.
     #Printing the body gives all the details to fix the errors

--- a/buildscripts/git-release
+++ b/buildscripts/git-release
@@ -94,7 +94,7 @@ rc_code=0
 #Github returns 201 Created on successfully creating a new release
 #201 means the request has been fulfilled and has resulted in one 
 #or more new resources being created.
-if [ $response_code != "201" && [[ $(is_release_already_exist $TEMP_RESP_FILE) -ne 0 ]]; then
+if [ $response_code != "201" ] && [[ $(is_release_already_exist $TEMP_RESP_FILE) -ne 0 ]]; then
     echo "Error: Unable to create release. See below response for more details"
     #The GitHub error response is pretty well formatted.
     #Printing the body gives all the details to fix the errors


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR is cherry-pick of [328](https://github.com/openebs/istgt/pull/328) and [329](https://github.com/openebs/istgt/pull/329).

**Why is this PR required? What issue does it fix?**:
git-release script returns an error if release at the targeted branch already exists. This PR address this issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests
