### PR TITLE
fix(travis): print istgt logs when travis timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
       sudo bash ./print_debug_info.sh &
       ## If test takes more than 45 minutes then print tail logs in /tmp/istgt.log and terminate travis
       ## Having 60minutes is causing travis timeout and not able to know easily which test is failed
-      travis_wait 45 sudo bash ./test_istgt.sh || sudo tail -500 /tmp/istgt.log || travis_terminate 1;
+      travis_wait 45 sudo bash ./test_istgt.sh || ( sudo tail -500 /tmp/istgt.log && travis_terminate 1 );
       fi
     - pwd
     - ./build_image.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,9 @@ script:
     - |
       if [ "${ARCH}" = "x86_64" ]; then
       sudo bash ./print_debug_info.sh &
-      travis_wait 60 sudo bash ./test_istgt.sh || travis_terminate 1;
+      ## If test takes more than 45 minutes then print tail logs in /tmp/istgt.log and terminate travis
+      ## Having 60minutes is causing travis timeout and not able to know easily which test is failed
+      travis_wait 45 sudo bash ./test_istgt.sh || sudo tail -500 /tmp/istgt.log || travis_terminate 1;
       fi
     - pwd
     - ./build_image.sh


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR helps to print last 500 lines of logs
istgt process when `test_istgt.sh` scripts take more than
45minutes to execute.

From the past success builds it was observed
that test_istgt.sh script doesn't take more than
40minutes to execute. So making it to 45 is better
instead of waiting till Travis timeouts(From the logs
we can able to find the reason of Travis failure). 

- Success [Build1](https://travis-ci.org/github/openebs/istgt/jobs/698464702):
```sh
**The approximate start time of test**: Jun 15 10:14:35 localhost systemd-resolved[814]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.

**The approximate end time of test**: 2020-06-15/10:47:01.323 istgt_lu_disk_exec:10931: l#2.140567517046528.: c#1 LU2.0: CSN:f3 OP=0x2a/8 (619790+1) complete [q:0.000000000 w:0.000000000](CheckCond_on_fake changed to Busy)
```
- Success [Build2](https://travis-ci.org/github/openebs/istgt/jobs/696398983):
```sh
**The approximate start time of test**: Jun  9 10:10:02 localhost systemd-resolved[836]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.

**The approximate end time of test**: 2020-06-09/10:42:14.048 istgt_lu_disk_exec:10931: l#2.140502942873344.: c#1 LU2.0: CSN:f3 OP=0x2a/8 (108082+1) complete [q:0.000000000 w:0.000000000](CheckCond_on_fake changed to Busy)
```
- Success [Build3](https://travis-ci.org/github/openebs/istgt/jobs/696570221):
```sh
**The approximate start time of test**: Jun 10 02:46:07 localhost systemd-resolved[786]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.

**The approximate end time of test**: 2020-06-10/03:20:43.450 istgt_lu_disk_exec:10931: l#2.139737692104448.: c#1 LU2.0: CSN:f8 OP=0x2a/8 (548754+1) complete [q:0.000000000 w:0.000000000](CheckCond_on_fake changed to Busy)
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This will help us to know the problem of Travis failure.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests
