### PR TITLE
refact(release): add cstor-operators in downstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ script:
         REL_BRANCH=$(echo $(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x$REL_SUFFIX);
 
         ./buildscripts/git-release "$REPO_ORG/external-storage" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+        ./buildscripts/git-release "$REPO_ORG/cstor-operators" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
       fi
 notifications:
   email:


### PR DESCRIPTION
**What this PR does / why we need it**:

The current release script(in travis) only tags
the external-storage and maya, that have control
plane operators for SPC.

The new control plane oprators for CSPC are under
cstor-operators repo.

**Which issue this PR fixes**:

After building the cstor-istgt containers,
tag cstor-operators to build and release the
new control plane operators.

Signed-off-by: kmova <kiran.mova@mayadata.io>
